### PR TITLE
Improve german verb form creation

### DIFF
--- a/packages/yoastseo/spec/morphology/german/detectAndStemRegularParticipleSpec.js
+++ b/packages/yoastseo/spec/morphology/german/detectAndStemRegularParticipleSpec.js
@@ -1,0 +1,69 @@
+import { detectAndStemRegularParticiple } from "../../../src/morphology/german/detectAndStemRegularParticiple";
+import getMorphologyData from "../../specHelpers/getMorphologyData";
+
+
+const morphologyDataDE = getMorphologyData( "de" ).de;
+
+describe( "Detects and stems participles", () => {
+	it( "doesn't incorrectly detect a participle if the word is on the participle exception list", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "gebirgsart" ) ).toEqual( "" );
+	} );
+
+	it( "doesn't incorrectly detect a participle if the word is matched by the participle exception regex", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "gewerkschaft" ) ).toEqual( "" );
+	} );
+
+	it( "detects a participle and stems it; input: ge-stem-t participle", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "gekauft" ) ).toEqual( "kauf" );
+	} );
+
+	it( "detects a participle and stems it; input: separablePrefix-ge-stem-t participle", () => {
+		// Separable prefix: weiter.
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "heraufgeholt" ) ).toEqual( "heraufhol" );
+	} );
+
+	it( "detects a participle and stems it; input: separablePrefix-ge-stem-et participle", () => {
+		// Separable prefix: weiter.
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "weitergebildet" ) ).toEqual( "weiterbild" );
+	} );
+
+	it( "detects a participle and stems it; input: inseparablePrefix-stem-t/sst participle", () => {
+		// Inseparable prefix: er.
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "ertappt" ) ).toEqual( "ertapp" );
+	} );
+
+	it( "detects a participle and stems it; input: inseparablePrefix-stem-t/sst participle", () => {
+		// Inseparable prefix: er.
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "erfasst" ) ).toEqual( "erfass" );
+	} );
+
+	it( "detects a participle and stems it; input: inseparablePrefix-stem-et participle", () => {
+		// Inseparable prefix: be.
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "bewertet" ) ).toEqual( "bewert" );
+	} );
+
+	it( "detects a participle and stems it; input: separableOrInseparablePrefix-ge-stem-t participle", () => {
+		// Inseparable/separable prefix: durch.
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "durchgemacht" ) ).toEqual( "durchmach" );
+	} );
+
+	it( "detects a participle and stems it; input: separableOrInseparablePrefix-ge-stem-et participle", () => {
+		// Inseparable/separable prefix: durch.
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "durchgearbeitet" ) ).toEqual( "durcharbeit" );
+	} );
+
+	it( "detects a participle and stems it; input: separableOrInseparablePrefix-stem-t/sst participle", () => {
+		// Inseparable/separable prefix: über.
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "überführt" ) ).toEqual( "überführ" );
+	} );
+
+	it( "detects a participle and stems it; input: separableOrInseparablePrefix-stem-t/sst participle", () => {
+		// Inseparable/separable prefix: um.
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "umfasst" ) ).toEqual( "umfass" );
+	} );
+
+	it( "detects a participle and stems it; input: separableOrInseparablePrefix-stem-et participle", () => {
+		// Inseparable/separable prefix: durch.
+		expect( detectAndStemRegularParticiple( morphologyDataDE.verbs, "durchlüftet" ) ).toEqual( "durchlüft" );
+	} );
+} );

