### PR TITLE
Paragraphs and headings within paragraphs and headings can now be parsed 

### DIFF
--- a/packages/yoastseo/spec/tree/builder/buildTreeSpec.js
+++ b/packages/yoastseo/spec/tree/builder/buildTreeSpec.js
@@ -6,6 +6,7 @@ import htmlFile from "../../fullTextTests/testTexts/en/englishPaper1.html";
 import htmlFile2 from "../../fullTextTests/testTexts/de/germanPaper2.html";
 
 import fullTexts from "../../fullTextTests/testTexts";
+import buildTreeFromYaml from "../../specHelpers/buildTreeFromYaml";
 
 describe( "build tree", () => {
 	it( "can build a tree from HTML source code", () => {
@@ -481,6 +482,30 @@ describe( "build tree", () => {
 		const tree = buildTree( input );
 
 		expect( tree.toString() ).toEqual( expected.toString() );
+	} );
+
+	it( "Adds leaf nodes as formatting elements to leaf nodes.", () => {
+		const input = "<h1>Hello <p>World!</p></h1>";
+		const expected = buildTreeFromYaml`
+Structured:
+  sourceStartIndex: 0
+  sourceEndIndex: 28
+  tag: root
+  children:
+    - Heading:
+        sourceStartIndex: 0
+        sourceEndIndex: 28
+        level: 1
+        text: Hello World!
+        formatting:
+          - p:
+              textStartIndex: 6
+              textEndIndex: 12
+              sourceStartIndex: 10
+              sourceEndIndex: 23
+`;
+		const output = buildTree( input );
+		expect( output.toString() ).toEqual( expected.toString() );
 	} );
 
 	it( "can parse a big HTML text", () => {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* _[non-user-facing]_ Paragraphs and headings, nested within other headings and paragraphs, are now added as formatting to those ancestors.

## Relevant technical choices:

* N/A

## Test instructions

This PR can be tested by following these steps:

* Run `yarn test`, check that all the tests run and the coverage is 100%.

Fixes https://github.com/yoast/yoastseo.js/issues/2180 
Transferred from YoastSEO.js (https://github.com/Yoast/YoastSEO.js/pull/2181)
