### PR TITLE
Yoastseo/2194 create headings research

### DIFF
--- a/packages/yoastseo/spec/tree/research/researches/HeadingsSpec.js
+++ b/packages/yoastseo/spec/tree/research/researches/HeadingsSpec.js
@@ -1,5 +1,6 @@
 import Headings from "../../../../src/tree/research/researches/Headings";
 import TreeResearcher from "../../../../src/tree/research/TreeResearcher";
+import Heading from "../../../../src/tree/structure/nodes/Heading";
 import buildTreeFromYaml from "../../../specHelpers/buildTreeFromYaml";
 
 describe( "Headings", () => {
@@ -15,22 +16,52 @@ Structured:
         level: 1
         sourceStartIndex: 25
         sourceEndIndex: 30
-        text: This is a header level 1.
+        text: This is a heading level 1.
     - Paragraph:
         tag: p
         sourceStartIndex: 23
         sourceEndIndex: 50
         text: This is a paragraph.
+    - Structured:
+        tag: section
+        sourceStartIndex: 23
+        sourceEndIndex: 50
+        children:
+          - Heading:
+              level: 2
+              sourceStartIndex: 23
+              sourceEndIndex: 50
+              text: This is a heading level 2.
+          - Paragraph:
+              tag: p
+              sourceStartIndex: 23
+              sourceEndIndex: 50
+              text: This is another paragraph.
 `;
 	} );
 
 	it( "gives back a list of headings when applying the research to a text with the researcher.", done => {
 		const researcher = new TreeResearcher();
 		const headings = new Headings();
+
+		const heading1 = new Heading( 1 );
+		heading1.text = "This is a heading level 1";
+		heading1.level = 1;
+		heading1.sourceStartIndex = 23;
+		heading1.sourceEndIndex = 50;
+
+		const heading2 = new Heading( 1 );
+		heading2.text = "This is a heading level 2";
+		heading2.level = 2;
+		heading2.sourceStartIndex = 23;
+		heading2.sourceEndIndex = 50;
+
+		const expected = [ heading1, heading2 ];
+
 		researcher.addResearch( "headings", headings );
 		researcher.doResearch( "headings", tree ).then(
-			result => {
-				console.log( result );
+			results => {
+				expect( results ).toEqual( expected );
 				done();
 			}
 		);

--- a/packages/yoastseo/spec/tree/research/researches/HeadingsSpec.js
+++ b/packages/yoastseo/spec/tree/research/researches/HeadingsSpec.js
@@ -66,4 +66,42 @@ Structured:
 			}
 		);
 	} );
+
+	it( "gives back an empty list of when applying the research to a text with no headings.", done => {
+		const researcher = new TreeResearcher();
+		const headings = new Headings();
+
+		const treeNoHeadings = buildTreeFromYaml`
+Structured:
+  tag: root
+  sourceStartIndex: 23
+  sourceEndIndex: 50
+  children:
+    - Paragraph:
+        tag: p
+        sourceStartIndex: 23
+        sourceEndIndex: 50
+        text: This is a paragraph.
+    - Structured:
+        tag: section
+        sourceStartIndex: 23
+        sourceEndIndex: 50
+        children:
+          - Paragraph:
+              tag: p
+              sourceStartIndex: 23
+              sourceEndIndex: 50
+              text: This is another paragraph.
+`;
+
+		const expected = [];
+
+		researcher.addResearch( "headings", headings );
+		researcher.doResearch( "headings", treeNoHeadings ).then(
+			results => {
+				expect( results ).toEqual( expected );
+				done();
+			}
+		);
+	} );
 } );

--- a/packages/yoastseo/spec/tree/research/researches/HeadingsSpec.js
+++ b/packages/yoastseo/spec/tree/research/researches/HeadingsSpec.js
@@ -1,0 +1,38 @@
+import Headings from "../../../../src/tree/research/researches/Headings";
+import TreeResearcher from "../../../../src/tree/research/TreeResearcher";
+import buildTreeFromYaml from "../../../specHelpers/buildTreeFromYaml";
+
+describe( "Headings", () => {
+	let tree;
+	beforeEach( () => {
+		tree = buildTreeFromYaml`
+Structured:
+  tag: root
+  sourceStartIndex: 23
+  sourceEndIndex: 50
+  children:
+    - Heading:
+        level: 1
+        sourceStartIndex: 25
+        sourceEndIndex: 30
+        text: This is a header level 1.
+    - Paragraph:
+        tag: p
+        sourceStartIndex: 23
+        sourceEndIndex: 50
+        text: This is a paragraph.
+`;
+	} );
+
+	it( "gives back a list of headings when applying the research to a text with the researcher.", done => {
+		const researcher = new TreeResearcher();
+		const headings = new Headings();
+		researcher.addResearch( "headings", headings );
+		researcher.doResearch( "headings", tree ).then(
+			result => {
+				console.log( result );
+				done();
+			}
+		);
+	} );
+} );

--- a/packages/yoastseo/spec/tree/research/researches/HeadingsSpec.js
+++ b/packages/yoastseo/spec/tree/research/researches/HeadingsSpec.js
@@ -45,16 +45,16 @@ Structured:
 		const headings = new Headings();
 
 		const heading1 = new Heading( 1 );
-		heading1.text = "This is a heading level 1";
-		heading1.level = 1;
-		heading1.sourceStartIndex = 23;
-		heading1.sourceEndIndex = 50;
+		heading1.text = "This is a heading level 1.";
+		heading1.sourceStartIndex = 25;
+		heading1.sourceEndIndex = 30;
+		heading1.setResearchResult( "headings", heading1 );
 
-		const heading2 = new Heading( 1 );
-		heading2.text = "This is a heading level 2";
-		heading2.level = 2;
+		const heading2 = new Heading( 2 );
+		heading2.text = "This is a heading level 2.";
 		heading2.sourceStartIndex = 23;
 		heading2.sourceEndIndex = 50;
+		heading2.setResearchResult( "headings", heading2 );
 
 		const expected = [ heading1, heading2 ];
 

--- a/packages/yoastseo/spec/tree/research/researches/HeadingsSpec.js
+++ b/packages/yoastseo/spec/tree/research/researches/HeadingsSpec.js
@@ -48,13 +48,13 @@ Structured:
 		heading1.text = "This is a heading level 1.";
 		heading1.sourceStartIndex = 25;
 		heading1.sourceEndIndex = 30;
-		heading1.setResearchResult( "headings", heading1 );
+		heading1.setResearchResult( "headings", [ heading1 ] );
 
 		const heading2 = new Heading( 2 );
 		heading2.text = "This is a heading level 2.";
 		heading2.sourceStartIndex = 23;
 		heading2.sourceEndIndex = 50;
-		heading2.setResearchResult( "headings", heading2 );
+		heading2.setResearchResult( "headings", [ heading2 ] );
 
 		const expected = [ heading1, heading2 ];
 

--- a/packages/yoastseo/src/tree/research/researches/Headings.js
+++ b/packages/yoastseo/src/tree/research/researches/Headings.js
@@ -1,0 +1,48 @@
+import Research from "./Research";
+
+/**
+ * A research giving back the headings located in a text.
+ */
+class Headings extends Research {
+
+	/**
+	 * Calculates the result of the research for the given Node.
+	 *
+	 * @param {module:tree/structure.Node} node The node to calculate the research for.
+	 *
+	 * @returns {Promise<*>} The result of the research.
+	 *
+	 * @abstract
+	 */
+	calculateFor( node ) {
+		return undefined;
+	}
+
+	/**
+	 * Checks if the given node is a leaf node for this research.
+	 *
+	 * @param {module:tree/structure.Node} node The node to check.
+	 *
+	 * @returns {boolean} If the given node is considered a leaf node for this research.
+	 *
+	 * @abstract
+	 */
+	isLeafNode( node ) {
+		return false;
+	}
+
+	/**
+	 * Merges results of this research according to a predefined strategy.
+	 *
+	 * @param {Array<*>} results The results of this research to merge.
+	 *
+	 * @returns {*} The merged results.
+	 *
+	 * @abstract
+	 */
+	mergeChildrenResults( results ) {
+		return undefined;
+	}
+}
+
+export default Headings;

--- a/packages/yoastseo/src/tree/research/researches/Headings.js
+++ b/packages/yoastseo/src/tree/research/researches/Headings.js
@@ -14,7 +14,7 @@ class Headings extends Research {
 	 *
 	 * @param {module:tree/structure.Node} node The node to do the research on.
 	 *
-	 * @returns {Promise<*>} The result of the research.
+	 * @returns {Promise<module:tree/structure.Heading[]|[]>} The result of the research.
 	 */
 	calculateFor( node ) {
 		return node instanceof Heading ? Promise.resolve( [ node ] ) : Promise.resolve( [] );
@@ -34,9 +34,9 @@ class Headings extends Research {
 	/**
 	 * Merges results of this research according to a predefined strategy.
 	 *
-	 * @param {Array<*>} results The results of this research to merge.
+	 * @param {Array<module:tree/structure.Heading[]>} results The results of this research to merge.
 	 *
-	 * @returns {*} The merged results.
+	 * @returns {module:tree/structure.Heading[]} The merged results.
 	 */
 	mergeChildrenResults( results ) {
 		return flatten( results );

--- a/packages/yoastseo/src/tree/research/researches/Headings.js
+++ b/packages/yoastseo/src/tree/research/researches/Headings.js
@@ -1,3 +1,8 @@
+import { flatten } from "lodash-es";
+
+/* Internal dependencies */
+import { Heading } from "../../structure";
+import LeafNode from "../../structure/nodes/LeafNode";
 import Research from "./Research";
 
 /**
@@ -11,11 +16,9 @@ class Headings extends Research {
 	 * @param {module:tree/structure.Node} node The node to calculate the research for.
 	 *
 	 * @returns {Promise<*>} The result of the research.
-	 *
-	 * @abstract
 	 */
 	calculateFor( node ) {
-		return undefined;
+		return node instanceof Heading ? Promise.resolve( node ) : Promise.resolve( null );
 	}
 
 	/**
@@ -24,11 +27,9 @@ class Headings extends Research {
 	 * @param {module:tree/structure.Node} node The node to check.
 	 *
 	 * @returns {boolean} If the given node is considered a leaf node for this research.
-	 *
-	 * @abstract
 	 */
 	isLeafNode( node ) {
-		return false;
+		return node instanceof LeafNode;
 	}
 
 	/**
@@ -37,11 +38,9 @@ class Headings extends Research {
 	 * @param {Array<*>} results The results of this research to merge.
 	 *
 	 * @returns {*} The merged results.
-	 *
-	 * @abstract
 	 */
 	mergeChildrenResults( results ) {
-		return undefined;
+		return flatten( results ).filter( node => node );
 	}
 }
 

--- a/packages/yoastseo/src/tree/research/researches/Headings.js
+++ b/packages/yoastseo/src/tree/research/researches/Headings.js
@@ -9,7 +9,6 @@ import Research from "./Research";
  * A research giving back the headings located in a text.
  */
 class Headings extends Research {
-
 	/**
 	 * Calculates the result of the research for the given Node.
 	 *

--- a/packages/yoastseo/src/tree/research/researches/Headings.js
+++ b/packages/yoastseo/src/tree/research/researches/Headings.js
@@ -13,7 +13,7 @@ class Headings extends Research {
 	/**
 	 * Calculates the result of the research for the given Node.
 	 *
-	 * @param {module:tree/structure.Node} node The node to calculate the research for.
+	 * @param {module:tree/structure.Node} node The node to do the research on.
 	 *
 	 * @returns {Promise<*>} The result of the research.
 	 */

--- a/packages/yoastseo/src/tree/research/researches/Headings.js
+++ b/packages/yoastseo/src/tree/research/researches/Headings.js
@@ -18,7 +18,7 @@ class Headings extends Research {
 	 * @returns {Promise<*>} The result of the research.
 	 */
 	calculateFor( node ) {
-		return node instanceof Heading ? Promise.resolve( node ) : Promise.resolve( null );
+		return node instanceof Heading ? Promise.resolve( [ node ] ) : Promise.resolve( [] );
 	}
 
 	/**
@@ -40,7 +40,7 @@ class Headings extends Research {
 	 * @returns {*} The merged results.
 	 */
 	mergeChildrenResults( results ) {
-		return flatten( results ).filter( node => node );
+		return flatten( results );
 	}
 }
 

--- a/packages/yoastseo/src/tree/research/researches/index.js
+++ b/packages/yoastseo/src/tree/research/researches/index.js
@@ -1,0 +1,1 @@
+export { default as Headings } from "./Headings";


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _[not-user-facing]_ Adds a `Headings` researcher that gets a node and returns a list of all its heading descendants. 

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Run the tests, check that the coverage of the `Headings` research is 100%.
* Go over the tests and code. Check if you see any edge cases that have been missed.

Fixes https://github.com/Yoast/YoastSEO.js/issues/2194
