### PR TITLE
Create FacebookTitle component

### DIFF
--- a/packages/yoast-components/app/FacebookPreviewExample.js
+++ b/packages/yoast-components/app/FacebookPreviewExample.js
@@ -12,19 +12,57 @@ const FacebookPreviewExample = () => {
 	return (
 		<ExamplesContainer backgroundColor="transparent">
 			<h2>FacebookPreview Landscape</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2015/06/How_to_choose_keywords_FI.png" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				title="YoastCon Workshops"
+				src="https://yoast.com/app/uploads/2015/06/How_to_choose_keywords_FI.png"
+			/>
 			<h2>FacebookPreview Landscape very large image</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2019/02/horizontal-1200x400.jpg" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				title={
+					"A very long title. A very long title. A very long title. A very long title. " +
+					"A very long title. A very long title. A very long title. A very long title. " +
+					"A very long title. A very long title. A very long title. A very long title. " +
+					"A very long title. A very long title. A very long title. A very long title. " +
+					"A very long title. A very long title. A very long title. A very long title. " +
+					"A very long title. A very long title. A very long title. A very long title. " +
+					"A very long title. A very long title. A very long title. A very long title. " +
+					"A very long title. A very long title. A very long title. A very long title. " +
+					"A very long title. A very long title. A very long title. A very long title."
+				}
+				src="https://yoast.com/app/uploads/2019/02/horizontal-1200x400.jpg"
+			/>
 			<h2>FacebookPreview Portrait</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2015/09/Author_Joost_x2.png" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				title="YoastCon Workshops"
+				src="https://yoast.com/app/uploads/2015/09/Author_Joost_x2.png"
+			/>
 			<h2>FacebookPreview Portrait very tall image</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2019/02/vertical-300x580.jpg" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				title="YoastCon Workshops"
+				src="https://yoast.com/app/uploads/2019/02/vertical-300x580.jpg"
+			/>
 			<h2>FacebookPreview Square</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2018/09/avatar_user_1_1537774226.png" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				title="YoastCon Workshops"
+				src="https://yoast.com/app/uploads/2018/09/avatar_user_1_1537774226.png"
+			/>
 			<h2>FacebookPreview image too small</h2>
-			<FacebookPreview siteName="SiteName.com" src="https://yoast.com/app/uploads/2018/11/Logo_TYPO3-250x105.png" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				title="YoastCon Workshops"
+				src="https://yoast.com/app/uploads/2018/11/Logo_TYPO3-250x105.png"
+			/>
 			<h2>FacebookPreview faulty image</h2>
-			<FacebookPreview siteName="SiteName.com" src="thisisnoimage" />
+			<FacebookPreview
+				siteName="SiteName.com"
+				title="YoastCon Workshops"
+				src="thisisnoimage"
+			/>
 		</ExamplesContainer>
 	);
 };

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookPreview.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookPreview.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 /* Internal dependencies */
 import FacebookSiteName from "./FacebookSiteName";
 import FacebookImage from "./FacebookImage";
