### PR TITLE
Check synonyms type

### DIFF
--- a/packages/yoastseo/spec/stringProcessing/parseSynonymsSpec.js
+++ b/packages/yoastseo/spec/stringProcessing/parseSynonymsSpec.js
@@ -9,6 +9,7 @@ describe( "A test for parsing a comma-separated list of synonyms into an array o
 		expect( parseSynonyms( "!, ,?" ) ).toEqual( [] );
 		expect( parseSynonyms( "To be, or not to be, that is the question:" ) ).toEqual( [ "To be", "or not to be", "that is the question" ] );
 		expect( parseSynonyms( "To be,or not to be,that is the question:" ) ).toEqual( [ "To be", "or not to be", "that is the question" ] );
+		expect( parseSynonyms( null ) ).toEqual( [] );
 	} );
 	it( "Should keep double quotation marks, which are needed to figure out if morphological analysis should be performed", function() {
 		expect( parseSynonyms( "\"Item 1\", item 2, item 3" ) ).toEqual( [ "\"Item 1\"", "item 2", "item 3" ] );

--- a/packages/yoastseo/src/stringProcessing/parseSynonyms.js
+++ b/packages/yoastseo/src/stringProcessing/parseSynonyms.js
@@ -10,7 +10,11 @@ import removePunctuationExceptQuotes from "../stringProcessing/removePunctuation
  *
  * @returns {Array} An array with all synonyms.
  */
-export default function( synonyms ) {
+module.exports = function( synonyms ) {
+	if ( typeof synonyms !== "string" ) {
+		synonyms = "";
+	}
+
 	let synonymsSplit = synonyms.split( "," );
 
 	synonymsSplit = synonymsSplit.map( function( synonym ) {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* n/a

## Relevant technical choices:

* Adds functionality for checking whether synonyms are a string to YoastSEO.js. After this has been merged, this functionality can be removed on the plugin side (see issue).

## Test instructions

This PR can be tested by following these steps:

* t.b.a

Fixes Yoast/YoastSEO.js#1700 

Transferred from https://github.com/Yoast/YoastSEO.js/pull/1701
