### PR TITLE
Fixes removed labels in onboarding wizard

### DIFF
--- a/packages/configuration-wizard/src/Step.js
+++ b/packages/configuration-wizard/src/Step.js
@@ -3,7 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 /* Yoast dependencies */
-import { Input } from "@yoast/components";
+import { Textfield as Input } from "@yoast/components";
 
 /* Internal dependencies */
 import HTML from "./Html";


### PR DESCRIPTION
## Summary

Fixes a bug that was introduced by https://github.com/Yoast/javascript/commit/c3fd96250a40c8ae5386ac46de42129da2afbb72#diff-261165497e796131a1bc5956847f4a9bR6, by importing the wrong component in `Step.js`. This should have been the `TextInput` component (that has an optional label), as seen here: https://github.com/Yoast/javascript/commit/6afe695f2d16150f3d13ab293f761c3316be1c94#diff-e97830e487e3ec141b3c3a84c37a6fe6R2.

## Relevant technical choices:

* [not-userfacing] Fixes bug where labels were removed from the onboarding wizard social page.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
