### PR TITLE
Ignore coverage directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 lerna-debug.log
 /packages/*/dist
 yarn-error.log
+coverage


### PR DESCRIPTION
A coverage report is generated by the `yarn test --coverage` command. We do not want to commit these.
This change will make git ignore any coverage directory. Which is handy because they can appear in any of our packages.