### PR TITLE
Fix yoast-components warning

### DIFF
--- a/apps/components/App.js
+++ b/apps/components/App.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { IntlProvider } from "react-intl";
 import styled, { ThemeProvider } from "styled-components";
+import { setLocaleData } from "@wordpress/i18n";
 
 import ButtonsWrapper from "./ButtonsWrapper";
 import ComponentsExample from "./ComponentsExample";
@@ -16,6 +17,9 @@ import UIControlsWrapper from "./UIControlsWrapper";
 import Wizard from "./WizardWrapper";
 import { Loader } from "@yoast/components";
 import FacebookPreviewExample from "./FacebookPreviewExample";
+
+// Setup empty translations to prevent Jed error.
+setLocaleData( { "": {} }, "yoast-components" );
 
 const components = [
 	{


### PR DESCRIPTION
## Relevant technical choices:

* Do this by providing an empty translations object.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test each tab and see no warning for locale in the console.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #161