### PR TITLE
190 assessment set researcher is not a function

### DIFF
--- a/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
+++ b/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
@@ -1542,12 +1542,10 @@ describe( "AnalysisWebWorker", () => {
 			worker = new AnalysisWebWorker( scope );
 		} );
 
-		it( "creates an SEO assessor and adds the registered assessments to it", () => {
-			const assessment = new TestAssessment( true, 2, "test assessment", null );
-			worker.registerAssessment( "An assessment", assessment, "test-plugin" );
+		it( "creates an SEO assessor", () => {
 			const assessor = worker.createSEOTreeAssessor( {} );
 
-			expect( assessor.getAssessments() ).toEqual( [ assessment ] );
+			expect( assessor.getAssessments() ).toEqual( [] );
 		} );
 	} );
 

--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -444,15 +444,7 @@ export default class AnalysisWebWorker {
 	 * @returns {module:tree/assess.TreeAssessor} The created tree assessor.
 	 */
 	createSEOTreeAssessor( assessorConfig ) {
-		const assessor = constructSEOAssessor( this._i18n, this._treeResearcher, assessorConfig );
-
-		this._registeredAssessments.forEach( ( { name, assessment } ) => {
-			if ( ! assessor.getAssessment( name ) ) {
-				assessor.registerAssessment( name, assessment );
-			}
-		} );
-
-		return assessor;
+		return constructSEOAssessor( this._i18n, this._treeResearcher, assessorConfig );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Removes registering external assessments when a new `TreeAssessor` is made.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout the `develop` branch of this repository (the `javascript` monorepo).
* Checkout `trunk` in `wordpress-seo-premium`.
* Build and start the plugin.
* Open a page or post.
* You should see this error in the console:
  ```
  Uncaught TypeError: assessment.setResearcher is not a function
    at TreeAssessor.registerAssessment (TreeAssessor.js?dfdf:117)
    at eval (AnalysisWebWorker.js?2f3a:451)
    at Array.forEach (<anonymous>)
    at AnalysisWebWorker.createSEOTreeAssessor (AnalysisWebWorker.js?2f3a:449)
    at AnalysisWebWorker.initialize (AnalysisWebWorker.js?2f3a:553)
    at AnalysisWebWorker.handleMessage (AnalysisWebWorker.js?2f3a:248)
  ```
* Checkout this branch (`190-assessment-set-researcher-is-not-a-function`) in the `javascript` repository.
* Open a page or post.
* You should not see the error above.


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #190 
