### PR TITLE
Fix UIControls tab in components app

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -59,7 +59,8 @@ export { default as YoastSeoIcon } from "./YoastSeoIcon";
 export { default as YoastTabs } from "./YoastTabs";
 export { default as YoastWarning } from "./YoastWarning";
 export { default as YouTubeVideo } from "./YouTubeVideo";
-export { default as WordList } from "./WordList";
+export { default as WordList } from "./WordList"
+export { default as Checkbox } from "./Checkbox";
 
 
 export { ListTable, ZebrafiedListTable } from "./table/ListTable";

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -59,7 +59,7 @@ export { default as YoastSeoIcon } from "./YoastSeoIcon";
 export { default as YoastTabs } from "./YoastTabs";
 export { default as YoastWarning } from "./YoastWarning";
 export { default as YouTubeVideo } from "./YouTubeVideo";
-export { default as WordList } from "./WordList"
+export { default as WordList } from "./WordList";
 export { default as Checkbox } from "./Checkbox";
 
 


### PR DESCRIPTION
## Summary

## Relevant technical choices:

* The Checkbox components wasn't exported in @yoast/components

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the UI Controls tab in the components app and see that it works.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #159