### PR TITLE
Uses the textfield instead of the input field

### DIFF
--- a/packages/configuration-wizard/src/Step.js
+++ b/packages/configuration-wizard/src/Step.js
@@ -3,7 +3,7 @@ import React from "react";
 import PropTypes from "prop-types";
 
 /* Yoast dependencies */
-import { Input } from "@yoast/components";
+import { Textfield as Input } from "@yoast/components";
 
 /* Internal dependencies */
 import HTML from "./Html";


### PR DESCRIPTION
## Summary

## Relevant technical choices:

*Fixes a bug where the label isn't rendered anymore

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go the the components app and do a yarn start
* In the example app open the wizard example
* Verify that the labels are rendered

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* x ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
