### PR TITLE
Implement tree assessor factory functions

### DIFF
--- a/packages/yoastseo/spec/tree/assess/assessorFactoriesSpec.js
+++ b/packages/yoastseo/spec/tree/assess/assessorFactoriesSpec.js
@@ -1,0 +1,145 @@
+import { ReadabilityScoreAggregator, SEOScoreAggregator } from "../../../src/tree/assess/scoreAggregators";
+import { TreeResearcher } from "../../../src/tree/research";
+import factory from "../../specHelpers/factory.js";
+
+import {
+	constructReadabilityAssessor,
+	constructSEOAssessor,
+} from "../../../src/tree/assess/assessorFactories";
+
+describe( "assessorFactories", () => {
+	let i18n;
+	let researcher;
+
+	beforeEach( () => {
+		i18n = factory.buildJed();
+		researcher = new TreeResearcher();
+	} );
+
+	describe( "constructSEOAssessor", () => {
+		it( "can create an SEO Assessor", () => {
+			const config = {};
+			const assessor = constructSEOAssessor( i18n, researcher, config );
+
+			const expectedAssessments = [];
+			const expectedResearcher = researcher;
+			const expectedScoreAggregator = new SEOScoreAggregator();
+
+			expect( assessor.getAssessments() ).toEqual( expectedAssessments );
+			expect( assessor.researcher ).toEqual( expectedResearcher );
+			expect( assessor.scoreAggregator ).toEqual( expectedScoreAggregator );
+		} );
+
+		it( "can create an SEO taxonomy Assessor", () => {
+			const config = {
+				taxonomy: true,
+			};
+			const assessor = constructSEOAssessor( i18n, researcher, config );
+
+			const expectedAssessments = [];
+			const expectedResearcher = researcher;
+			const expectedScoreAggregator = new SEOScoreAggregator();
+
+			expect( assessor.getAssessments() ).toEqual( expectedAssessments );
+			expect( assessor.researcher ).toEqual( expectedResearcher );
+			expect( assessor.scoreAggregator ).toEqual( expectedScoreAggregator );
+		} );
+
+		it( "can create an SEO related keyphrase Assessor", () => {
+			const config = {
+				relatedKeyphrase: true,
+			};
+			const assessor = constructSEOAssessor( i18n, researcher, config );
+
+			const expectedAssessments = [];
+			const expectedResearcher = researcher;
+			const expectedScoreAggregator = new SEOScoreAggregator();
+
+			expect( assessor.getAssessments() ).toEqual( expectedAssessments );
+			expect( assessor.researcher ).toEqual( expectedResearcher );
+			expect( assessor.scoreAggregator ).toEqual( expectedScoreAggregator );
+		} );
+
+		it( "can create an SEO taxonomy related keyphrase Assessor", () => {
+			const config = {
+				taxonomy: true,
+				relatedKeyphrase: true,
+			};
+			const assessor = constructSEOAssessor( i18n, researcher, config );
+
+			const expectedAssessments = [];
+			const expectedResearcher = researcher;
+			const expectedScoreAggregator = new SEOScoreAggregator();
+
+			expect( assessor.getAssessments() ).toEqual( expectedAssessments );
+			expect( assessor.researcher ).toEqual( expectedResearcher );
+			expect( assessor.scoreAggregator ).toEqual( expectedScoreAggregator );
+		} );
+
+		it( "can create an SEO cornerstone Assessor", () => {
+			const config = {
+				cornerstone: true,
+			};
+			const assessor = constructSEOAssessor( i18n, researcher, config );
+
+			const expectedAssessments = [];
+			const expectedResearcher = researcher;
+			const expectedScoreAggregator = new SEOScoreAggregator();
+
+			expect( assessor.getAssessments() ).toEqual( expectedAssessments );
+			expect( assessor.researcher ).toEqual( expectedResearcher );
+			expect( assessor.scoreAggregator ).toEqual( expectedScoreAggregator );
+		} );
+
+		it( "can create an SEO cornerstone related keyphrase Assessor", () => {
+			const config = {
+				cornerstone: true,
+				relatedKeyphrase: true,
+			};
+			const assessor = constructSEOAssessor( i18n, researcher, config );
+
+			const expectedAssessments = [];
+			const expectedResearcher = researcher;
+			const expectedScoreAggregator = new SEOScoreAggregator();
+
+			expect( assessor.getAssessments() ).toEqual( expectedAssessments );
+			expect( assessor.researcher ).toEqual( expectedResearcher );
+			expect( assessor.scoreAggregator ).toEqual( expectedScoreAggregator );
+		} );
+
+		it( "throws an error when the given configuration combination does not exist", () => {
+			const config = {
+				cornerstone: true,
+				taxonomy: true,
+			};
+
+			expect( () => constructSEOAssessor( i18n, researcher, config ) ).toThrow();
+		} );
+	} );
+
+	describe( "constructReadabilityAssessor", () => {
+		it( "construct a readability assessor", () => {
+			const assessor = constructReadabilityAssessor( i18n, researcher );
+
+			const expectedAssessments = [];
+			const expectedResearcher = researcher;
+			const expectedScoreAggregator = new ReadabilityScoreAggregator();
+
+			expect( assessor.getAssessments() ).toEqual( expectedAssessments );
+			expect( assessor.researcher ).toEqual( expectedResearcher );
+			expect( assessor.scoreAggregator ).toEqual( expectedScoreAggregator );
+		} );
+
+		it( "construct a cornerstone readability assessor", () => {
+			const assessor = constructReadabilityAssessor( i18n, researcher, true );
+
+			const expectedAssessments = [];
+			const expectedResearcher = researcher;
+			const expectedScoreAggregator = new ReadabilityScoreAggregator();
+
+			expect( assessor.getAssessments() ).toEqual( expectedAssessments );
+			expect( assessor.researcher ).toEqual( expectedResearcher );
+			expect( assessor.scoreAggregator ).toEqual( expectedScoreAggregator );
+		} );
+	} );
+} );

