### PR TITLE
Create FacebookAuthorName component

### DIFF
--- a/packages/yoast-components/app/FacebookPreviewExample.js
+++ b/packages/yoast-components/app/FacebookPreviewExample.js
@@ -12,11 +12,19 @@ const FacebookPreviewExample = () => {
 	return (
 		<ExamplesContainer backgroundColor="transparent">
 			<h2>FacebookPreview Landscape</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2015/06/How_to_choose_keywords_FI.png" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				authorName="John Doe"
+				src="https://yoast.com/app/uploads/2015/06/How_to_choose_keywords_FI.png"
+			/>
 			<h2>FacebookPreview Landscape very large image</h2>
 			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2019/02/horizontal-1200x400.jpg" />
 			<h2>FacebookPreview Portrait</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2015/09/Author_Joost_x2.png" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				authorName="John Doe"
+				src="https://yoast.com/app/uploads/2015/09/Author_Joost_x2.png"
+			/>
 			<h2>FacebookPreview Portrait very tall image</h2>
 			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2019/02/vertical-300x580.jpg" />
 			<h2>FacebookPreview Square</h2>

--- a/packages/yoast-components/app/FacebookPreviewExample.js
+++ b/packages/yoast-components/app/FacebookPreviewExample.js
@@ -1,5 +1,7 @@
+/* External dependencies */
 import React from "react";
 
+/* Internal dependencies */
 import ExamplesContainer from "./ExamplesContainer";
 import FacebookPreview from "../composites/Plugin/SocialPreviews/Facebook/components/FacebookPreview";
 

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookAuthorName.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookAuthorName.js
@@ -1,0 +1,33 @@
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+const FacebookAuthorNameWrapper = styled.span`
+    color: #3b5998;
+    font-size: 12px;
+    line-height: 11px;
+    position: relative;
+    text-decoration: none;
+    cursor: auto;
+`;
+
+/**
+ * Renders a FacebookAuthorName component.
+ *
+ * @param {object} props The props.
+ *
+ * @returns {React.Element} The rendered element.
+ */
+const FacebookAuthorName = ( props ) => {
+	return (
+		<FacebookAuthorNameWrapper>
+			{ props.authorName }
+		</FacebookAuthorNameWrapper>
+	);
+};
+
+FacebookAuthorName.propTypes = {
+	authorName: PropTypes.string.isRequired,
+};
+
+export default FacebookAuthorName;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookAuthorName.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookAuthorName.js
@@ -4,12 +4,12 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 
 const FacebookAuthorNameWrapper = styled.span`
-    color: #3b5998;
-    font-size: 12px;
-    line-height: 11px;
-    position: relative;
-    text-decoration: none;
-    cursor: auto;
+	color: #3b5998;
+	font-size: 12px;
+	line-height: 11px;
+	position: relative;
+	text-decoration: none;
+	cursor: auto;
 `;
 
 /**

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookAuthorName.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookAuthorName.js
@@ -7,9 +7,6 @@ const FacebookAuthorNameWrapper = styled.span`
 	color: #3b5998;
 	font-size: 12px;
 	line-height: 11px;
-	position: relative;
-	text-decoration: none;
-	cursor: auto;
 `;
 
 /**

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookAuthorName.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookAuthorName.js
@@ -1,3 +1,4 @@
+/* External dependencies */
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookPreview.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookPreview.js
@@ -3,7 +3,7 @@ import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 
 /* Internal dependencies */
-import FacebookSiteName from "./FacebookSiteName";
+import FacebookSiteAndAuthorNames from "./FacebookSiteAndAuthorNames";
 import FacebookImage from "./FacebookImage";
 
 /**
@@ -17,18 +17,20 @@ const FacebookPreview = ( props ) => {
 	return (
 		<Fragment>
 			<FacebookImage src={ props.src } alt={ props.alt } />
-			<FacebookSiteName siteName={ props.siteName } />
+			<FacebookSiteAndAuthorNames siteName={ props.siteName } authorName={ props.authorName } />
 		</Fragment>
 	);
 };
 
 FacebookPreview.propTypes = {
 	siteName: PropTypes.string.isRequired,
+	authorName: PropTypes.string,
 	src: PropTypes.string.isRequired,
 	alt: PropTypes.string,
 };
 
 FacebookPreview.defaultProps = {
+	authorName: "",
 	alt: "",
 };
 

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteAndAuthorNames.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteAndAuthorNames.js
@@ -1,8 +1,10 @@
+/* External dependencies */
 import React, { Fragment } from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import { __ } from "@wordpress/i18n";
 
+/* Internal dependencies */
 import FacebookSiteName from "./FacebookSiteName";
 import FacebookAuthorName from "./FacebookAuthorName";
 

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteAndAuthorNames.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteAndAuthorNames.js
@@ -9,13 +9,13 @@ import FacebookSiteName from "./FacebookSiteName";
 import FacebookAuthorName from "./FacebookAuthorName";
 
 const FacebookSiteAndAuthorNamesWrapper = styled.p`
-    color: #606770;
-    font-size: 12px;
-    line-height: 11px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    text-transform: uppercase;
-    white-space: nowrap;
+	color: #606770;
+	font-size: 12px;
+	line-height: 11px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	text-transform: uppercase;
+	white-space: nowrap;
 `;
 
 const FacebookSiteAndAuthorNamesSeparator = styled.span`

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteAndAuthorNames.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteAndAuthorNames.js
@@ -1,0 +1,75 @@
+import React, { Fragment } from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+import { __ } from "@wordpress/i18n";
+
+import FacebookSiteName from "./FacebookSiteName";
+import FacebookAuthorName from "./FacebookAuthorName";
+
+const FacebookSiteAndAuthorNamesWrapper = styled.p`
+    color: #606770;
+    font-size: 12px;
+    line-height: 11px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+`;
+
+const FacebookSiteAndAuthorNamesSeparator = styled.span`
+    padding-left: 5px;
+    padding-right: 5px;
+`;
+
+/**
+ * Renders a FacebookAuthorName component with accompanying elements.
+ *
+ * @param {string} authorName The author's name.
+ *
+ * @returns {React.Element} The rendered element.
+ */
+function renderFacebookAuthorName( authorName ) {
+	// Do not render anything when there is no author name.
+	if ( authorName.length === 0 ) {
+		return null;
+	}
+
+	/* Translators: The context is: SITE | By AUTHOR */
+	const by = __( "By", "yoast-components" );
+
+	return (
+		<Fragment>
+			<FacebookSiteAndAuthorNamesSeparator>|</FacebookSiteAndAuthorNamesSeparator>
+			{ by }
+			&nbsp;
+			<FacebookAuthorName authorName={ authorName } />
+		</Fragment>
+	);
+}
+
+/**
+ * Renders a FacebookSiteAndAuthorNames component.
+ *
+ * @param {object} props The props.
+ *
+ * @returns {React.Element} The rendered element.
+ */
+const FacebookSiteAndAuthorNames = ( props ) => {
+	return (
+		<FacebookSiteAndAuthorNamesWrapper>
+			<FacebookSiteName siteName={ props.siteName } />
+			{ renderFacebookAuthorName( props.authorName ) }
+		</FacebookSiteAndAuthorNamesWrapper>
+	);
+};
+
+FacebookSiteAndAuthorNames.propTypes = {
+	siteName: PropTypes.string.isRequired,
+	authorName: PropTypes.string,
+};
+
+FacebookSiteAndAuthorNames.defaultProps = {
+	authorName: "",
+};
+
+export default FacebookSiteAndAuthorNames;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteName.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteName.js
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
 
-const FacebookSiteNameWrapper = styled.p`
+const FacebookSiteNameWrapper = styled.span`
 	color: #606770;
 	font-size: 12px;
 	line-height: 11px;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteName.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteName.js
@@ -9,8 +9,6 @@ const FacebookSiteNameWrapper = styled.span`
 	line-height: 11px;
 	text-transform: uppercase;
 	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 `;
 
 /**

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteName.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteName.js
@@ -1,3 +1,4 @@
+/* External dependencies */
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookAuthorNameTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookAuthorNameTest.js
@@ -1,0 +1,17 @@
+/* External dependencies */
+import React from "react";
+import renderer from "react-test-renderer";
+
+/* Internal dependencies */
+import FacebookAuthorName from "../components/FacebookAuthorName";
+
+describe( "FacebookAuthorName", () => {
+	it( "matches the snapshot by default", () => {
+		const component = renderer.create(
+			<FacebookAuthorName authorName="John Doe" />
+		);
+
+		const tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+} );

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookSiteAndAuthorNamesTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookSiteAndAuthorNamesTest.js
@@ -1,0 +1,32 @@
+/* External dependencies */
+import React from "react";
+import renderer from "react-test-renderer";
+
+/* Internal dependencies */
+import FacebookSiteAndAuthorNames from "../components/FacebookSiteAndAuthorNames";
+
+describe( "FacebookSiteAndAuthorNames", () => {
+	it( "matches the snapshot by default", () => {
+		const component = renderer.create(
+			<FacebookSiteAndAuthorNames siteName="sitename.com" authorName="John Doe" />
+		);
+
+		const tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+
+	it( "does not contain the author name when no author name was given", () => {
+		const component = renderer.create(
+			<FacebookSiteAndAuthorNames siteName="sitename.com" />
+		);
+
+		const tree = component.toJSON();
+
+		/*
+		 * Not optimal, but the TestRenderer does not have support for function components. which FacebookAuthorName is.
+		 * See: https://reactjs.org/docs/test-renderer.html#testrenderergetinstance
+		 */
+		const facebookAuthorNameExists = tree.children.some( el => el.type === "span" && el.props.className.startsWith( "FacebookAuthorName" ) );
+		expect( facebookAuthorNameExists ).toEqual( false );
+	} );
+} );

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookAuthorNameTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookAuthorNameTest.js.snap
@@ -5,10 +5,6 @@ exports[`FacebookAuthorName matches the snapshot by default 1`] = `
   color: #3b5998;
   font-size: 12px;
   line-height: 11px;
-  position: relative;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  cursor: auto;
 }
 
 <span

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookAuthorNameTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookAuthorNameTest.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FacebookAuthorName matches the snapshot by default 1`] = `
+.c0 {
+  color: #3b5998;
+  font-size: 12px;
+  line-height: 11px;
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: auto;
+}
+
+<span
+  className="c0"
+>
+  John Doe
+</span>
+`;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
@@ -11,7 +11,7 @@ Array [
 <div
     className="c0"
   />,
-  .c0 {
+  .c1 {
   color: #606770;
   font-size: 12px;
   line-height: 11px;
@@ -21,10 +21,24 @@ Array [
   white-space: nowrap;
 }
 
+.c0 {
+  color: #606770;
+  font-size: 12px;
+  line-height: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 <p
     className="c0"
   >
-    yoast.com
+    <span
+      className="c1"
+    >
+      yoast.com
+    </span>
   </p>,
 ]
 `;
@@ -40,7 +54,7 @@ Array [
 <div
     className="c0"
   />,
-  .c0 {
+  .c1 {
   color: #606770;
   font-size: 12px;
   line-height: 11px;
@@ -50,10 +64,24 @@ Array [
   white-space: nowrap;
 }
 
+.c0 {
+  color: #606770;
+  font-size: 12px;
+  line-height: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 <p
     className="c0"
   >
-    yosat.com
+    <span
+      className="c1"
+    >
+      yosat.com
+    </span>
   </p>,
 ]
 `;
@@ -69,7 +97,7 @@ Array [
 <div
     className="c0"
   />,
-  .c0 {
+  .c1 {
   color: #606770;
   font-size: 12px;
   line-height: 11px;
@@ -79,10 +107,24 @@ Array [
   white-space: nowrap;
 }
 
+.c0 {
+  color: #606770;
+  font-size: 12px;
+  line-height: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 <p
     className="c0"
   >
-    yoast.com
+    <span
+      className="c1"
+    >
+      yoast.com
+    </span>
   </p>,
 ]
 `;
@@ -98,7 +140,7 @@ Array [
 <div
     className="c0"
   />,
-  .c0 {
+  .c1 {
   color: #606770;
   font-size: 12px;
   line-height: 11px;
@@ -108,10 +150,24 @@ Array [
   white-space: nowrap;
 }
 
+.c0 {
+  color: #606770;
+  font-size: 12px;
+  line-height: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 <p
     className="c0"
   >
-    yoast.com
+    <span
+      className="c1"
+    >
+      yoast.com
+    </span>
   </p>,
 ]
 `;
@@ -127,7 +183,7 @@ Array [
 <div
     className="c0"
   />,
-  .c0 {
+  .c1 {
   color: #606770;
   font-size: 12px;
   line-height: 11px;
@@ -137,10 +193,24 @@ Array [
   white-space: nowrap;
 }
 
+.c0 {
+  color: #606770;
+  font-size: 12px;
+  line-height: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 <p
     className="c0"
   >
-    yoast.com
+    <span
+      className="c1"
+    >
+      yoast.com
+    </span>
   </p>,
 ]
 `;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
@@ -17,8 +17,6 @@ Array [
   line-height: 11px;
   text-transform: uppercase;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 {
@@ -60,8 +58,6 @@ Array [
   line-height: 11px;
   text-transform: uppercase;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 {
@@ -103,8 +99,6 @@ Array [
   line-height: 11px;
   text-transform: uppercase;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 {
@@ -146,8 +140,6 @@ Array [
   line-height: 11px;
   text-transform: uppercase;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 {
@@ -189,8 +181,6 @@ Array [
   line-height: 11px;
   text-transform: uppercase;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c0 {

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
@@ -38,6 +38,24 @@ Array [
       yoast.com
     </span>
   </p>,
+  .c0 {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 3px;
+  width: 100%;
+}
+
+<p
+    className="c0"
+  >
+    Description to go along with a faulty image.
+  </p>,
 ]
 `;
 
@@ -76,8 +94,26 @@ Array [
     <span
       className="c1"
     >
-      yosat.com
+      yoast.com
     </span>
+  </p>,
+  .c0 {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 3px;
+  width: 100%;
+}
+
+<p
+    className="c0"
+  >
+    Description to go along with a landscape image.
   </p>,
 ]
 `;
@@ -120,6 +156,24 @@ Array [
       yoast.com
     </span>
   </p>,
+  .c0 {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 3px;
+  width: 100%;
+}
+
+<p
+    className="c0"
+  >
+    Description to go along with a portrait image.
+  </p>,
 ]
 `;
 
@@ -161,6 +215,24 @@ Array [
       yoast.com
     </span>
   </p>,
+  .c0 {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 3px;
+  width: 100%;
+}
+
+<p
+    className="c0"
+  >
+    Description to go along with a square image.
+  </p>,
 ]
 `;
 
@@ -201,6 +273,24 @@ Array [
     >
       yoast.com
     </span>
+  </p>,
+  .c0 {
+  color: #606770;
+  font-size: 14px;
+  line-height: 20px;
+  word-break: break-word;
+  max-height: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin-top: 3px;
+  width: 100%;
+}
+
+<p
+    className="c0"
+  >
+    Description to go along with too small an image.
   </p>,
 ]
 `;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookSiteAndAuthorNamesTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookSiteAndAuthorNamesTest.js.snap
@@ -1,0 +1,60 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FacebookSiteAndAuthorNames matches the snapshot by default 1`] = `
+.c1 {
+  color: #606770;
+  font-size: 12px;
+  line-height: 11px;
+  text-transform: uppercase;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.c3 {
+  color: #3b5998;
+  font-size: 12px;
+  line-height: 11px;
+  position: relative;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  cursor: auto;
+}
+
+.c0 {
+  color: #606770;
+  font-size: 12px;
+  line-height: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.c2 {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+<p
+  className="c0"
+>
+  <span
+    className="c1"
+  >
+    sitename.com
+  </span>
+  <span
+    className="c2"
+  >
+    |
+  </span>
+  By
+   
+  <span
+    className="c3"
+  >
+    John Doe
+  </span>
+</p>
+`;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookSiteAndAuthorNamesTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookSiteAndAuthorNamesTest.js.snap
@@ -7,18 +7,12 @@ exports[`FacebookSiteAndAuthorNames matches the snapshot by default 1`] = `
   line-height: 11px;
   text-transform: uppercase;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .c3 {
   color: #3b5998;
   font-size: 12px;
   line-height: 11px;
-  position: relative;
-  -webkit-text-decoration: none;
-  text-decoration: none;
-  cursor: auto;
 }
 
 .c0 {

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookSiteNameTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookSiteNameTest.js.snap
@@ -7,8 +7,6 @@ exports[`FacebookSiteName matches the snapshot by default 1`] = `
   line-height: 11px;
   text-transform: uppercase;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 <span

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookSiteNameTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookSiteNameTest.js.snap
@@ -11,9 +11,9 @@ exports[`FacebookSiteName matches the snapshot by default 1`] = `
   white-space: nowrap;
 }
 
-<p
+<span
   className="c0"
 >
   sitename.com
-</p>
+</span>
 `;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a FacebookAuthorName component.
* Adds a FacebookSiteAndAuthorNames component.

## Relevant technical choices:

* Instead of placing the `FacebookAuthorName` within the `FacebookSiteName` I created a `FacebookSiteAndAuthorNames` to hold them both.
* Changed `FacebookSiteName`'s HTML element to span because it should be inline.
* Adapted `FacebookPreview` to use `FacebookSiteAndAuthorContainer` instead of `FacebookSiteName`.

## Test instructions

This PR can be tested by following these steps:

* Check the tests.
* Start the stand-alone.
* Go to the FacebookPreview page by clicking on the button in the top right.
* Check if they look according to spec (see issue or better yet Facebook itself).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes #42
