### PR TITLE
Make sure that common OS files (like .DS_Store) are not tracked

### DIFF
--- a/packages/yoastseo/.gitignore
+++ b/packages/yoastseo/.gitignore
@@ -6,5 +6,11 @@ out/
 coverage/
 .tscache/
 
+# Ignore common OS files
+[Tt]humbs.db
+[Dd]esktop.ini
+*.DS_store
+.DS_store?
+
 /examples/browserified/example-browserified.js
 /premium-configuration


### PR DESCRIPTION
## Summary

Adds some pesky little OS files to the `.gitignore` so that they are not tracked by the repository.
These are files that are automatically created by Mac and/or Windows for e.g. showing thumbnails in the finder or explorer.

Transferred from https://github.com/Yoast/YoastSEO.js/pull/1829