### PR TITLE
Accept yarn lint and yarn test args

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     ]
   },
   "scripts": {
-    "lint": "lerna run lint",
+    "lint": "lerna run lint --",
     "lint2": "eslint packages apps",
-    "test": "lerna run test --stream",
+    "test": "lerna run test --stream --",
     "install-ci": "lerna run install-ci",
     "link-all": "lerna exec yarn link",
     "unlink-all": "lerna exec yarn unlink",


### PR DESCRIPTION
Enables you to run `yarn lint --fix` from the javascript project root.