### PR TITLE
Improve list of German transition words

### DIFF
--- a/packages/yoastseo/src/researches/german/transitionWords.js
+++ b/packages/yoastseo/src/researches/german/transitionWords.js
@@ -4,7 +4,7 @@ const singleWords = [ "aber", "abschließend", "abschliessend", "alldieweil", "a
 	"anfaenglich", "anfänglich", "anfangs", "angenommen", "anschliessend", "anschließend",	"aufgrund",	"ausgenommen",
 	"ausserdem", "außerdem", "beispielsweise", "bevor", "beziehungsweise", "bspw", "bzw", "d.h", "da", "dabei", "dadurch", "dafuer", "dafür",
 	"dagegen", "daher", "dahingegen", "danach", "dann", "darauf", "darum", "dass", "davor", "dazu", "dementgegen", "dementsprechend", "demgegenüber",
-	"demgegenueber", "demgemaess", "demgemäß", "demzufolge", "denn", "dennoch", "dergestalt", "desto", "deshalb", "desungeachtet",
+	"demgegenueber", "demgemaess", "demgemäß", "demzufolge", "denn", "dennoch", "dergestalt", "derweil", "desto", "deshalb", "desungeachtet",
 	"deswegen", "doch", "dort", "drittens",	"ebenfalls", "ebenso", "endlich", "ehe", "einerseits", "einesteils", "entsprechend",
 	"entweder", "erst", "erstens", "falls", "ferner", "folgerichtig", "folglich", "fürderhin", "fuerderhin", "genauso",
 	"hierdurch", "hierzu", "hingegen", "immerhin", "indem", "indes", "indessen", "infolge",	"infolgedessen", "insofern", "insoweit", "inzwischen",
@@ -15,14 +15,14 @@ const singleWords = [ "aber", "abschließend", "abschliessend", "alldieweil", "a
 	"ueberdies", "uebrigens", "ungeachtet", "vielmehr", "vorausgesetzt", "vorher", "waehrend", "während", "währenddessen",
 	"waehrenddessen", "weder", "wegen", "weil", "weiter", "weiterhin", "wenn", "wenngleich", "wennschon", "wennzwar", "weshalb", "widrigenfalls",
 	"wiewohl", "wobei", "wohingegen", "z.b", "zudem", "zuerst", "zufolge", "zuletzt", "zumal", "zuvor", "zwar", "zweitens" ];
-const multipleWords = [ "abgesehen von", "abgesehen davon", "als dass", "als wenn", "anders ausgedrückt", "anders ausgedrueckt",
+const multipleWords = [ "abgesehen von", "abgesehen davon", "als dass", "als ob", "als wenn", "anders ausgedrückt", "anders ausgedrueckt",
 	"anders formuliert", "anders gefasst", "anders gefragt", "anders gesagt", "anders gesprochen", "anstatt dass", "auch wenn",
 	"auf grund", "auf jeden fall", "aus diesem grund", "ausser dass", "außer dass", "ausser wenn", "außer wenn", "besser ausgedrückt",
 	"besser ausgedrueckt", "besser formuliert", "besser gesagt", "besser gesprochen", "bloss dass", "bloß dass", "darüber hinaus",
 	"das heisst", "das heißt", "des weiteren", "dessen ungeachtet", "ebenso wie", "genauso wie", "geschweige denn", "im fall",
-	"im falle", "im folgenden", "im gegensatz dazu", "im grunde genommen", "in diesem sinne", "je nachdem", "kurz gesagt",
+	"im falle", "im folgenden", "im gegensatz dazu", "im gegenteil", "im grunde genommen", "in diesem sinne", "je nachdem", "kurz gesagt",
 	"mit anderen worten", "ohne dass", "so dass", "umso mehr als", "umso weniger als", "umso mehr, als", "umso weniger, als",
-	"unbeschadet dessen", "und zwar", "ungeachtet dessen", "unter dem strich", "zum beispiel" ];
+	"unbeschadet dessen", "und zwar", "ungeachtet dessen", "unter dem strich", "zum beispiel", "zunächts einmal" ];
 
 /**
  * Returns lists with transition words to be used by the assessments.

--- a/packages/yoastseo/src/researches/german/twoPartTransitionWords.js
+++ b/packages/yoastseo/src/researches/german/twoPartTransitionWords.js
@@ -7,7 +7,7 @@
 export default function() {
 	return [ [ "anstatt", "dass" ], [ "bald", "bald" ], [ "dadurch", "dass" ], [ "dessen ungeachtet", "dass" ],
 		[ "entweder", "oder" ], [ "einerseits", "andererseits" ], [ "erst", "wenn" ], [ "je", "desto" ], [ "je", "umso" ],
-		[ "umso", "umso" ], ["mal", "mal"], [ "nicht nur", "sondern auch" ], [ "ob", "oder" ], [ "ohne", "dass" ], [ "so", "dass" ],
-		[ "sowohl", "als auch" ], [ "sowohl", "wie auch" ], ["teils", "teils"], [ "unbeschadet dessen", "dass" ], [ "weder", "noch" ],
+		[ "umso", "umso" ], [ "mal", "mal" ], [ "nicht nur", "sondern auch" ], [ "ob", "oder" ], [ "ohne", "dass" ], [ "so", "dass" ],
+		[ "sowohl", "als auch" ], [ "sowohl", "wie auch" ], [ "teils", "teils" ], [ "unbeschadet dessen", "dass" ], [ "weder", "noch" ],
 		[ "wenn", "auch" ], [ "wenn", "schon" ], [ "nicht weil", "sondern" ]  ];
 }

--- a/packages/yoastseo/src/researches/german/twoPartTransitionWords.js
+++ b/packages/yoastseo/src/researches/german/twoPartTransitionWords.js
@@ -7,7 +7,7 @@
 export default function() {
 	return [ [ "anstatt", "dass" ], [ "bald", "bald" ], [ "dadurch", "dass" ], [ "dessen ungeachtet", "dass" ],
 		[ "entweder", "oder" ], [ "einerseits", "andererseits" ], [ "erst", "wenn" ], [ "je", "desto" ], [ "je", "umso" ],
-		[ "umso", "umso" ], [ "nicht nur", "sondern auch" ], [ "ob", "oder" ], [ "ohne", "dass" ], [ "so", "dass" ],
-		[ "sowohl", "als auch" ], [ "sowohl", "wie auch" ], [ "unbeschadet dessen", "dass" ], [ "weder", "noch" ],
+		[ "umso", "umso" ], ["mal", "mal"], [ "nicht nur", "sondern auch" ], [ "ob", "oder" ], [ "ohne", "dass" ], [ "so", "dass" ],
+		[ "sowohl", "als auch" ], [ "sowohl", "wie auch" ], ["teils", "teils"], [ "unbeschadet dessen", "dass" ], [ "weder", "noch" ],
 		[ "wenn", "auch" ], [ "wenn", "schon" ], [ "nicht weil", "sondern" ]  ];
 }


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Improves list of German transition words, props to [SereniTeaTime](https://github.com/SereniTeaTime).

## Test instructions

This PR can be tested by following these steps:

* Change locale to de_DE and paste the added transition words into the text editor. Make sure they are marked as transition words.

Fixes https://github.com/Yoast/YoastSEO.js/issues/2200