--- a/packages/yoastseo/src/tree/assess/assessmentListFactories.js
+++ b/packages/yoastseo/src/tree/assess/assessmentListFactories.js
@@ -1,0 +1,73 @@
+/**
+ * Factory functions for creating lists of assessments.
+ *
+ * To be used in creating the different kinds of assessors.
+ */
+
+/**
+ * Creates a new list of SEO assessments.
+ *
+ * @returns {module:tree/assess.Assessment[]} The list of SEO assessments.
+ *
+ * @private
+ * @memberOf module:tree/assess
+ */
+const constructSEOAssessments = () => [
+	// Needs to be populated by fancy new assessments that work on the tree representation of the text.
+];
+
+/**
+ * Creates a new list of readability assessments.
+ *
+ * @returns {module:tree/assess.Assessment[]} The list of readability assessments.
+ *
+ * @private
+ * @memberOf module:tree/assess
+ */
+const constructReadabilityAssessments = () => [
+	// Needs to be populated by fancy new assessments that work on the tree representation of the text.
+];
+
+/**
+ * Creates a new list of SEO assessments for taxonomy pages.
+ *
+ * @returns {module:tree/assess.Assessment[]} The list of SEO assessments.
+ *
+ * @private
+ * @memberOf module:tree/assess
+ */
+const constructTaxonomyAssessments = () => [
+	// Needs to be populated by fancy new assessments that work on the tree representation of the text.
+];
+
+/**
+ * Creates a new list of SEO assessments for related keyphrases.
+ *
+ * @returns {module:tree/assess.Assessment[]} The list of SEO assessments.
+ *
+ * @private
+ * @memberOf module:tree/assess
+ */
+const constructRelatedKeyphraseAssessments = () => [
+	// Needs to be populated by fancy new assessments that work on the tree representation of the text.
+];
+
+/**
+ * Creates a new list of SEO assessments for related keyphrases on taxonomy pages.
+ *
+ * @returns {module:tree/assess.Assessment[]} The list of SEO assessments.
+ *
+ * @private
+ * @memberOf module:tree/assess
+ */
+const constructRelatedKeyphraseTaxonomyAssessments = () => [
+	// Needs to be populated by fancy new assessments that work on the tree representation of the text.
+];
+
+export {
+	constructSEOAssessments,
+	constructReadabilityAssessments,
+	constructTaxonomyAssessments,
+	constructRelatedKeyphraseAssessments,
+	constructRelatedKeyphraseTaxonomyAssessments,
+};

