### PR TITLE
Use custom researcher in taxonomy assessor

### DIFF
--- a/packages/yoastseo/src/relatedKeywordTaxonomyAssessor.js
+++ b/packages/yoastseo/src/relatedKeywordTaxonomyAssessor.js
@@ -11,10 +11,11 @@ import FunctionWordsInKeyphrase from "./assessments/seo/FunctionWordsInKeyphrase
  * Creates the Assessor used for taxonomy pages.
  *
  * @param {object} i18n The i18n object used for translations.
+ * @param {Object} options The options for this assessor.
  * @constructor
  */
-const RelatedKeywordTaxonomyAssessor = function( i18n ) {
-	Assessor.call( this, i18n );
+const RelatedKeywordTaxonomyAssessor = function( i18n, options ) {
+	Assessor.call( this, i18n, options );
 	this.type = "RelatedKeywordsTaxonomyAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/taxonomyAssessor.js
+++ b/packages/yoastseo/src/taxonomyAssessor.js
@@ -35,10 +35,11 @@ export const getTextLengthAssessment = function() {
  * Creates the Assessor used for taxonomy pages.
  *
  * @param {object} i18n The i18n object used for translations.
+ * @param {Object} options The options for this assessor.
  * @constructor
  */
-const TaxonomyAssessor = function( i18n ) {
-	Assessor.call( this, i18n );
+const TaxonomyAssessor = function( i18n, options ) {
+	Assessor.call( this, i18n, options );
 	this.type = "TaxonomyAssessor";
 
 	this._assessments = [

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -329,7 +329,7 @@ export default class AnalysisWebWorker {
 		let assessor;
 
 		if ( useTaxonomy === true ) {
-			assessor = new TaxonomyAssessor( this._i18n );
+			assessor = new TaxonomyAssessor( this._i18n, { locale: locale, researcher: this._researcher } );
 		} else {
 			assessor = useCornerstone === true
 				? new CornerstoneSEOAssessor( this._i18n, { locale: locale, researcher: this._researcher } )

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -372,7 +372,7 @@ export default class AnalysisWebWorker {
 		let assessor;
 
 		if ( useTaxonomy === true ) {
-			assessor = new RelatedKeywordTaxonomyAssessor( this._i18n );
+			assessor = new RelatedKeywordTaxonomyAssessor( this._i18n, { locale: locale, researcher: this._researcher } );
 		} else {
 			assessor = useCornerstone === true
 				? new CornerstoneRelatedKeywordAssessor( this._i18n, { locale: locale, researcher: this._researcher } )


### PR DESCRIPTION
## Summary
* [not-user-facing] Fixes the bug when custom `researcher` would not be passed to the taxonomy assessor, which would result in morphological analysis not run on taxonomy pages (concerns English and German)

## Testing instructions
* Use the local testing environment to check if the morphology data is being used for taxonomy analysis.

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2305