--- a/packages/yoastseo/spec/morphology/german/generateParticipleFormSpec.js
+++ b/packages/yoastseo/spec/morphology/german/generateParticipleFormSpec.js
@@ -12,4 +12,14 @@ describe( "Test for generating participle forms", () => {
 	it( "generates a regular participle form for a stem ending in any other", () => {
 		expect( generateParticipleForm( morphologyDataDE.verbs, "spiel" ) ).toEqual( "gespielt" );
 	} );
+
+	it( "generates a participle form for a stem starting with a separable prefix", () => {
+		// Separable prefix: ein.
+		expect( generateParticipleForm( morphologyDataDE.verbs, "einkauf" ) ).toEqual( "eingekauft" );
+	} );
+
+	it( "generates a participle form for a stem starting with a non-separable/separable prefix", () => {
+		// Inseparable/separable prefix: über.
+		expect( generateParticipleForm( morphologyDataDE.verbs, "überkoch" ) ).toEqual( "übergekocht" );
+	} );
 } );

--- a/packages/yoastseo/spec/morphology/german/generateRegularVerbFormsSpec.js
+++ b/packages/yoastseo/spec/morphology/german/generateRegularVerbFormsSpec.js
@@ -1,0 +1,28 @@
+import { generateRegularVerbForms } from "../../../src/morphology/german/generateRegularVerbForms";
+import getMorphologyData from "../../specHelpers/getMorphologyData";
+
+
+const morphologyDataDE = getMorphologyData( "de" ).de;
+
+describe( "Test for getting the right verb suffixes depending on the stem ending", () => {
+	it( "adds all verb suffixes for a verb that doesn't fall into any of the modification categories", () => {
+		expect( generateRegularVerbForms( morphologyDataDE.verbs, "kauf" ) ).toEqual( [
+			"kaufe",
+			"kauft",
+			"kaufst",
+			"kaufen",
+			"kaufest",
+			"kaufet",
+			"kaufte",
+			"kauftet",
+			"kauften",
+			"kauftest",
+			"kaufete",
+			"kaufetet",
+			"kaufeten",
+			"kaufetest",
+			"kaufend",
+			"gekauft",
+		] );
+	} );
+} );

--- a/packages/yoastseo/spec/morphology/german/getGermanFormsSpec.js
+++ b/packages/yoastseo/spec/morphology/german/getGermanFormsSpec.js
@@ -303,4 +303,46 @@ describe( "Test for creating forms for German words", () => {
 			stem: "sau",
 		} );
 	} );
+
+	it( "creates verb and adjective forms if a word was recognized and stemmed as a participle", () => {
+		expect( getForms( "gefärbt", morphologyDataDE ) ).toEqual( {
+			forms: [
+				// The original word.
+				"gefärbt",
+				// Verbal forms.
+				"färbe",
+				"färbt",
+				"färbst",
+				"färben",
+				"färbest",
+				"färbet",
+				"färbte",
+				"färbtet",
+				"färbten",
+				"färbtest",
+				"färbete",
+				"färbetet",
+				"färbeten",
+				"färbetest",
+				"färbend",
+				// Adjectival forms.
+				"gefärbte",
+				"gefärbtem",
+				"gefärbten",
+				"gefärbter",
+				"gefärbtes",
+				"gefärbtere",
+				"gefärbterem",
+				"gefärbteren",
+				"gefärbterer",
+				"gefärbteres",
+				"gefärbteste",
+				"gefärbtestem",
+				"gefärbtesten",
+				"gefärbtester",
+				"gefärbtestes",
+			],
+			stem: "färb",
+		} );
+	} );
 } );

