### PR TITLE
Move the a11y tests

### DIFF
--- a/packages/components/tests/ScreenReaderShortcutTest.js
+++ b/packages/components/tests/ScreenReaderShortcutTest.js
@@ -1,10 +1,10 @@
-jest.unmock( "../ScreenReaderShortcut" );
+jest.unmock( "../a11y/ScreenReaderShortcut" );
 jest.unmock( "prop-types" );
 
 import React from "react";
 import ReactShallowRenderer from "react-test-renderer/shallow";
-import ScreenReaderShortcut from "../ScreenReaderShortcut";
-import Styles from "../Styles";
+import ScreenReaderShortcut from "../a11y/ScreenReaderShortcut";
+import Styles from "../a11y/Styles";
 import { shallow } from "enzyme";
 
 describe( "ScreenReaderShortcut", () => {

--- a/packages/components/tests/ScreenReaderTextTest.js
+++ b/packages/components/tests/ScreenReaderTextTest.js
@@ -1,10 +1,10 @@
-jest.unmock( "../ScreenReaderText" );
+jest.unmock( "../a11y/ScreenReaderText" );
 jest.unmock( "prop-types" );
 
 import React from "react";
 import ReactShallowRenderer from "react-test-renderer/shallow";
-import ScreenReaderText from "../ScreenReaderText";
-import Styles from "../Styles";
+import ScreenReaderText from "../a11y/ScreenReaderText";
+import Styles from "../a11y/Styles";
 
 describe( "ScreenReaderText", () => {
 	const renderer = new ReactShallowRenderer();

--- a/packages/components/tests/StylesTest.js
+++ b/packages/components/tests/StylesTest.js
@@ -1,4 +1,4 @@
-import Styles from "../Styles";
+import Styles from "../a11y/Styles";
 
 describe( "Styles", () => {
 	it( "contains styles for ScreenReaderText", () => {


### PR DESCRIPTION
Fixes #154 

The tests are moved from `a11y/tests` to the `tests` directory.