### PR TITLE
Fix our content-analysis app

### DIFF
--- a/apps/content-analysis/package.json
+++ b/apps/content-analysis/package.json
@@ -61,7 +61,7 @@
 		"webpack-manifest-plugin": "2.0.4",
 		"workbox-webpack-plugin": "3.6.3",
 		"worker-loader": "^2.0.0",
-		"yoast-components": "^4.23.0-rc.6"
+	  	"@yoast/analysis-report": "^0.1.0"
 	},
 	"scripts": {
 		"start": "node scripts/start.js",

--- a/apps/content-analysis/src/components/Results.js
+++ b/apps/content-analysis/src/components/Results.js
@@ -1,7 +1,7 @@
 // External dependencies.
 import React, { Fragment } from "react";
 import { connect } from "react-redux";
-import { AnalysisList } from "yoast-components";
+import { AnalysisList } from "@yoast/analysis-report";
 
 // Internal dependencies.
 import { setActiveMarker } from "../redux/actions/results";


### PR DESCRIPTION
## Summary

The content-analysis app was broken because of an outdated import on yoast-components.

## Relevant technical choices:

* Remove the outdated import and import from the newly created package.

## Test instructions
This PR can be tested by following these steps:

* Check that the content-analysis app works.