--- a/packages/yoastseo/src/tree/assess/assessorFactories.js
+++ b/packages/yoastseo/src/tree/assess/assessorFactories.js
@@ -1,0 +1,105 @@
+/* Assessment list factories. */
+import {
+	constructReadabilityAssessments,
+	constructRelatedKeyphraseAssessments,
+	constructRelatedKeyphraseTaxonomyAssessments,
+	constructSEOAssessments,
+	constructTaxonomyAssessments,
+} from "./assessmentListFactories";
+
+import {
+	constructSEOAssessments as constructCornerstoneSEOAssessments,
+	constructRelatedKeyphraseAssessments as constructCornerstoneRelatedKeyphraseAssessments,
+	constructReadabilityAssessments as constructCornerstoneReadabilityAssessments,
+} from "./cornerstone/assessmentListFactories";
+
+/* Score aggregators */
+import { ReadabilityScoreAggregator, SEOScoreAggregator } from "./scoreAggregators";
+
+/* Base TreeAssessor class */
+import TreeAssessor from "./TreeAssessor";
+
+/**
+ * Maps combinations of assessor parameters (if the assessor is for related keyphrases, cornerstone content and/or taxonomy pages)
+ * to functions that generate a list of applicable assessments.
+ *
+ * @const
+ * @private
+ * @type {Object}
+ */
+const SEO_ASSESSMENTS_MAP = {
+	Default: constructSEOAssessments,
+
+	RelatedKeyphrase: constructRelatedKeyphraseAssessments,
+	Taxonomy: constructTaxonomyAssessments,
+	RelatedKeyphraseTaxonomy: constructRelatedKeyphraseTaxonomyAssessments,
+
+	Cornerstone: constructCornerstoneSEOAssessments,
+	CornerstoneRelatedKeyphrase: constructCornerstoneRelatedKeyphraseAssessments,
+};
+
+/**
+ * Constructs a new SEO assessor.
+ *
+ * @param {Jed}                                 i18n       The Jed object to use for localization / internalization.
+ * @param {module:tree/research.TreeResearcher} researcher The researcher the assessments need to use to get information about the text.
+ *
+ * @param {Object}                              config                    The assessor configuration.
+ * @param {boolean}                             [config.relatedKeyphrase] If this assessor is for a related keyphrase, instead of the main one.
+ * @param {boolean}                             [config.taxonomy]         If this assessor is for a taxonomy page, instead of .
+ * @param {boolean}                             [config.cornerstone]      If this assessor is for cornerstone content.
+ *
+ * @returns {module:tree/assess.TreeAssessor} The created SEO assessor.
+ *
+ * @throws {Error} An error when no assessor exists for the given combination of configuration options.
+ *
+ * @memberOf module:tree/assess
+ */
+const constructSEOAssessor = function( i18n, researcher, config ) {
+	/*
+	 * Construct the key to retrieve the right assessment list factory.
+	 * E.g. "RelatedKeyphraseTaxonomy" for related keyphrase + taxonomy;
+	 */
+	const cornerstone = config.cornerstone ? "Cornerstone" : "";
+	const relatedKeyphrase = config.relatedKeyphrase ? "RelatedKeyphrase" : "";
+	const taxonomy = config.taxonomy ? "Taxonomy" : "";
+
+	// (Empty key defaults to "Default" key)
+	const key = [ cornerstone, relatedKeyphrase, taxonomy ].join( "" ) || "Default";
+
+	// Retrieve the assessment list factory.
+	const assessmentFactory = SEO_ASSESSMENTS_MAP[ key ];
+
+	// This specific combination of cornerstone, taxonomy and related keyphrase does not exist.
+	if ( ! assessmentFactory ) {
+		throw new Error( "Cannot make an assessor based on the provided combination of configuration options" );
+	}
+
+	// Construct assessor.
+	const assessments = assessmentFactory();
+	const scoreAggregator = new SEOScoreAggregator();
+	return new TreeAssessor( { i18n, researcher, assessments, scoreAggregator } );
+};
+
+/**
+ * Constructs a new readability assessor.
+ *
+ * @param {Jed}                                 i18n                 The Jed object to use for localization / internalization.
+ * @param {module:tree/research.TreeResearcher} researcher           The researcher the assessments need to use to get information about the text.
+ * @param {boolean}                             isCornerstoneContent If the to be analyzed content is considered cornerstone content
+ * (which uses stricter boundaries).
+ *
+ * @returns {module:tree/assess.TreeAssessor} The created readability assessor.
+ *
+ * @memberOf module:tree/assess
+ */
+const constructReadabilityAssessor = function( i18n, researcher, isCornerstoneContent = false ) {
+	const assessments = isCornerstoneContent ? constructReadabilityAssessments() : constructCornerstoneReadabilityAssessments();
+	const scoreAggregator = new ReadabilityScoreAggregator();
+	return new TreeAssessor( { i18n, researcher, assessments, scoreAggregator } );
+};
+
+export {
+	constructSEOAssessor,
+	constructReadabilityAssessor,
+};

