### PR TITLE
Add german stemming functionality to internal linking

### DIFF
--- a/apps/content-analysis/src/utils/getMorphologyData.js
+++ b/apps/content-analysis/src/utils/getMorphologyData.js
@@ -1,3 +1,4 @@
+import { merge } from "lodash-es";
 let morphologyData = null;
 
 /**
@@ -5,15 +6,17 @@ let morphologyData = null;
  * @returns {Object} The morphology data, or an empty object if not available.
  */
 function loadLocalMorphologyData() {
-	let data = {};
+	let data, dataDe = {};
 	try {
 		// Disabling global require to be able to fail.
 		// eslint-disable-next-line global-require
 		data = require( "../../../../packages/yoastseo/premium-configuration/data/morphologyData.json" );
+		// eslint-disable-next-line global-require
+		dataDe = require( "../../../../packages/yoastseo/premium-configuration/data/morphologyData-de.json" );
 	} catch ( error ) {
 		// Falling back to empty data.
 	}
-	return data;
+	return merge( data, dataDe );
 }
 
 /**

--- a/packages/yoastseo/spec/stringProcessing/relevantWordsGermanSpec.js
+++ b/packages/yoastseo/spec/stringProcessing/relevantWordsGermanSpec.js
@@ -1,5 +1,6 @@
 import WordCombination from "../../src/values/WordCombination";
 import { getRelevantWords } from "../../src/stringProcessing/relevantWords";
+import { de as morphologyData } from "../../premium-configuration/data/morphologyData-de.json";
 
 describe( "gets German word combinations", function() {
 	it( "returns word combinations", function() {
@@ -16,11 +17,11 @@ describe( "gets German word combinations", function() {
 			" Probieren geht über Studieren. Probieren geht über Studieren. Probieren geht über Studieren. Probieren geht über Studieren." +
 			" Probieren geht über Studieren. Probieren geht über Studieren. Probieren geht über Studieren.  Probieren geht über Studieren.";
 		const expected = [
-			new WordCombination( "probieren", "probieren", 48 ),
-			new WordCombination( "studieren", "studieren", 48 ),
+			new WordCombination( "probieren", "probi", 48 ),
+			new WordCombination( "studieren", "studium", 48 ),
 		];
 
-		const words = getRelevantWords( input, "de", false );
+		const words = getRelevantWords( input, "de", morphologyData );
 
 		expect( words ).toEqual( expected );
 	} );

--- a/packages/yoastseo/src/helpers/getStemForLanguage.js
+++ b/packages/yoastseo/src/helpers/getStemForLanguage.js
@@ -1,4 +1,5 @@
 import { determineStem as englishDetermineStem } from "../morphology/english/determineStem";
+import { determineStem as germanDetermineStem } from "../morphology/german/determineStem";
 
 /**
  * Collects all functions for determining a stem per language and returns this collection to a Researcher
@@ -8,5 +9,6 @@ import { determineStem as englishDetermineStem } from "../morphology/english/det
 export default function() {
 	return {
 		en: englishDetermineStem,
+		de: germanDetermineStem,
 	};
 }


### PR DESCRIPTION
## Summary
* Adds functionality to allow German words to be stemmed before they are saved in the database for internal linking suggestions

## Relevant technical choices:

* Separately requires German morphology data for the `content-analysis` tool. I an eager to hear a more elegant way to do so!

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check out this branch in `monorepo` and the same-name branch in `premium-configuration`
* Run the `content-analysis` tool
* Enter a German text and specify locale `de_DE`
* Check that different forms of German words get stemmed for Internal linking and the number of occurrences is calculated over all word forms

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
