### PR TITLE
Add a deploy stage for lerna publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,37 @@ node_js:
 matrix:
   allow_failures:
     - node_js: node
+stages:
+  - test
+  - name: 🚀 rc-deployment
+    if: branch =~ /^(release|release-yoast-seo)\/*/
+  - name: 🚀 deployment
+    if: branch = master
+jobs:
+  include:
+    - stage: 🚀 rc-deployment
+      node_js: lts/*
+      name: "Deploy to the npm rc channel"
+      script: skip
+      deploy:
+        skip_cleanup: true
+        provider: script
+        script: yarn lerna-publish-rc
+        on:
+          # Branch condition is in the stages configuration
+          all_branches: true
+    - stage: 🚀 deployment
+      node_js: lts/*
+      name: "Deploy to the npm latest channel"
+      script: skip
+      deploy:
+        skip_cleanup: true
+        provider: script
+        script: yarn lerna-publish
+        on:
+          # Branch condition is in the stages configuration
+          all_branches: true
+
 cache:
   yarn: true
   directories:
@@ -27,6 +58,9 @@ script:
 - yarn lint
 - yarn test -- -- --coverage
 
+before_deploy:
+- echo "//registry.npmjs.org/:_authToken=\${CI_NPM_YOASTBOT_TOKEN}" > .npmrc
+
 #after_success:
 #- yarn global add codeclimate-test-reporter
 #- codeclimate-test-reporter < coverage/lcov.info
@@ -34,12 +68,3 @@ script:
 #notifications:
 #  slack:
 #    secure: W3StABr+AdcdQawTObK4nbsnn5nLrTTtZfVpD/GEN6gvSOQcykbGEC5+ceYg0jn5b4StDyCiTo5blEsrpVICFpYKc44+ogah+qaGRUfVRS/rpOvn4AueXTWn4JxhZzuxqKMiTmyW+MQG0uYM7sk7Q5S+15jj6ilkj4QATaBVNbY=
-
-#deploy:
-#  provider: npm
-#  email: webmaster@yoast.com
-#  api_key:
-#    secure: zQGIEY373GvvXJav2qaeJ39qeFfz33/mZa4+VqvSBp+M68/VKdGukGd/oVqOsiKVX8+zqjjIsCnWY1LQ1sWjS2W5XAMQGC278lJj/YvKMAHcdVFqr1sE7C4CWY9JVQZy3YN/cfSwkSiu1ntIJQYsNJc8yBZgMP/1mu3auROlr//W6orT8H0ToVRJbfXIstmeDbrmEgU2fNEr+6Y6KADROUoQZcoFkxgSF/Pm2TU7gmHb4DuJO7aBw15Che/OSKCKG7kFobAl3Sw60BB3Caa4RWCFMFfA7GOlWtm6q6jVqBFb/rxmdYY0hpyidmcKFj6tAaHoh27kx8zzf8bRy9+ICtZuTFruHY9YKsALvRvKKprwM8nYE/T4mzSCOlRiCMWPo1AyNqtF1nGDVQOKQOCH5qsAC2dFgQJKfy8x+DPj+tPsV3aevq+VhgF0Rek1LqyQLsKZv5xFAvil9rU3We3R2foJDqMgZwf5QVI0ZlOAIQSh5zORMoKAPKxAOVcODiNEiOkOZrj1A4CLX33V0e3td5qBSltGzlZQEbryvy8yFB4rBqE+1TpcCnu29rYcdVB8X78mz/uuQJG+VMfHTmYXD1vRZbgEzACaOsZR7eKZGi5BmfVMVnkqjM2vR24xCPOB2Laj/889PWJZPtL9D5mD0lsG7ln36honrk3aI+fYBjM=
-#  on:
-#    tags: true
-#    repo: Yoast/yoast-components

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 stages:
   - test
   - name: 🚀 rc-deployment
-    if: branch =~ /^(release|release-yoast-seo)\/*/
+    if: branch =~ /^(release-yoast-seo|release)\/*/
   - name: 🚀 deployment
     if: branch = master
 jobs:

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "transfer-branch": "./transfer-branch.sh",
     "lerna-version": "lerna version",
     "lerna-version-rc": "lerna version --preid rc",
-    "lerna-publish": "lerna publish --contents dist",
-    "lerna-publish-rc": "lerna publish --contents dist --dist-tag rc"
+    "lerna-publish": "lerna publish --contents dist --yes from-git",
+    "lerna-publish-rc": "lerna publish --contents dist --dist-tag rc --yes from-git"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,7 +989,7 @@ acorn@^4.0.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
   integrity sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=
 
-acorn@^5.5.0, acorn@^5.5.3:
+acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==


### PR DESCRIPTION
The workflow will be as follows:

* The team to release the monorepo pushes a new version using `yarn lerna-version` or `yarn lerna-version-rc`. 
* Travis will start building, either on `master` or the `release-yoast-seo/[version]` branch.
* Travis executes the correct deployment stage (either `deployment` or `rc-deployment`)
* Travis publishes using `yarn lerna-publish` or `yarn lerna-publish-rc`.

This is near impossible to test yourself, so I will be working with @manuelaugustin to test the RC version on the `release-yoast-seo/10.1` branch. So, after code review you may merge this PR.

## Technical choices

I've chosen to put the decisions whether to deploy in the build stages definition. This makes it easy to see which stage has been executed without having to dig through the logs of a job. It also doesn't spin up a machine when that is unnecessary.

Fixes #15.