+import FacebookTitle from "./FacebookTitle";
 
 /**
  * Renders a FacebookPreview component.
@@ -18,12 +19,14 @@ const FacebookPreview = ( props ) => {
 		<Fragment>
 			<FacebookImage src={ props.src } alt={ props.alt } />
 			<FacebookSiteName siteName={ props.siteName } />
+			<FacebookTitle title={ props.title } />
 		</Fragment>
 	);
 };
 
 FacebookPreview.propTypes = {
 	siteName: PropTypes.string.isRequired,
+	title: PropTypes.string.isRequired,
 	src: PropTypes.string.isRequired,
 	alt: PropTypes.string,
 };

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookTitle.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookTitle.js
@@ -1,0 +1,39 @@
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+const FacebookTitleWrapper = styled.span`
+	color: #1d2129;
+	font-weight: 600;
+	overflow: hidden;
+	font-size: 16px;
+	line-height: 20px;
+	margin: 5px 0 0;
+	max-height: 110px;
+	word-wrap: break-word;
+	letter-spacing: normal;
+	text-overflow: ellipsis;
+	white-space: normal;
+	cursor: pointer;
+`;
+
+/**
+ * Renders a FacebookTitle component.
+ *
+ * @param {object} props The props.
+ *
+ * @returns {React.Element} The rendered element.
+ */
+const FacebookTitle = ( props ) => {
+	return (
+		<FacebookTitleWrapper>
+			{ props.title }
+		</FacebookTitleWrapper>
+	);
+};
+
+FacebookTitle.propTypes = {
+	title: PropTypes.string.isRequired,
+};
+
+export default FacebookTitle;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookPreviewTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookPreviewTest.js
@@ -8,7 +8,11 @@ import FacebookPreview from "../components/FacebookPreview";
 describe( "FacebookPreview", () => {
 	it( "matches the snapshot for a landscape image", () => {
 		const component = renderer.create(
-			<FacebookPreview siteName="yosat.com" src="https://yoast.com/app/uploads/2015/06/How_to_choose_keywords_FI.png" />
+			<FacebookPreview
+				siteName="yosat.com"
+				title="YoastCon Workshops"
+				src="https://yoast.com/app/uploads/2015/06/How_to_choose_keywords_FI.png"
+			/>
 		);
 
 		const tree = component.toJSON();
@@ -16,7 +20,11 @@ describe( "FacebookPreview", () => {
 	} );
 	it( "matches the snapshot for a portrait image", () => {
 		const component = renderer.create(
-			<FacebookPreview siteName="yoast.com" src="https://yoast.com/app/uploads/2015/09/Author_Joost_x2.png" />
+			<FacebookPreview
+				siteName="yoast.com"
+				title="YoastCon Workshops"
+				src="https://yoast.com/app/uploads/2015/09/Author_Joost_x2.png"
+			/>
 		);
 
 		const tree = component.toJSON();
@@ -24,7 +32,11 @@ describe( "FacebookPreview", () => {
 	} );
 	it( "matches the snapshot for a square image", () => {
 		const component = renderer.create(
-			<FacebookPreview siteName="yoast.com" src="https://yoast.com/app/uploads/2018/09/avatar_user_1_1537774226.png" />
+			<FacebookPreview
+				siteName="yoast.com"
+				title="YoastCon Workshops"
+				src="https://yoast.com/app/uploads/2018/09/avatar_user_1_1537774226.png"
+			/>
 		);
 
 		const tree = component.toJSON();
@@ -32,7 +44,11 @@ describe( "FacebookPreview", () => {
 	} );
 	it( "matches the snapshot for a too small image", () => {
 		const component = renderer.create(
-			<FacebookPreview siteName="yoast.com" src="https://yoast.com/app/uploads/2018/11/Logo_TYPO3-250x105.png" />
+			<FacebookPreview
+				siteName="yoast.com"
+				title="YoastCon Workshops"
+				src="https://yoast.com/app/uploads/2018/11/Logo_TYPO3-250x105.png"
+			/>
 		);
 
 		const tree = component.toJSON();
@@ -40,7 +56,11 @@ describe( "FacebookPreview", () => {
 	} );
 	it( "matches the snapshot for a faulty image", () => {
 		const component = renderer.create(
-			<FacebookPreview siteName="yoast.com" src="thisisnoimage" />
+			<FacebookPreview
+				siteName="yoast.com"
+				title="YoastCon Workshops"
+				src="thisisnoimage"
+			/>
 		);
 
 		const tree = component.toJSON();

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookTitleTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookTitleTest.js
@@ -1,0 +1,17 @@
+/* External dependencies */
+import React from "react";
+import renderer from "react-test-renderer";
+
+/* Internal dependencies */
+import FacebookTitle from "../components/FacebookTitle";
+
+describe( "FacebookTitle", () => {
+	it( "matches the snapshot by default", () => {
+		const component = renderer.create(
+			<FacebookTitle title="YoastCon Workshops" />
+		);
+
+		const tree = component.toJSON();
+		expect( tree ).toMatchSnapshot();
+	} );
+} );

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
@@ -26,6 +26,29 @@ Array [
   >
     yoast.com
   </p>,
+  .c0 {
+  color: #1d2129;
+  font-weight: 600;
+  overflow: hidden;
+  font-size: 16px;
+  line-height: 20px;
+  margin: 5px 0 0;
+  max-height: 110px;
+  word-wrap: break-word;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  text-overflow: ellipsis;
+  white-space: normal;
+  cursor: pointer;
+}
+
+<span
+    className="c0"
+  >
+    YoastCon Workshops
+  </span>,
 ]
 `;
 
@@ -55,6 +78,29 @@ Array [
   >
     yosat.com
   </p>,
+  .c0 {
+  color: #1d2129;
+  font-weight: 600;
+  overflow: hidden;
+  font-size: 16px;
+  line-height: 20px;
+  margin: 5px 0 0;
+  max-height: 110px;
+  word-wrap: break-word;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  text-overflow: ellipsis;
+  white-space: normal;
+  cursor: pointer;
+}
+
+<span
+    className="c0"
+  >
+    YoastCon Workshops
+  </span>,
 ]
 `;
 
@@ -84,6 +130,29 @@ Array [
   >
     yoast.com
   </p>,
+  .c0 {
+  color: #1d2129;
+  font-weight: 600;
+  overflow: hidden;
+  font-size: 16px;
+  line-height: 20px;
+  margin: 5px 0 0;
+  max-height: 110px;
+  word-wrap: break-word;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  text-overflow: ellipsis;
+  white-space: normal;
+  cursor: pointer;
+}
+
+<span
+    className="c0"
+  >
+    YoastCon Workshops
+  </span>,
 ]
 `;
 
@@ -113,6 +182,29 @@ Array [
   >
     yoast.com
   </p>,
+  .c0 {
+  color: #1d2129;
+  font-weight: 600;
+  overflow: hidden;
+  font-size: 16px;
+  line-height: 20px;
+  margin: 5px 0 0;
+  max-height: 110px;
+  word-wrap: break-word;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  text-overflow: ellipsis;
+  white-space: normal;
+  cursor: pointer;
+}
+
+<span
+    className="c0"
+  >
+    YoastCon Workshops
+  </span>,
 ]
 `;
 
@@ -142,5 +234,28 @@ Array [
   >
     yoast.com
   </p>,
+  .c0 {
+  color: #1d2129;
+  font-weight: 600;
+  overflow: hidden;
+  font-size: 16px;
+  line-height: 20px;
+  margin: 5px 0 0;
+  max-height: 110px;
+  word-wrap: break-word;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  text-overflow: ellipsis;
+  white-space: normal;
+  cursor: pointer;
+}
+
+<span
+    className="c0"
+  >
+    YoastCon Workshops
+  </span>,
 ]
 `;

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookTitleTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookTitleTest.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FacebookTitle matches the snapshot by default 1`] = `
+.c0 {
+  color: #1d2129;
+  font-weight: 600;
+  overflow: hidden;
+  font-size: 16px;
+  line-height: 20px;
+  margin: 5px 0 0;
+  max-height: 110px;
+  word-wrap: break-word;
+  -webkit-letter-spacing: normal;
+  -moz-letter-spacing: normal;
+  -ms-letter-spacing: normal;
+  letter-spacing: normal;
+  text-overflow: ellipsis;
+  white-space: normal;
+  cursor: pointer;
+}
+
+<span
+  className="c0"
+>
+  YoastCon Workshops
+</span>
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -989,7 +989,7 @@ acorn@^4.0.4:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
   integrity sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=
 
-acorn@^5.5.0, acorn@^5.5.3:
+acorn@^5.0.0, acorn@^5.5.0, acorn@^5.5.3:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
   integrity sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [non-userfacing] Adds a FacebookTitle component in SocialPreviews/Facebook

## Relevant technical choices:

* I created the FacebookTitle component.
* I added the FacebookTitle component to the FacebookPreview component.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check out this branch.
* From the `packages/yoast-components` folder in the terminal, run `yarn` and `yarn start`.
* Run the unit tests (`FacebookTitleTest.js` and `FacebookPreviewTest.js`), they should not result in any errors.
* Start the stand-alone by navigating to `http://localhost:3333/` in the browser.
* Go to the `FacebookPreview` page by clicking on the button in the top right.
* Check if the titles look alright.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #40 