--- a/packages/yoastseo/src/morphology/german/detectAndStemRegularParticiple.js
+++ b/packages/yoastseo/src/morphology/german/detectAndStemRegularParticiple.js
@@ -1,0 +1,196 @@
+import exceptionsParticiplesActive from "../../researches/german/passiveVoice/exceptionsParticiplesActive";
+import { exceptions } from "../../researches/german/passiveVoice/regex";
+
+/**
+ * Detects whether a word is a regular participle without a prefix and if so, returns the stem.
+ *
+ * @param {Object}  morphologyDataVerbs The German morphology data for verbs.
+ * @param {string}  word                The word (not stemmed) to check.
+ *
+ * @returns {string}    The stem.
+ */
+const detectAndStemParticiplesWithoutPrefixes = function( morphologyDataVerbs, word ) {
+	const participleRegex1 = new RegExp( "^" + morphologyDataVerbs.participleRegexes.participleRegexGeStemTEnd );
+	const participleRegex2 = new RegExp( "^" + morphologyDataVerbs.participleRegexes.participleRegexGeStemTdEt );
+
+	/*
+	 * Check if it's a ge + stem ending in d/t + et participle.
+	 * As this is the more specific regex, it needs to be checked before the ge + stem + t regex.
+	 */
+	if ( participleRegex2.test( word ) ) {
+		// Remove the two-letter prefix and the two-letter suffix.
+		return ( word.slice( 2, word.length - 2 ) );
+	}
+
+	// Check if it's a ge + stem + t participle.
+	if ( participleRegex1.test( word ) ) {
+		// Remove the two-letter prefix and the one-letter suffix.
+		return ( word.slice( 2, word.length - 1 ) );
+	}
+
+	return "";
+};
+
+/**
+ * Determines whether a given participle pattern combined with prefixes from a given class applies to a given word
+ * and if so, returns the stem.
+ *
+ * @param {string}      word        The word (not stemmed) to check.
+ * @param {string[]}    prefixes    The prefixes of a certain prefix class.
+ * @param {string}      regexPart   The regex part for a given class (completed to a full regex within the function).
+ * @param {number}      startStem   Where to start cutting off the de-prefixed word.
+ * @param {number}      endStem     Where to end cutting off the de-prefixed word (from the end index).
+ *
+ * @returns {string} The stem.
+ */
+const detectAndStemParticiplePerPrefixClass = function( word, prefixes, regexPart, startStem, endStem ) {
+	for ( let i = 0; i < prefixes.length; i++ ) {
+		const currentPrefix = prefixes[ i ];
+		const participleRegex = new RegExp( "^" + currentPrefix + regexPart );
+
+		if ( participleRegex.test( word ) ) {
+			const wordWithoutPrefix = word.slice( currentPrefix.length - word.length );
+			const wordWithoutParticipleAffixes = wordWithoutPrefix.slice( startStem, wordWithoutPrefix.length - endStem );
+
+			return ( currentPrefix + wordWithoutParticipleAffixes );
+		}
+	}
+
+	return "";
+};
+
+/**
+ * Detects whether a word is a regular participle with a prefix and if so, returns the stem.
+ *
+ * @param {Object}  morphologyDataVerbs The German morphology data for verbs.
+ * @param {string}  word                The word (not stemmed) to check.
+ *
+ * @returns {string} The stem.
+ */
+const detectAndStemParticiplesWithPrefixes = function( morphologyDataVerbs, word ) {
+	const prefixExceptionChecks = [
+		/*
+		 * Check if it's a separable prefix + ge + stem ending in d/t + et participle.
+		 * As this is the more specific regex, which needs to be checked before the ge + stem + t regex.
+		 */
+		() => {
+			return detectAndStemParticiplePerPrefixClass(
+				word,
+				morphologyDataVerbs.verbPrefixesSeparable,
+				morphologyDataVerbs.participleRegexes.participleRegexGeStemTdEt,
+				2,
+				2,
+			);
+		},
+		// Check if it's a separable prefix + ge + stem + t participle.
+		() => {
+			return detectAndStemParticiplePerPrefixClass(
+				word,
+				morphologyDataVerbs.verbPrefixesSeparable,
+				morphologyDataVerbs.participleRegexes.participleRegexGeStemTEnd,
+				2,
+				1,
+			);
+		},
+		// Check if it's an inseparable prefix + stem ending in d/t + et participle.
+		() => {
+			return detectAndStemParticiplePerPrefixClass(
+				word,
+				morphologyDataVerbs.verbPrefixesInseparable,
+				morphologyDataVerbs.participleRegexes.participleRegexStemTdEt,
+				0,
+				2,
+			);
+		},
+		// Check if it's an inseparable prefix + stem + t/sst participle.
+		() => {
+			return detectAndStemParticiplePerPrefixClass(
+				word,
+				morphologyDataVerbs.verbPrefixesInseparable,
+				morphologyDataVerbs.participleRegexes.participleRegexStemTSst,
+				0,
+				1,
+			);
+		},
+		/*
+	    * Check if it's a separable/inseparable prefix + ge + stem ending in d/t + et participle.
+	    * As this is the more specific regex, which needs to be checked before the ge + stem + t regex.
+	    */
+		() => {
+			return detectAndStemParticiplePerPrefixClass(
+				word,
+				morphologyDataVerbs.verbPrefixesSeparableOrInseparable,
+				morphologyDataVerbs.participleRegexes.participleRegexGeStemTdEt,
+				2,
+				2,
+			);
+		},
+		// Check if it's a separable/inseparable prefix + ge + stem + t participle.
+		() => {
+			return detectAndStemParticiplePerPrefixClass(
+				word,
+				morphologyDataVerbs.verbPrefixesSeparableOrInseparable,
+				morphologyDataVerbs.participleRegexes.participleRegexGeStemTEnd,
+				2,
+				1,
+			);
+		},
+		// Check if it's an separable/inseparable prefix + stem ending in d/t + et participle.
+		() => {
+			return detectAndStemParticiplePerPrefixClass(
+				word,
+				morphologyDataVerbs.verbPrefixesSeparableOrInseparable,
+				morphologyDataVerbs.participleRegexes.participleRegexStemTdEt,
+				0,
+				2,
+			);
+		},
+		// Check if it's an separable/inseparable prefix + stem + t/sst participle.
+		() => {
+			return detectAndStemParticiplePerPrefixClass(
+				word,
+				morphologyDataVerbs.verbPrefixesSeparableOrInseparable,
+				morphologyDataVerbs.participleRegexes.participleRegexStemTSst,
+				0,
+				1,
+			);
+		},
+	];
+
+	for ( let i = 0; i < prefixExceptionChecks.length; i++ ) {
+		const stem = prefixExceptionChecks[ i ]();
+		if ( stem.length > 0 ) {
+			return stem;
+		}
+	}
+
+	return "";
+};
+
+/**
+ * Detects whether a word is a regular participle and if so, returns the stem.
+ *
+ * @param {Object}  morphologyDataVerbs The German morphology data for verbs.
+ * @param {string}  word                The word (not stemmed) to check.
+ *
+ * @returns {string} The stem.
+ */
+export function detectAndStemRegularParticiple( morphologyDataVerbs, word ) {
+	if ( exceptions( word ).length > 0 || exceptionsParticiplesActive().includes( word ) ) {
+		return "";
+	}
+
+	let stem = detectAndStemParticiplesWithoutPrefixes( morphologyDataVerbs, word );
+
+	if ( stem.length > 0 ) {
+		return stem;
+	}
+
+	stem = detectAndStemParticiplesWithPrefixes( morphologyDataVerbs, word );
+
+	if ( stem.length > 0 ) {
+		return stem;
+	}
+
+	return "";
+}

