### PR TITLE
Create FacebookDescription component

### DIFF
--- a/packages/yoast-components/app/FacebookPreviewExample.js
+++ b/packages/yoast-components/app/FacebookPreviewExample.js
@@ -1,7 +1,7 @@
 import React from "react";
+import FacebookPreview from "../composites/Plugin/SocialPreviews/Facebook/components/FacebookPreview";
 
 import ExamplesContainer from "./ExamplesContainer";
-import FacebookPreview from "../composites/Plugin/SocialPreviews/Facebook/components/FacebookPreview";
 
 /**
  * Returns the FacebookPreview examples.
@@ -12,19 +12,57 @@ const FacebookPreviewExample = () => {
 	return (
 		<ExamplesContainer backgroundColor="transparent">
 			<h2>FacebookPreview Landscape</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2015/06/How_to_choose_keywords_FI.png" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				description="Some description with words. In two whole sentences."
+				src="https://yoast.com/app/uploads/2015/06/How_to_choose_keywords_FI.png"
+			/>
 			<h2>FacebookPreview Landscape very large image</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2019/02/horizontal-1200x400.jpg" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				description={
+					"A very long description. A very long description. A very long description. A very long description. " +
+					"A very long description. A very long description. A very long description. A very long description. " +
+					"A very long description. A very long description. A very long description. A very long description. " +
+					"A very long description. A very long description. A very long description. A very long description. " +
+					"A very long description. A very long description. A very long description. A very long description. " +
+					"A very long description. A very long description. A very long description. A very long description. " +
+					"A very long description. A very long description. A very long description. A very long description. " +
+					"A very long description. A very long description. A very long description. A very long description. " +
+					"A very long description. A very long description. A very long description. A very long description."
+				}
+				src="https://yoast.com/app/uploads/2019/02/horizontal-1200x400.jpg"
+			/>
 			<h2>FacebookPreview Portrait</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2015/09/Author_Joost_x2.png" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				description="<h1>Some description with words. And some <strong>HTML</strong> that will get stripped.</h1>"
+				src="https://yoast.com/app/uploads/2015/09/Author_Joost_x2.png"
+			/>
 			<h2>FacebookPreview Portrait very tall image</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2019/02/vertical-300x580.jpg" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				description=""
+				src="https://yoast.com/app/uploads/2019/02/vertical-300x580.jpg"
+			/>
 			<h2>FacebookPreview Square</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2018/09/avatar_user_1_1537774226.png" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				description="Some description with words. In two whole sentences."
+				src="https://yoast.com/app/uploads/2018/09/avatar_user_1_1537774226.png"
+			/>
 			<h2>FacebookPreview image too small</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2018/11/Logo_TYPO3-250x105.png" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				description="Some description with words. In two whole sentences."
+				src="https://yoast.com/app/uploads/2018/11/Logo_TYPO3-250x105.png"
+			/>
 			<h2>FacebookPreview faulty image</h2>
-			<FacebookPreview siteName="SiteName.com" src="thisisnoimage" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				description="Some description with words. In two whole sentences."
+				src="thisisnoimage"
+			/>
 		</ExamplesContainer>
 	);
 };

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
@@ -24,7 +24,9 @@ const FacebookDescriptionWrapper = styled.p`
  */
 const FacebookDescription = ( props ) => {
 	let description = string.stripHTMLTags( props.description );
-	if ( description.length === 0 ) description = "Modify your Facebook description by editing it right here";
+	if ( description.length === 0 ) {
+		description = "Modify your Facebook description by editing it right here";
+	}
 
 	return (
 		<FacebookDescriptionWrapper>

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
@@ -11,8 +11,9 @@ const FacebookDescriptionWrapper = styled.p`
 	max-height: 80px;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	white-space: normal;
+	white-space: nowrap;
 	margin-top: 3px;
+	width: 100%;
 `;
 
 /**

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
@@ -23,9 +23,12 @@ const FacebookDescriptionWrapper = styled.p`
  * @returns {React.Element} The rendered element.
  */
 const FacebookDescription = ( props ) => {
+	let description = string.stripHTMLTags( props.description );
+	if ( description.length === 0 ) description = "Modify your Facebook description by editing it right here";
+
 	return (
 		<FacebookDescriptionWrapper>
-			{ string.stripHTMLTags( props.description ) }
+			{ description }
 		</FacebookDescriptionWrapper>
 	);
 };

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
@@ -1,0 +1,41 @@
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import { string } from "yoastseo";
+
+const FacebookDescriptionWrapper = styled.p`
+    color: #606770;
+    font-size: 14px;
+    line-height: 20px;
+    word-break: break-word;
+    max-height: 80px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: normal;
+    margin-top: 3px;
+`;
+
+/**
+ * Renders a FacebookDescription component.
+ *
+ * @param {object} props The props.
+ *
+ * @returns {React.Element} The rendered element.
+ */
+const FacebookDescription = ( props ) => {
+	return (
+		<FacebookDescriptionWrapper>
+			{ string.stripHTMLTags( props.description ) }
+		</FacebookDescriptionWrapper>
+	);
+};
+
+FacebookDescription.propTypes = {
+	description: PropTypes.string,
+};
+
+FacebookDescription.defaultProps = {
+	description: "",
+};
+
+export default FacebookDescription;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
@@ -1,17 +1,18 @@
+/* External dependencies */
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 
 const FacebookDescriptionWrapper = styled.p`
-    color: #606770;
-    font-size: 14px;
-    line-height: 20px;
-    word-break: break-word;
-    max-height: 80px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: normal;
-    margin-top: 3px;
+	color: #606770;
+	font-size: 14px;
+	line-height: 20px;
+	word-break: break-word;
+	max-height: 80px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: normal;
+	margin-top: 3px;
 `;
 
 /**

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
@@ -1,7 +1,6 @@
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import { string } from "yoastseo";
 
 const FacebookDescriptionWrapper = styled.p`
     color: #606770;
@@ -23,26 +22,15 @@ const FacebookDescriptionWrapper = styled.p`
  * @returns {React.Element} The rendered element.
  */
 const FacebookDescription = ( props ) => {
-	const description = string.stripHTMLTags( props.description );
-
-	// Do not render when there is no description.
-	if ( description.length === 0 ) {
-		return null;
-	}
-
 	return (
 		<FacebookDescriptionWrapper>
-			{ description }
+			{ props.description }
 		</FacebookDescriptionWrapper>
 	);
 };
 
 FacebookDescription.propTypes = {
-	description: PropTypes.string,
-};
-
-FacebookDescription.defaultProps = {
-	description: "",
+	description: PropTypes.string.isRequired,
 };
 
 export default FacebookDescription;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookDescription.js
@@ -23,9 +23,11 @@ const FacebookDescriptionWrapper = styled.p`
  * @returns {React.Element} The rendered element.
  */
 const FacebookDescription = ( props ) => {
-	let description = string.stripHTMLTags( props.description );
+	const description = string.stripHTMLTags( props.description );
+
+	// Do not render when there is no description.
 	if ( description.length === 0 ) {
-		description = "Modify your Facebook description by editing it right here";
+		return null;
 	}
 
 	return (

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookPreview.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookPreview.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 /* Internal dependencies */
 import FacebookSiteName from "./FacebookSiteName";
 import FacebookImage from "./FacebookImage";
+import FacebookDescription from "./FacebookDescription";
 
 /**
  * Renders a FacebookPreview component.
@@ -18,17 +19,20 @@ const FacebookPreview = ( props ) => {
 		<Fragment>
 			<FacebookImage src={ props.src } alt={ props.alt } />
 			<FacebookSiteName siteName={ props.siteName } />
+			<FacebookDescription description={ props.description }/>
 		</Fragment>
 	);
 };
 
 FacebookPreview.propTypes = {
 	siteName: PropTypes.string.isRequired,
+	description: PropTypes.string,
 	src: PropTypes.string.isRequired,
 	alt: PropTypes.string,
 };
 
 FacebookPreview.defaultProps = {
+	description: "",
 	alt: "",
 };
 

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookPreview.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookPreview.js
@@ -19,7 +19,7 @@ const FacebookPreview = ( props ) => {
 		<Fragment>
 			<FacebookImage src={ props.src } alt={ props.alt } />
 			<FacebookSiteName siteName={ props.siteName } />
-			<FacebookDescription description={ props.description }/>
+			<FacebookDescription description={ props.description } />
 		</Fragment>
 	);
 };

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookDescriptionTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookDescriptionTest.js
@@ -24,4 +24,24 @@ describe( "FacebookDescription", () => {
 		expect( tree.children.length ).toEqual( 1 );
 		expect( tree.children[ 0 ] ).toEqual( "Cornerstone content is one of the most important building blocks of your site." );
 	} );
+
+	it( "renders the fallback string when the description is empty", () => {
+		const component = renderer.create(
+			<FacebookDescription description="" />
+		);
+
+		const tree = component.toJSON();
+		expect( tree.children.length ).toEqual( 1 );
+		expect( tree.children[ 0 ] ).toEqual( "Modify your Facebook description by editing it right here" );
+	} );
+
+	it( "renders the fallback string when the description is empty, ignoring any HTML", () => {
+		const component = renderer.create(
+			<FacebookDescription description="<div></div>" />
+		);
+
+		const tree = component.toJSON();
+		expect( tree.children.length ).toEqual( 1 );
+		expect( tree.children[ 0 ] ).toEqual( "Modify your Facebook description by editing it right here" );
+	} );
 } );

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookDescriptionTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookDescriptionTest.js
@@ -17,7 +17,11 @@ describe( "FacebookDescription", () => {
 
 	it( "strips any HTML in the description", () => {
 		const component = renderer.create(
-			<FacebookDescription description="<h1>Cornerstone content is one of the most <strong>important</strong> building blocks of your site.</h1>" />
+			<FacebookDescription
+				description={
+					"<h1>Cornerstone content is one of the most <strong>important</strong> building blocks of your site.</h1>"
+				}
+			/>
 		);
 
 		const tree = component.toJSON();

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookDescriptionTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookDescriptionTest.js
@@ -29,23 +29,21 @@ describe( "FacebookDescription", () => {
 		expect( tree.children[ 0 ] ).toEqual( "Cornerstone content is one of the most important building blocks of your site." );
 	} );
 
-	it( "renders the fallback string when the description is empty", () => {
+	it( "does not render anything when the description is empty", () => {
 		const component = renderer.create(
 			<FacebookDescription description="" />
 		);
 
 		const tree = component.toJSON();
-		expect( tree.children.length ).toEqual( 1 );
-		expect( tree.children[ 0 ] ).toEqual( "Modify your Facebook description by editing it right here" );
+		expect( tree ).toBeNull();
 	} );
 
-	it( "renders the fallback string when the description is empty, ignoring any HTML", () => {
+	it( "does not render anything when the description is empty, ignoring any HTML", () => {
 		const component = renderer.create(
 			<FacebookDescription description="<div></div>" />
 		);
 
 		const tree = component.toJSON();
-		expect( tree.children.length ).toEqual( 1 );
-		expect( tree.children[ 0 ] ).toEqual( "Modify your Facebook description by editing it right here" );
+		expect( tree ).toBeNull();
 	} );
 } );

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookDescriptionTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookDescriptionTest.js
@@ -1,0 +1,27 @@
+/* External dependencies */
+import React from "react";
+import renderer from "react-test-renderer";
+
+/* Internal dependencies */
+import FacebookDescription from "../components/FacebookDescription";
+
+describe( "FacebookDescription", () => {
+	it( "matches the snapshot by default", () => {
+		const component = renderer.create(
+			<FacebookDescription description="Cornerstone content is one of the most important building blocks of your site." />
+		);
+
+		const tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	it( "strips any HTML in the description", () => {
+		const component = renderer.create(
+			<FacebookDescription description="<h1>Cornerstone content is one of the most <strong>important</strong> building blocks of your site.</h1>" />
+		);
+
+		const tree = component.toJSON();
+		expect( tree.children.length ).toEqual( 1 );
+		expect( tree.children[ 0 ] ).toEqual( "Cornerstone content is one of the most important building blocks of your site." );
+	} );
+} );

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookDescriptionTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookDescriptionTest.js
@@ -14,36 +14,4 @@ describe( "FacebookDescription", () => {
 		const tree = component.toJSON();
 		expect( tree ).toMatchSnapshot();
 	} );
-
-	it( "strips any HTML in the description", () => {
-		const component = renderer.create(
-			<FacebookDescription
-				description={
-					"<h1>Cornerstone content is one of the most <strong>important</strong> building blocks of your site.</h1>"
-				}
-			/>
-		);
-
-		const tree = component.toJSON();
-		expect( tree.children.length ).toEqual( 1 );
-		expect( tree.children[ 0 ] ).toEqual( "Cornerstone content is one of the most important building blocks of your site." );
-	} );
-
-	it( "does not render anything when the description is empty", () => {
-		const component = renderer.create(
-			<FacebookDescription description="" />
-		);
-
-		const tree = component.toJSON();
-		expect( tree ).toBeNull();
-	} );
-
-	it( "does not render anything when the description is empty, ignoring any HTML", () => {
-		const component = renderer.create(
-			<FacebookDescription description="<div></div>" />
-		);
-
-		const tree = component.toJSON();
-		expect( tree ).toBeNull();
-	} );
 } );

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookPreviewTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookPreviewTest.js
@@ -8,7 +8,11 @@ import FacebookPreview from "../components/FacebookPreview";
 describe( "FacebookPreview", () => {
 	it( "matches the snapshot for a landscape image", () => {
 		const component = renderer.create(
-			<FacebookPreview siteName="yosat.com" src="https://yoast.com/app/uploads/2015/06/How_to_choose_keywords_FI.png" />
+			<FacebookPreview
+				siteName="yoast.com"
+				description="Description to go along with a landscape image."
+				src="https://yoast.com/app/uploads/2015/06/How_to_choose_keywords_FI.png"
+			/>
 		);
 
 		const tree = component.toJSON();
@@ -16,7 +20,11 @@ describe( "FacebookPreview", () => {
 	} );
 	it( "matches the snapshot for a portrait image", () => {
 		const component = renderer.create(
-			<FacebookPreview siteName="yoast.com" src="https://yoast.com/app/uploads/2015/09/Author_Joost_x2.png" />
+			<FacebookPreview
+				siteName="yoast.com"
+				description="Description to go along with a portrait image."
+				src="https://yoast.com/app/uploads/2015/09/Author_Joost_x2.png"
+			/>
 		);
 
 		const tree = component.toJSON();
@@ -24,7 +32,11 @@ describe( "FacebookPreview", () => {
 	} );
 	it( "matches the snapshot for a square image", () => {
 		const component = renderer.create(
-			<FacebookPreview siteName="yoast.com" src="https://yoast.com/app/uploads/2018/09/avatar_user_1_1537774226.png" />
+			<FacebookPreview
+				siteName="yoast.com"
+				description="Description to go along with a square image."
+				src="https://yoast.com/app/uploads/2018/09/avatar_user_1_1537774226.png"
+			/>
 		);
 
 		const tree = component.toJSON();
@@ -32,7 +44,11 @@ describe( "FacebookPreview", () => {
 	} );
 	it( "matches the snapshot for a too small image", () => {
 		const component = renderer.create(
-			<FacebookPreview siteName="yoast.com" src="https://yoast.com/app/uploads/2018/11/Logo_TYPO3-250x105.png" />
+			<FacebookPreview
+				siteName="yoast.com"
+				description="Description to go along with too small an image."
+				src="https://yoast.com/app/uploads/2018/11/Logo_TYPO3-250x105.png"
+			/>
 		);
 
 		const tree = component.toJSON();
@@ -40,7 +56,11 @@ describe( "FacebookPreview", () => {
 	} );
 	it( "matches the snapshot for a faulty image", () => {
 		const component = renderer.create(
-			<FacebookPreview siteName="yoast.com" src="thisisnoimage" />
+			<FacebookPreview
+				siteName="yoast.com"
+				description="Description to go along with a faulty image."
+				src="thisisnoimage"
+			/>
 		);
 
 		const tree = component.toJSON();

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookDescriptionTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookDescriptionTest.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FacebookDescription matches the snapshot by default 1`] = `
+.c0 {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  margin-top: 3px;
+}
+
+<p
+  className="c0"
+>
+  Cornerstone content is one of the most important building blocks of your site.
+</p>
+`;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookDescriptionTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookDescriptionTest.js.snap
@@ -9,8 +9,9 @@ exports[`FacebookDescription matches the snapshot by default 1`] = `
   max-height: 80px;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: normal;
+  white-space: nowrap;
   margin-top: 3px;
+  width: 100%;
 }
 
 <p

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
@@ -34,8 +34,9 @@ Array [
   max-height: 80px;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: normal;
+  white-space: nowrap;
   margin-top: 3px;
+  width: 100%;
 }
 
 <p
@@ -80,8 +81,9 @@ Array [
   max-height: 80px;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: normal;
+  white-space: nowrap;
   margin-top: 3px;
+  width: 100%;
 }
 
 <p
@@ -126,8 +128,9 @@ Array [
   max-height: 80px;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: normal;
+  white-space: nowrap;
   margin-top: 3px;
+  width: 100%;
 }
 
 <p
@@ -172,8 +175,9 @@ Array [
   max-height: 80px;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: normal;
+  white-space: nowrap;
   margin-top: 3px;
+  width: 100%;
 }
 
 <p
@@ -218,8 +222,9 @@ Array [
   max-height: 80px;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: normal;
+  white-space: nowrap;
   margin-top: 3px;
+  width: 100%;
 }
 
 <p

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
@@ -26,6 +26,23 @@ Array [
   >
     yoast.com
   </p>,
+  .c0 {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  margin-top: 3px;
+}
+
+<p
+    className="c0"
+  >
+    Description to go along with a faulty image.
+  </p>,
 ]
 `;
 
@@ -53,7 +70,24 @@ Array [
 <p
     className="c0"
   >
-    yosat.com
+    yoast.com
+  </p>,
+  .c0 {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  margin-top: 3px;
+}
+
+<p
+    className="c0"
+  >
+    Description to go along with a landscape image.
   </p>,
 ]
 `;
@@ -84,6 +118,23 @@ Array [
   >
     yoast.com
   </p>,
+  .c0 {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  margin-top: 3px;
+}
+
+<p
+    className="c0"
+  >
+    Description to go along with a portrait image.
+  </p>,
 ]
 `;
 
@@ -113,6 +164,23 @@ Array [
   >
     yoast.com
   </p>,
+  .c0 {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  margin-top: 3px;
+}
+
+<p
+    className="c0"
+  >
+    Description to go along with a square image.
+  </p>,
 ]
 `;
 
@@ -141,6 +209,23 @@ Array [
     className="c0"
   >
     yoast.com
+  </p>,
+  .c0 {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;
+  margin-top: 3px;
+}
+
+<p
+    className="c0"
+  >
+    Description to go along with too small an image.
   </p>,
 ]
 `;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a FacebookDescription component in SocialPreview\Facebook

## Relevant technical choices:

* Requires a description property. The parent should take care of the event we do not have a description and not render this component (if this happens at all - e.g. we have a fallback).
* ~Use a fallback string for when the description is empty.~ No longer using a fallback here. It should be a simple component. The place to do this should probably be the Redux container.
* The stripping of the HTML is also no longer done here. Because if that results in an empty string we would want the fallback to be displayed. So this needs to be done in combination with the above.
* Add the FacebookDescription to the FacebookPreview directly for now (should be through FacebookTextContainer later).

## Test instructions

This PR can be tested by following these steps:

* Check the tests.
* Start the stand-alone.
* Go to the `FacebookPreview` page by clicking on the button in the top right.
* Check if they look alright. Mind you that the text container is not made, which will implement the sizes.
* Pay extra attention to the truncation in different browsers! IE, Firefox and Chrome.

Fixes #41 