--- a/packages/yoastseo/src/tree/assess/assessorFactories.js
+++ b/packages/yoastseo/src/tree/assess/assessorFactories.js
@@ -46,7 +46,7 @@ const SEO_ASSESSMENTS_MAP = {
  *
  * @param {Object}                              config                    The assessor configuration.
  * @param {boolean}                             [config.relatedKeyphrase] If this assessor is for a related keyphrase, instead of the main one.
- * @param {boolean}                             [config.taxonomy]         If this assessor is for a taxonomy page, instead of .
+ * @param {boolean}                             [config.taxonomy]         If this assessor is for a taxonomy page, instead of a regular page.
  * @param {boolean}                             [config.cornerstone]      If this assessor is for cornerstone content.
  *
  * @returns {module:tree/assess.TreeAssessor} The created SEO assessor.

--- a/packages/yoastseo/src/tree/assess/cornerstone/assessmentListFactories.js
+++ b/packages/yoastseo/src/tree/assess/cornerstone/assessmentListFactories.js
@@ -1,0 +1,47 @@
+/**
+ * Factory functions for creating lists of assessments for cornerstone content.
+ *
+ * To be used in creating the different kinds of assessors.
+ */
+
+/**
+ * Creates a new list of SEO assessments.
+ *
+ * @returns {module:tree/assess.Assessment[]} The list of SEO assessments.
+ *
+ * @private
+ * @memberOf module:tree/assess
+ */
+const constructSEOAssessments = () => [
+	// Needs to be populated by fancy new assessments that work on the tree representation of the text.
+];
+
+/**
+ * Creates a new list of readability assessments.
+ *
+ * @returns {module:tree/assess.Assessment[]} The list of readability assessments.
+ *
+ * @private
+ * @memberOf module:tree/assess
+ */
+const constructReadabilityAssessments = () => [
+	// Needs to be populated by fancy new assessments that work on the tree representation of the text.
+];
+
+/**
+ * Creates a new list of SEO assessments for related keyphrases.
+ *
+ * @returns {module:tree/assess.Assessment[]} The list of SEO assessments.
+ *
+ * @private
+ * @memberOf module:tree/assess
+ */
+const constructRelatedKeyphraseAssessments = () => [
+	// Needs to be populated by fancy new assessments that work on the tree representation of the text.
+];
+
+export {
+	constructSEOAssessments,
+	constructReadabilityAssessments,
+	constructRelatedKeyphraseAssessments,
+};

--- a/packages/yoastseo/src/tree/assess/cornerstone/index.js
+++ b/packages/yoastseo/src/tree/assess/cornerstone/index.js
@@ -1,0 +1,5 @@
+import * as cornerstoneAssessmentListFactories from "./assessmentListFactories";
+
+export {
+	cornerstoneAssessmentListFactories,
+};

--- a/packages/yoastseo/src/tree/assess/index.js
+++ b/packages/yoastseo/src/tree/assess/index.js
@@ -1,6 +1,9 @@
 import TreeAssessor from "./TreeAssessor";
 import * as ScoreAggregators from "./scoreAggregators";
 import * as Assessments from "./assessments";
+import * as assessorFactories from "./assessorFactories";
+import { cornerstoneAssessorFactories } from "./cornerstone";
+import { cornerstoneAssessmentListFactories } from "./cornerstone";
 
 /**
  * Contains the logic to assess a tree representation of a text.
@@ -13,4 +16,7 @@ export {
 	TreeAssessor,
 	ScoreAggregators,
 	Assessments,
+	assessorFactories,
+	cornerstoneAssessorFactories,
+	cornerstoneAssessmentListFactories,
 };


### PR DESCRIPTION
This is a clone of https://github.com/Yoast/YoastSEO.js/pull/2187

## Summary

This PR can be summarized in the following changelog entry:

* _[non-user-facing]_ Implements a collection of factory functions that create `TreeAssessor`s for different kinds of SEO and readability analysis. The kind produced depends on factors like type of content (normal page/post, cornerstone, taxonomy page) and type of keyphrase (main or related).

## Relevant technical choices:
I made some JSDoc submodules to keep relevant content together, whilst keeping them from all getting on the `tree/assess` module. I am not quite sure about the naming, so a second opinion would be nice!

* The factory functions live in their own JSDoc module called `tree/assess/assessors`.
     * Cornerstone functions live in `tree/assess/assessors/cornerstone`.
* I separated creating the assessment lists into separate factory functions, since they can grow quite big. They live in the submodule `tree/assess/assessors/assessments` and `tree/assess/assessors/cornerstone/assessments` respectively.

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test`, check if the coverage is 100% for the `tree/assess` folder.
* Check if the tests cover all edge cases.
* Review the code a second time, check if you can find any missing functionality or code improvements.

Fixes https://github.com/Yoast/YoastSEO.js/issues/2126 
