### PR TITLE
Create TwitterTitle component

### DIFF
--- a/packages/yoast-components/App.js
+++ b/packages/yoast-components/App.js
@@ -16,6 +16,7 @@ import UIControlsWrapper from "./app/UIControlsWrapper";
 import Wizard from "./app/WizardWrapper";
 import Loader from "./composites/basic/Loader";
 import FacebookPreviewExample from "./app/FacebookPreviewExample";
+import TwitterPreviewExample from "./app/TwitterPreviewExample";
 
 const components = [
 	{
@@ -87,6 +88,11 @@ const components = [
 		id: "facebookpreview-example",
 		name: "FacebookPreview",
 		component: <FacebookPreviewExample />,
+	},
+	{
+		id: "twitterpreview-example",
+		name: "TwitterPreview",
+		component: <TwitterPreviewExample />,
 	},
 ];
 

--- a/packages/yoast-components/app/TwitterPreviewExample.js
+++ b/packages/yoast-components/app/TwitterPreviewExample.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+import ExamplesContainer from "./ExamplesContainer";
+import TwitterPreview from "../composites/Plugin/SocialPreviews/Twitter/components/TwitterPreview";
+
+/**
+ * Returns the TwitterPreview examples.
+ *
+ * @returns {ReactElement} The TwitterPreview examples.
+ */
+const TwitterPreviewExample = () => {
+	return (
+		<ExamplesContainer backgroundColor="transparent">
+			<h2>TwitterPreview</h2>
+			<TwitterPreview title="YoastCon Workshops &bull; Yoast" />
+		</ExamplesContainer>
+	);
+};
+
+export default TwitterPreviewExample;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/components/TwitterPreview.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/components/TwitterPreview.js
@@ -1,0 +1,30 @@
+/* External dependencies */
+import React, { Fragment } from "react";
+import PropTypes from "prop-types";
+
+/* Internal dependencies */
+import TwitterTitle from "./TwitterTitle";
+
+/**
+ * Renders a TwitterPreview component.
+ *
+ * @param {object} props The props.
+ *
+ * @returns {React.Element} The rendered element.
+ */
+const TwitterPreview = ( props ) => {
+	return (
+		<Fragment>
+			<TwitterTitle title={ props.title } />
+		</Fragment>
+	);
+};
+
+TwitterPreview.propTypes = {
+	title: PropTypes.string.isRequired,
+};
+
+TwitterPreview.defaultProps = {
+};
+
+export default TwitterPreview;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/components/TwitterTitle.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/components/TwitterTitle.js
@@ -1,16 +1,17 @@
+/* External dependencies */
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 
 const TwitterTitleWrapper = styled.p`
-    font-weight: bold;
-    font-size: 14px;
-    max-height: 18.2px;
-    line-height: 18.2px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    margin-bottom: 2.1px
+	font-weight: bold;
+	font-size: 14px;
+	max-height: 18px;
+	line-height: 18px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	margin-bottom: 2px;
 `;
 
 /**

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/components/TwitterTitle.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/components/TwitterTitle.js
@@ -23,11 +23,6 @@ const TwitterTitleWrapper = styled.p`
 const TwitterTitle = ( props ) => {
 	let title = props.title;
 
-	// Do not render when there is no title.
-	if ( title.length === 0 ) {
-		return null;
-	}
-
 	// Only allow a certain amount of characters.
 	if ( props.maximumTitleLength && title.length > props.maximumTitleLength ) {
 		title = title.substr( 0, props.maximumTitleLength );
@@ -41,12 +36,11 @@ const TwitterTitle = ( props ) => {
 };
 
 TwitterTitle.propTypes = {
-	title: PropTypes.string,
+	title: PropTypes.string.isRequired,
 	maximumTitleLength: PropTypes.number,
 };
 
 TwitterTitle.defaultProps = {
-	title: "",
 	maximumTitleLength: 70,
 };
 

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/components/TwitterTitle.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/components/TwitterTitle.js
@@ -1,0 +1,53 @@
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+const TwitterTitleWrapper = styled.p`
+    font-weight: bold;
+    font-size: 14px;
+    max-height: 18.2px;
+    line-height: 18.2px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin-bottom: 2.1px
+`;
+
+/**
+ * Renders a TwitterTitle component.
+ *
+ * @param {object} props The props.
+ *
+ * @returns {React.Element} The rendered element.
+ */
+const TwitterTitle = ( props ) => {
+	let title = props.title;
+
+	// Do not render when there is no title.
+	if ( title.length === 0 ) {
+		return null;
+	}
+
+	// Only allow a certain amount of characters.
+	if ( props.maximumTitleLength && title.length > props.maximumTitleLength ) {
+		title = title.substr( 0, props.maximumTitleLength );
+	}
+
+	return (
+		<TwitterTitleWrapper>
+			{ title }
+		</TwitterTitleWrapper>
+	);
+};
+
+TwitterTitle.propTypes = {
+	title: PropTypes.string,
+	maximumTitleLength: PropTypes.number,
+};
+
+TwitterTitle.defaultProps = {
+	title: "",
+	maximumTitleLength: 70,
+};
+
+export default TwitterTitle;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/TwitterPreviewTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/TwitterPreviewTest.js
@@ -1,0 +1,17 @@
+/* External dependencies */
+import React from "react";
+import renderer from "react-test-renderer";
+
+/* Internal dependencies */
+import TwitterPreview from "../components/TwitterPreview";
+
+describe( "TwitterPreview", () => {
+	it( "matches the snapshot", () => {
+		const component = renderer.create(
+			<TwitterPreview title="YoastCon Workshops &bull; Yoast" />
+		);
+
+		const tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+} );

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/TwitterTitleTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/TwitterTitleTest.js
@@ -39,13 +39,4 @@ describe( "TwitterTitle", () => {
 		expect( tree.children.length ).toEqual( 1 );
 		expect( tree.children[ 0 ] ).toEqual( "My" );
 	} );
-
-	it( "does not render anything when the title is empty", () => {
-		const component = renderer.create(
-			<TwitterTitle title="" />
-		);
-
-		const tree = component.toJSON();
-		expect( tree ).toBeNull();
-	} );
 } );

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/TwitterTitleTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/TwitterTitleTest.js
@@ -1,0 +1,51 @@
+/* External dependencies */
+import React from "react";
+import renderer from "react-test-renderer";
+
+/* Internal dependencies */
+import TwitterTitle from "../components/TwitterTitle";
+
+describe( "TwitterTitle", () => {
+	it( "matches the snapshot by default", () => {
+		const component = renderer.create(
+			<TwitterTitle title="My Twitter Title" />
+		);
+
+		const tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	it( "truncates the title to a maximum length, which defaults to 70 characters", () => {
+		const component = renderer.create(
+			<TwitterTitle
+				title={ "0123456789".repeat( 11 ) }
+			/>
+		);
+
+		const tree = component.toJSON();
+		expect( tree.children.length ).toEqual( 1 );
+		expect( tree.children[ 0 ] ).toEqual( "0123456789".repeat( 7 ) );
+	} );
+
+	it( "truncates the title to a given maximum length", () => {
+		const component = renderer.create(
+			<TwitterTitle
+				title="My Twitter Title"
+				maximumTitleLength={ 2 }
+			/>
+		);
+
+		const tree = component.toJSON();
+		expect( tree.children.length ).toEqual( 1 );
+		expect( tree.children[ 0 ] ).toEqual( "My" );
+	} );
+
+	it( "does not render anything when the title is empty", () => {
+		const component = renderer.create(
+			<TwitterTitle title="" />
+		);
+
+		const tree = component.toJSON();
+		expect( tree ).toBeNull();
+	} );
+} );

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/__snapshots__/TwitterPreviewTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/__snapshots__/TwitterPreviewTest.js.snap
@@ -4,12 +4,12 @@ exports[`TwitterPreview matches the snapshot 1`] = `
 .c0 {
   font-weight: bold;
   font-size: 14px;
-  max-height: 18.2px;
-  line-height: 18.2px;
+  max-height: 18px;
+  line-height: 18px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 2.1px;
+  margin-bottom: 2px;
 }
 
 <p

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/__snapshots__/TwitterPreviewTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/__snapshots__/TwitterPreviewTest.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TwitterPreview matches the snapshot 1`] = `
+.c0 {
+  font-weight: bold;
+  font-size: 14px;
+  max-height: 18.2px;
+  line-height: 18.2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 2.1px;
+}
+
+<p
+  className="c0"
+>
+  YoastCon Workshops • Yoast
+</p>
+`;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/__snapshots__/TwitterTitleTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/__snapshots__/TwitterTitleTest.js.snap
@@ -4,12 +4,12 @@ exports[`TwitterTitle matches the snapshot by default 1`] = `
 .c0 {
   font-weight: bold;
   font-size: 14px;
-  max-height: 18.2px;
-  line-height: 18.2px;
+  max-height: 18px;
+  line-height: 18px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  margin-bottom: 2.1px;
+  margin-bottom: 2px;
 }
 
 <p

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/__snapshots__/TwitterTitleTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Twitter/tests/__snapshots__/TwitterTitleTest.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TwitterTitle matches the snapshot by default 1`] = `
+.c0 {
+  font-weight: bold;
+  font-size: 14px;
+  max-height: 18.2px;
+  line-height: 18.2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-bottom: 2.1px;
+}
+
+<p
+  className="c0"
+>
+  My Twitter Title
+</p>
+`;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a TwitterTitle component in SocialPreview\Twitter
* Adds a basic TwitterPreview component in SocialPreview\Twitter

## Relevant technical choices:

* Use TwitterPreview as base for now, to be able to easily add new components to later and to use it in the stand-alone.

## Test instructions

This PR can be tested by following these steps:

* Check the tests.
* Start the stand-alone.
* Go to the ~~`FacebookPreview`~~ `TwitterPreview ` (Edit by Andrea) page by clicking on the button in the top right.
* Check if they look alright. Mind you that the text container is not made, which will implement the sizes.

Fixes #44 
