### PR TITLE
Add lerna-debug.log to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+lerna-debug.log


### PR DESCRIPTION
Add lerna-debug.log to .gitignore. This file is created locally when you run a lerna command that exits with an error.