### PR TITLE
Make screen readers correctly announce Facebook preview site and author name

### DIFF
--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteAndAuthorNames.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteAndAuthorNames.js
@@ -31,7 +31,7 @@ const FacebookSiteAndAuthorNamesSeparator = styled.span`
  * @returns {React.Element} The rendered element.
  */
 function renderFacebookAuthorName( authorName ) {
-	/* translators: the context is: SITE | By AUTHOR */
+	/* Translators: the context is: SITE | By AUTHOR */
 	const by = __( "By", "yoast-components" );
 
 	return (
@@ -54,7 +54,7 @@ function renderFacebookAuthorName( authorName ) {
 const FacebookSiteAndAuthorNames = ( props ) => {
 	const hasAuthorName = props.authorName.length > 0;
 	const screenReaderText = hasAuthorName
-		/* translators: 1: site name, 2: post author name */
+		/* Translators: 1: site name, 2: post author name */
 		? sprintf( __( "%1$s by %2$s", "yoast-components" ), props.siteName, props.authorName )
 		: props.siteName;
 

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteAndAuthorNames.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/components/FacebookSiteAndAuthorNames.js
@@ -2,7 +2,7 @@
 import React, { Fragment } from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import { __ } from "@wordpress/i18n";
+import { __, sprintf } from "@wordpress/i18n";
 
 /* Internal dependencies */
 import FacebookSiteName from "./FacebookSiteName";
@@ -31,12 +31,7 @@ const FacebookSiteAndAuthorNamesSeparator = styled.span`
  * @returns {React.Element} The rendered element.
  */
 function renderFacebookAuthorName( authorName ) {
-	// Do not render anything when there is no author name.
-	if ( authorName.length === 0 ) {
-		return null;
-	}
-
-	/* Translators: The context is: SITE | By AUTHOR */
+	/* translators: the context is: SITE | By AUTHOR */
 	const by = __( "By", "yoast-components" );
 
 	return (
@@ -57,11 +52,20 @@ function renderFacebookAuthorName( authorName ) {
  * @returns {React.Element} The rendered element.
  */
 const FacebookSiteAndAuthorNames = ( props ) => {
+	const hasAuthorName = props.authorName.length > 0;
+	const screenReaderText = hasAuthorName
+		/* translators: 1: site name, 2: post author name */
+		? sprintf( __( "%1$s by %2$s", "yoast-components" ), props.siteName, props.authorName )
+		: props.siteName;
+
 	return (
-		<FacebookSiteAndAuthorNamesWrapper>
-			<FacebookSiteName siteName={ props.siteName } />
-			{ renderFacebookAuthorName( props.authorName ) }
-		</FacebookSiteAndAuthorNamesWrapper>
+		<Fragment>
+			<span className="screen-reader-text">{ screenReaderText }</span>
+			<FacebookSiteAndAuthorNamesWrapper aria-hidden="true">
+				<FacebookSiteName siteName={ props.siteName } />
+				{ hasAuthorName && renderFacebookAuthorName( props.authorName ) }
+			</FacebookSiteAndAuthorNamesWrapper>
+		</Fragment>
 	);
 };
 

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookSiteAndAuthorNamesTest.js
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/FacebookSiteAndAuthorNamesTest.js
@@ -26,7 +26,7 @@ describe( "FacebookSiteAndAuthorNames", () => {
 		 * Not optimal, but the TestRenderer does not have support for function components. which FacebookAuthorName is.
 		 * See: https://reactjs.org/docs/test-renderer.html#testrenderergetinstance
 		 */
-		const facebookAuthorNameExists = tree.children.some( el => el.type === "span" && el.props.className.startsWith( "FacebookAuthorName" ) );
+		const facebookAuthorNameExists = tree[ 1 ].children.some( el => el.type === "span" && el.props.className.startsWith( "FacebookAuthorName" ) );
 		expect( facebookAuthorNameExists ).toEqual( false );
 	} );
 } );

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookPreviewTest.js.snap
@@ -11,6 +11,11 @@ Array [
 <div
     className="c0"
   />,
+  <span
+    className="screen-reader-text"
+  >
+    yoast.com
+  </span>,
   .c1 {
   color: #606770;
   font-size: 12px;
@@ -30,6 +35,7 @@ Array [
 }
 
 <p
+    aria-hidden="true"
     className="c0"
   >
     <span
@@ -70,6 +76,11 @@ Array [
 <div
     className="c0"
   />,
+  <span
+    className="screen-reader-text"
+  >
+    yoast.com
+  </span>,
   .c1 {
   color: #606770;
   font-size: 12px;
@@ -89,6 +100,7 @@ Array [
 }
 
 <p
+    aria-hidden="true"
     className="c0"
   >
     <span
@@ -129,6 +141,11 @@ Array [
 <div
     className="c0"
   />,
+  <span
+    className="screen-reader-text"
+  >
+    yoast.com
+  </span>,
   .c1 {
   color: #606770;
   font-size: 12px;
@@ -148,6 +165,7 @@ Array [
 }
 
 <p
+    aria-hidden="true"
     className="c0"
   >
     <span
@@ -188,6 +206,11 @@ Array [
 <div
     className="c0"
   />,
+  <span
+    className="screen-reader-text"
+  >
+    yoast.com
+  </span>,
   .c1 {
   color: #606770;
   font-size: 12px;
@@ -207,6 +230,7 @@ Array [
 }
 
 <p
+    aria-hidden="true"
     className="c0"
   >
     <span
@@ -247,6 +271,11 @@ Array [
 <div
     className="c0"
   />,
+  <span
+    className="screen-reader-text"
+  >
+    yoast.com
+  </span>,
   .c1 {
   color: #606770;
   font-size: 12px;
@@ -266,6 +295,7 @@ Array [
 }
 
 <p
+    aria-hidden="true"
     className="c0"
   >
     <span

--- a/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookSiteAndAuthorNamesTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/SocialPreviews/Facebook/tests/__snapshots__/FacebookSiteAndAuthorNamesTest.js.snap
@@ -1,7 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FacebookSiteAndAuthorNames matches the snapshot by default 1`] = `
-.c1 {
+Array [
+  <span
+    className="screen-reader-text"
+  >
+    sitename.com by John Doe
+  </span>,
+  .c1 {
   color: #606770;
   font-size: 12px;
   line-height: 11px;
@@ -31,24 +37,26 @@ exports[`FacebookSiteAndAuthorNames matches the snapshot by default 1`] = `
 }
 
 <p
-  className="c0"
->
-  <span
-    className="c1"
+    aria-hidden="true"
+    className="c0"
   >
-    sitename.com
-  </span>
-  <span
-    className="c2"
-  >
-    |
-  </span>
-  By
-   
-  <span
-    className="c3"
-  >
-    John Doe
-  </span>
-</p>
+    <span
+      className="c1"
+    >
+      sitename.com
+    </span>
+    <span
+      className="c2"
+    >
+      |
+    </span>
+    By
+     
+    <span
+      className="c3"
+    >
+      John Doe
+    </span>
+  </p>,
+]
 `;


### PR DESCRIPTION
Fixes #89 

- adds a screen-reader-text with lowercase text for screen readers
- hides the uppercase text from screen readers

Initially, I thought to use an `aria-label` but on a non-interactive element `aria-label` makes also screen reader announce the element has "group" (that is, it assign it an ARIA role).

Finally opted for a screen-reader-text, sees to me the cleanest way to provide a lowercase string to screen readers. Also, improves a bit the conditional rendering of the author name.

<img width="690" alt="Screenshot 2019-03-20 at 13 57 28" src="https://user-images.githubusercontent.com/1682452/54690546-ee911400-4b21-11e9-9091-97bc7c3d71d2.png">

(notice above the lowercase text gets announced vs. the visible uppercase text)