### PR TITLE
Use the right keyphrase boundaries for morphology languages

### DIFF
--- a/packages/yoastseo/spec/assessments/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/assessments/KeywordDensityAssessmentSpec.js
@@ -122,6 +122,16 @@ describe( "Tests for the keywordDensity assessment for languages with morphology
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 32 times. This is great!" );
 	} );
+
+	it( "gives a GOOD result when keyword density is between 3 and 3.5%, also for other languages with morphology support", function() {
+		const paper = new Paper( nonkeyword.repeat( 968 ) + keyword.repeat( 32 ), { keyword: "keyword", locale: "de_DE" } );
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		expect( result.getScore() ).toBe( 9 );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+			"The focus keyphrase was found 32 times. This is great!" );
+	} );
 } );
 
 describe( "A test for marking the keyword", function() {

--- a/packages/yoastseo/spec/assessments/KeywordDensityAssessmentSpec.js
+++ b/packages/yoastseo/spec/assessments/KeywordDensityAssessmentSpec.js
@@ -132,6 +132,16 @@ describe( "Tests for the keywordDensity assessment for languages with morphology
 		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
 			"The focus keyphrase was found 32 times. This is great!" );
 	} );
+
+	it( "gives a BAD result when keyword density is between 3 and 3.5%, if morphology support is added, but there is no morphology data", function() {
+		const paper = new Paper( nonkeyword.repeat( 968 ) + keyword.repeat( 32 ), { keyword: "keyword", locale: "de_DE" } );
+		const researcher = new Researcher( paper );
+		const result = new KeywordDensityAssessment().getResult( paper, researcher, i18n );
+		expect( result.getScore() ).toBe( -10 );
+		expect( result.getText() ).toBe( "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
+			"The focus keyphrase was found 32 times. That's more than the recommended maximum of 29 times for a text of this length. " +
+			"<a href='https://yoa.st/33w' target='_blank'>Don't overoptimize</a>!" );
+	} );
 } );
 
 describe( "A test for marking the keyword", function() {

--- a/packages/yoastseo/src/assessments/seo/KeywordDensityAssessment.js
+++ b/packages/yoastseo/src/assessments/seo/KeywordDensityAssessment.js
@@ -3,6 +3,7 @@ import { merge } from "lodash-es";
 import recommendedKeywordCount from "../../assessmentHelpers/recommendedKeywordCount.js";
 import Assessment from "../../assessment";
 import getLanguage from "../../helpers/getLanguage";
+import getLanguagesWithWordFormSupport from "../../helpers/getLanguagesWithWordFormSupport";
 import AssessmentResult from "../../values/AssessmentResult";
 import { inRangeEndInclusive, inRangeStartEndInclusive, inRangeStartInclusive } from "../../helpers/inRange";
 import { createAnchorOpeningTag } from "../../helpers/shortlinker";
@@ -100,7 +101,8 @@ class KeywordDensityAssessment extends Assessment {
 	 * @returns {AssessmentResult} The result of the assessment.
 	 */
 	getResult( paper, researcher, i18n ) {
-		this._hasMorphologicalForms = researcher.getData( "morphology" ) !== false && getLanguage( paper.getLocale() ) === "en";
+		this._hasMorphologicalForms = researcher.getData( "morphology" ) !== false &&
+			getLanguagesWithWordFormSupport().includes( getLanguage( paper.getLocale() ) );
 
 		this._keywordCount = researcher.getResearch( "keywordCount" );
 		const keyphraseLength = this._keywordCount.length;


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [not-user-facing] Makes sure that all languages with morphology support use the correct keyphrase boundaries.

## Relevant technical choices:

* Previously, the check for whether to use the specific keyphrase boundaries for languages with morphology support was set hard-coded to English. Since that is not the only language with morphology support, we now make use of the helper function `getLanguagesWithMorphologySupport`.

## Test instructions

This PR can be tested by following these steps:

* In the example, set a keyphrase and add a text that's long enough to trigger the keyphrase density assessment (>150 words).
* Add `console.log( this._keywordDensity )` on line 117 of `KeywordDensityAssessment`. You'll need this to montor the calculated keyphrase density, as it's not apparent from the feedback strings.
* Set your locale to `de_DE`. Add the keyphrase often enough in the text to get a density between 3 and 3.5. If you're within this range, you should get a green score.
* Now set your locale to one for which we don't have morphology support, e.g. `nl_NL`. The keyphrase density should stay the same, but you should now get a red bullet.


Fixes #
