### PR TITLE
Add yarn lerna script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     ]
   },
   "scripts": {
+    "lerna": "lerna",
     "lint": "lerna run lint",
     "test": "lerna run test --stream",
     "install-ci": "lerna run install-ci",


### PR DESCRIPTION
This change makes it possible to use 'yarn lerna [whatever]', which means lerna doesn't have to be installed locally in order to use it.