--- a/packages/yoastseo/src/morphology/german/detectAndStemRegularParticiple.js
+++ b/packages/yoastseo/src/morphology/german/detectAndStemRegularParticiple.js
@@ -10,20 +10,20 @@ import { exceptions } from "../../researches/german/passiveVoice/regex";
  * @returns {string|null} The stem or null if no participle was matched.
  */
 const detectAndStemParticiplesWithoutPrefixes = function( morphologyDataVerbs, word ) {
-	const participleRegex1 = new RegExp( "^" + morphologyDataVerbs.participleStemmingClasses[ 1 ].regex );
-	const participleRegex2 = new RegExp( "^" + morphologyDataVerbs.participleStemmingClasses[ 0 ].regex );
+	const geStemTParticipleRegex = new RegExp( "^" + morphologyDataVerbs.participleStemmingClasses[ 1 ].regex );
+	const geStemEtParticipleRegex = new RegExp( "^" + morphologyDataVerbs.participleStemmingClasses[ 0 ].regex );
 
 	/*
 	 * Check if it's a ge + stem ending in d/t + et participle.
 	 * As this is the more specific regex, it needs to be checked before the ge + stem + t regex.
 	 */
-	if ( participleRegex2.test( word ) ) {
+	if ( geStemEtParticipleRegex.test( word ) ) {
 		// Remove the two-letter prefix and the two-letter suffix.
 		return ( word.slice( 2, word.length - 2 ) );
 	}
 
 	// Check if it's a ge + stem + t participle.
-	if ( participleRegex1.test( word ) ) {
+	if ( geStemTParticipleRegex.test( word ) ) {
 		// Remove the two-letter prefix and the one-letter suffix.
 		return ( word.slice( 2, word.length - 1 ) );
 	}

--- a/packages/yoastseo/src/morphology/german/generateParticipleForm.js
+++ b/packages/yoastseo/src/morphology/german/generateParticipleForm.js
@@ -37,9 +37,7 @@ const generateRegularParticipleForm = function( morphologyDataVerbs, stemmedWord
  * @returns {string} The created participle form.
  */
 const generateParticipleFormWithSeparablePrefix = function( morphologyDataVerbs, stemmedWord, prefixes ) {
-	for ( let i = 0; i < prefixes.length; i++ ) {
-		const currentPrefix = prefixes[ i ];
-
+	for ( const currentPrefix of prefixes ) {
 		if ( stemmedWord.startsWith( currentPrefix ) ) {
 			const stemmedWordWithoutPrefix = stemmedWord.slice( currentPrefix.length, stemmedWord.length );
 

--- a/packages/yoastseo/src/morphology/german/generateParticipleForm.js
+++ b/packages/yoastseo/src/morphology/german/generateParticipleForm.js
@@ -34,7 +34,7 @@ const generateRegularParticipleForm = function( morphologyDataVerbs, stemmedWord
  * @param {string}      stemmedWord         The stem to check.
  * @param {string[]}    prefixes            The prefixes to check.
  *
- * @returns {string} The created participle form.
+ * @returns {string|null} The created participle form or null if the stem doesn't start with a prefix.
  */
 const generateParticipleFormWithSeparablePrefix = function( morphologyDataVerbs, stemmedWord, prefixes ) {
 	for ( const currentPrefix of prefixes ) {
@@ -49,7 +49,7 @@ const generateParticipleFormWithSeparablePrefix = function( morphologyDataVerbs,
 		}
 	}
 
-	return "";
+	return null;
 };
 
 /**
@@ -67,7 +67,7 @@ export function generateParticipleForm( morphologyDataVerbs, stemmedWord ) {
 		morphologyDataVerbs.verbPrefixesSeparable
 	);
 
-	if ( participleFormWithPrefix.length > 0 ) {
+	if ( participleFormWithPrefix ) {
 		return participleFormWithPrefix;
 	}
 
@@ -82,7 +82,7 @@ export function generateParticipleForm( morphologyDataVerbs, stemmedWord ) {
 		morphologyDataVerbs.verbPrefixesSeparableOrInseparable
 	);
 
-	if ( participleFormWithPrefix.length > 0 ) {
+	if ( participleFormWithPrefix ) {
 		return participleFormWithPrefix;
 	}
 

--- a/packages/yoastseo/src/morphology/german/generateParticipleForm.js
+++ b/packages/yoastseo/src/morphology/german/generateParticipleForm.js
@@ -1,13 +1,14 @@
 /**
  * Adds a prefix and a suffix to a stem in order to create a past participle form
  *
- * @param {string}  stemmedWord The stemmed word on which to
- * @param {Object}  affixes     The suffix and prefix data.
+ * @param {string}  stemmedWord             The stemmed word for which to create the past participle form.
+ * @param {Object}  affixes                 The suffix and prefix data.
+ * @param {string}  [additionalPrefix = ""] An additional prefix to attach to the beginning of the participle.
  *
  * @returns {string} The participle form.
  */
-const addParticipleAffixes = function( stemmedWord, affixes ) {
-	return affixes.prefix + stemmedWord + affixes.suffix;
+const addParticipleAffixes = function( stemmedWord, affixes, additionalPrefix = "" ) {
+	return additionalPrefix + affixes.prefix + stemmedWord + affixes.suffix;
 };
 
 /**
@@ -18,10 +19,74 @@ const addParticipleAffixes = function( stemmedWord, affixes ) {
  *
  * @returns {string} A past participle form.
  */
-export function generateParticipleForm( morphologyDataVerbs, stemmedWord ) {
+const generateRegularParticipleForm = function( morphologyDataVerbs, stemmedWord ) {
 	if ( stemmedWord.endsWith( "d" ) || stemmedWord.endsWith( "t" ) ) {
 		return addParticipleAffixes( stemmedWord, morphologyDataVerbs.participleAffixes.stemEndsInDOrT );
 	}
 
 	return addParticipleAffixes( stemmedWord, morphologyDataVerbs.participleAffixes.regular );
+};
+
+/**
+ * Generates participle forms with separable or separable/inseparable prefixes.
+ *
+ * @param {Object}      morphologyDataVerbs The German morphology data for verbs.
+ * @param {string}      stemmedWord         The stem to check.
+ * @param {string[]}    prefixes            The prefixes to check.
+ *
+ * @returns {string} The created participle form.
+ */
+const generateParticipleFormWithSeparablePrefix = function( morphologyDataVerbs, stemmedWord, prefixes ) {
+	for ( let i = 0; i < prefixes.length; i++ ) {
+		const currentPrefix = prefixes[ i ];
+
+		if ( stemmedWord.startsWith( currentPrefix ) ) {
+			const stemmedWordWithoutPrefix = stemmedWord.slice( currentPrefix.length, stemmedWord.length );
+
+			if ( stemmedWord.endsWith( "d" ) || stemmedWord.endsWith( "t" ) ) {
+				return addParticipleAffixes( stemmedWordWithoutPrefix, morphologyDataVerbs.participleAffixes.stemEndsInDOrT, currentPrefix );
+			}
+
+			return addParticipleAffixes( stemmedWordWithoutPrefix, morphologyDataVerbs.participleAffixes.regular, currentPrefix );
+		}
+	}
+
+	return "";
+};
+
+/**
+ * Generates participle forms for a given stem.
+ *
+ * @param {Object}  morphologyDataVerbs The German morphology data for verbs.
+ * @param {string}  stemmedWord         The stem to check.
+ *
+ * @returns {string} The created participle form.
+ */
+export function generateParticipleForm( morphologyDataVerbs, stemmedWord ) {
+	let participleFormWithPrefix = generateParticipleFormWithSeparablePrefix(
+		morphologyDataVerbs,
+		stemmedWord,
+		morphologyDataVerbs.verbPrefixesSeparable
+	);
+
+	if ( participleFormWithPrefix.length > 0 ) {
+		return participleFormWithPrefix;
+	}
+
+	/*
+	 * Check forms with a separable/non-separable prefix used in its separable form, e.g. ("überkochen" - "übergekocht")
+	 * For its these prefixes used in the inseparable form, the resulting participle would be the same as
+	 * the 3rd person singular, so we don't need to create a separate form here (e.g., "überführen" - "überführt").
+	 */
+	participleFormWithPrefix = generateParticipleFormWithSeparablePrefix(
+		morphologyDataVerbs,
+		stemmedWord,
+		morphologyDataVerbs.verbPrefixesSeparableOrInseparable
+	);
+
+	if ( participleFormWithPrefix.length > 0 ) {
+		return participleFormWithPrefix;
+	}
+
+	return generateRegularParticipleForm( morphologyDataVerbs, stemmedWord );
 }

--- a/packages/yoastseo/src/morphology/german/generateRegularVerbForms.js
+++ b/packages/yoastseo/src/morphology/german/generateRegularVerbForms.js
@@ -1,0 +1,17 @@
+import { addVerbSuffixes } from "./addVerbSuffixes";
+import { generateParticipleForm } from "./generateParticipleForm";
+
+/**
+ * Generates regular verb forms.
+ *
+ * @param {Object}  morphologyDataVerbs The German morphology data for verbs.
+ * @param {string}  stemmedWord         The stemmed word for which to create the past participle form.
+ *
+ * @returns {string[]} The created verb forms.
+ */
+export function generateRegularVerbForms( morphologyDataVerbs, stemmedWord ) {
+	return [
+		...addVerbSuffixes( morphologyDataVerbs, stemmedWord ),
+		generateParticipleForm( morphologyDataVerbs, stemmedWord ),
+	];
+}

--- a/packages/yoastseo/src/morphology/german/getForms.js
+++ b/packages/yoastseo/src/morphology/german/getForms.js
@@ -1,11 +1,12 @@
 import { addAllAdjectiveSuffixes } from "./addAdjectiveSuffixes";
-import { addVerbSuffixes } from "./addVerbSuffixes";
+import { detectAndStemRegularParticiple } from "./detectAndStemRegularParticiple";
 import { generateAdjectiveExceptionForms } from "./generateAdjectiveExceptionForms";
 import { generateNounExceptionForms } from "./generateNounExceptionForms";
-import { uniq as unique } from "lodash-es";
-import { generateParticipleForm } from "./generateParticipleForm";
+import { generateRegularVerbForms } from "./generateRegularVerbForms";
 import { generateVerbExceptionForms } from "./generateVerbExceptionForms";
 import stem from "./stem";
+
+import { uniq as unique } from "lodash-es";
 
 /**
  * Adds suffixes to the list of regular suffixes.
@@ -107,7 +108,7 @@ const addFormsWithRemovedLetters = function( morphologyDataNouns, stemmedWordToC
  */
 export function getForms( word, morphologyData ) {
 	const stemmedWord = stem( word );
-	const forms = new Array( word );
+	const forms = [ word ];
 
 	/*
 	 * Generate exception forms if the word is on an exception list. Since a given stem might sometimes be
@@ -126,6 +127,26 @@ export function getForms( word, morphologyData ) {
 		return { forms: unique( exceptions ), stem: stemmedWord };
 	}
 
+	const stemIfWordIsParticiple = detectAndStemRegularParticiple( morphologyData.verbs, word );
+
+	/*
+	 * If the original word is a regular participle, it gets stemmed here. We then only create verb forms (assuming
+	 * that the participle was used verbally, e.g. "er hat sich die Haare gefärbt" - "he dyed his hair") and adjective
+	 * forms (assuming that the participle was used adjectivally, e.g. "die Haare sind gefärbt" - "the hair is dyed").
+	 * The adjective forms are based on the stem that has only the suffixes removed, not the prefixes. This is because
+	 * we want forms such as "die gefärbten Haare" and not (incorrectly) "*die färbten Haare".
+	 */
+	if ( stemIfWordIsParticiple.length > 0 ) {
+		return {
+			forms: unique( [
+				...forms,
+				...generateRegularVerbForms( morphologyData.verbs, stemIfWordIsParticiple ),
+				...addAllAdjectiveSuffixes( morphologyData.adjectives, stemmedWord ),
+			] ),
+			stem: stemIfWordIsParticiple,
+		};
+	}
+
 	// Modify regular suffixes assuming the word is a noun.
 	let regularNounSuffixes = morphologyData.nouns.regularSuffixes.slice();
 	// Depending on the specific ending of the stem, we can add/remove some suffixes from the list of regulars.
@@ -138,10 +159,7 @@ export function getForms( word, morphologyData ) {
 	forms.push( ...addAllAdjectiveSuffixes( morphologyData.adjectives, stemmedWord ) );
 
 	// Also add regular verb suffixes.
-	forms.push( ...addVerbSuffixes( morphologyData.verbs, stemmedWord ) );
-
-	// Add a participle form.
-	forms.push( generateParticipleForm( morphologyData.verbs, stemmedWord  ) );
+	forms.push( ...generateRegularVerbForms( morphologyData.verbs, stemmedWord ) );
 
 	// Also add the stemmed word, since it might be a valid word form on its own.
 	forms.push( stemmedWord );

--- a/packages/yoastseo/src/morphology/german/getForms.js
+++ b/packages/yoastseo/src/morphology/german/getForms.js
@@ -136,7 +136,7 @@ export function getForms( word, morphologyData ) {
 	 * The adjective forms are based on the stem that has only the suffixes removed, not the prefixes. This is because
 	 * we want forms such as "die gefärbten Haare" and not (incorrectly) "*die färbten Haare".
 	 */
-	if ( stemIfWordIsParticiple.length > 0 ) {
+	if ( stemIfWordIsParticiple ) {
 		return {
 			forms: unique( [
 				...forms,

--- a/packages/yoastseo/src/researches/german/passiveVoice/regex.js
+++ b/packages/yoastseo/src/researches/german/passiveVoice/regex.js
@@ -58,14 +58,15 @@ var verbsEndingWithIert = function( word ) {
 };
 
 /**
- * Matches the word againts the exceptions regex.
+ * Matches the word against the exceptions regex.
  *
  * @param {string} word The word to match.
+ *
  * @returns {Array} A list with matches.
  */
-var exceptions = function( word ) {
+export function exceptions( word ) {
 	return word.match( exceptionsRegex ) || [];
-};
+}
 
 /**
  * Returns lists of verbs that are relevant for determining passive voice in German.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Makes it possible to create stems from German participles, e.g. `gekauft` -> `kauf`. From these stems, the correct verb and adjectives forms are then created.
* Adds functionality to create participle forms with prefixes, e.g. `eingekauft`.

## Relevant technical choices:

* The check for whether a word is a participle takes place after checking exceptions (since these also include participle stems) but before creating regular forms.
* If a participle is detected, we only create verb forms (assuming that the participle was used verbally, e.g. "er hat sich die Haare gefärbt" - "he dyed his hair") and adjective forms (assuming that the participle was used adjectivally, e.g. "die Haare sind gefärbt" - "the hair is dyed"). The adjective forms are based on the stem that has only the suffixes removed, not the prefixes. This is because we want forms such as "die gefärbten Haare" and not (incorrectly) "*die färbten Haare".

## Test instructions

This PR can be tested by following these steps:

* To check whether participles get stemmed correctly:
  * In the example, make sure your locale is set to `de_DE` and you have enabled morphology.
  * Add a text with at least 150 words.
  * Set a keyphrase containing a participle, e.g. `gekauft`.
  * In the text, add different forms of the verb `kaufen`, e.g. `kaufe`, `kaufte` etc.
  * Make sure these forms get recognized as forms of the keyphrase.
* To check whether participle forms get created correctly:
 * In the example, make sure your locale is set to `de_DE` and you have enabled morphology.
  * Add a text with at least 150 words.
  * Set a keyphrase containing a verb, e.g. `kaufen`.
  * In the text, add the participle `gekauft`.
  * Make sure the participle forms gets recognized as a form of the keyphrase.
* For different verb/verb forms for testing, consult a dictionary, e.g. https://de.wiktionary.org/wiki/Wiktionary:Hauptseite.

Moved from https://github.com/Yoast/YoastSEO.js/pull/2191

Fixes https://github.com/Yoast/YoastSEO.js/issues/2190
