### PR TITLE
203 implement feature toggle functionality

### DIFF
--- a/packages/feature-toggle/package.json
+++ b/packages/feature-toggle/package.json
@@ -11,12 +11,12 @@
   "license": "GPL-3.0",
   "private": false,
   "scripts": {
-    "test": "jest",
-    "lint": "eslint . --max-warnings=5",
+    "test": "jest --coverage",
+    "lint": "eslint ./src ./tests --max-warnings=5",
     "prepublishOnly": "rm -rf dist && cp -R src dist && cp package.json dist/package.json && json -I -f dist/package.json -e \"this.main='index.js'\""
   },
   "devDependencies": {
-
+    "jest": "^22.4.3"
   },
   "dependencies": {
 

--- a/packages/feature-toggle/src/index.js
+++ b/packages/feature-toggle/src/index.js
@@ -1,0 +1,59 @@
+/**
+ * Which features are currently enabled.
+ *
+ * @type {Object<string,string[]>}
+ * @private
+ */
+const _enabledFeatures = {
+	"": [],
+};
+
+/**
+ * Checks whether the given feature is enabled.
+ *
+ * @param {string} featureName      The name of the feature to check.
+ * @param {string} [namespace=""]   An optional namespace to prepend to the feature name. To avoid possible conflicts between packages.
+ *
+ * @returns {boolean} `true` when the feature is enabled, `false` if not.
+ */
+const isFeatureEnabled = function( featureName, namespace = "" ) {
+	return _enabledFeatures[ namespace ].includes( featureName );
+};
+
+/**
+ * Enables the features with the given names.
+ *
+ * @param {string[]} featureNames   A list of names of the features to enable.
+ * @param {string} [namespace=""]   An optional namespace to prepend to each feature name. To avoid possible conflicts between packages.
+ *
+ * @returns {void}
+ */
+const enableFeatures = function( featureNames, namespace = "" ) {
+	// Check whether the features are already enabled, if not: add them.
+	featureNames.forEach( name => {
+		// Create the namespace if it does not exist yet.
+		_enabledFeatures[ namespace ] = _enabledFeatures[ namespace ] || [];
+
+		if ( ! _enabledFeatures[ namespace ].includes( name ) ) {
+			_enabledFeatures[ namespace ].push( name );
+		}
+	} );
+};
+
+/**
+ * Returns the list of enabled features.
+ *
+ * @param {string} [namespace=""] An optional namespace. If not provided, only the features on the global namespace are returned.
+ *
+ * @returns {string[]} The list of enabled features.
+ */
+const enabledFeatures = function( namespace = "" ) {
+	return _enabledFeatures[ namespace ] || [];
+};
+
+
+export {
+	isFeatureEnabled,
+	enableFeatures,
+	enabledFeatures,
+};

--- a/packages/feature-toggle/src/index.js
+++ b/packages/feature-toggle/src/index.js
@@ -4,9 +4,7 @@
  * @type {Object<string,string[]>}
  * @private
  */
-const _enabledFeatures = {
-	"": [],
-};
+const _enabledFeatures = { };
 
 /**
  * Checks whether the given feature is enabled.

--- a/packages/feature-toggle/tests/indexTest.js
+++ b/packages/feature-toggle/tests/indexTest.js
@@ -1,0 +1,55 @@
+import { enabledFeatures, enableFeatures, isFeatureEnabled } from "../src";
+
+describe( "enableFeatures", () => {
+	it( "enables a list of given features", () => {
+		const previousFeatures = enabledFeatures().slice();
+		const featuresToEnable = [ "feature-1", "feature-2" ];
+		enableFeatures( featuresToEnable );
+		const newFeatures = enabledFeatures();
+
+		expect( newFeatures ).toEqual( [ ...featuresToEnable, ...previousFeatures ] );
+	} );
+
+	it( "does not add features that have already been enabled", () => {
+		const previousFeatures = enabledFeatures().slice();
+		const featuresToEnable = [ "feature-1", "feature-2" ];
+		enableFeatures( featuresToEnable );
+		enableFeatures( featuresToEnable );
+		const newFeatures = enabledFeatures();
+
+		const expected = new Set( [ ...previousFeatures, ...featuresToEnable ] );
+
+		expect( new Set( newFeatures ) ).toEqual( expected );
+	} );
+
+	it( "sets features on a namespace", () => {
+		const previousFeatures1 = enabledFeatures( "namespace-1" ).slice();
+		const previousFeatures2 = enabledFeatures( "namespace-2" ).slice();
+
+		const featuresToEnable1 = [ "feature-1", "feature-3" ];
+		const featuresToEnable2 = [ "feature-1", "feature-2" ];
+
+		enableFeatures( featuresToEnable1, "namespace-1" );
+		enableFeatures( featuresToEnable2, "namespace-2" );
+
+		const expected1 = new Set( [ ...previousFeatures1, ...featuresToEnable1 ] );
+		const expected2 = new Set( [ ...previousFeatures2, ...featuresToEnable2 ] );
+
+		const newFeatures1 = enabledFeatures( "namespace-1" );
+		const newFeatures2 = enabledFeatures( "namespace-2" );
+
+		expect( new Set( newFeatures1 ) ).toEqual( expected1 );
+		expect( new Set( newFeatures2 ) ).toEqual( expected2 );
+	} );
+} );
+
+describe( "isFeatureEnabled", () => {
+	it( "returns true when a particular feature is enabled", () => {
+		const featureName = "feature-1";
+		enableFeatures( [ featureName ] );
+
+		const featureIsEnabled = isFeatureEnabled( featureName );
+
+		expect( featureIsEnabled ).toEqual( true );
+	} );
+} );

--- a/packages/feature-toggle/tests/indexTest.js
+++ b/packages/feature-toggle/tests/indexTest.js
@@ -52,4 +52,13 @@ describe( "isFeatureEnabled", () => {
 
 		expect( featureIsEnabled ).toEqual( true );
 	} );
+
+	it( "returns false when a particular feature is disabled", () => {
+		const featureName = "feature-1";
+		enableFeatures( [ featureName ] );
+
+		const featureIsEnabled = isFeatureEnabled( "disabled-feature" );
+
+		expect( featureIsEnabled ).toEqual( false );
+	} );
 } );

--- a/packages/feature-toggle/tests/testTest.js
+++ b/packages/feature-toggle/tests/testTest.js
@@ -1,6 +1,0 @@
-
-describe( "Jest", () => {
-	it( "runs a test", () => {
-		expect( true ).toEqual( true );
-	} );
-} );


### PR DESCRIPTION
## Summary

* _[not-user-facing]_ Adds feature toggle functionality to the new `yoast/feature-toggle` package.

## Relevant technical choices:

* You can (optionally) add a namespace when enabling a feature. This is to avoid possible feature toggle name conflicts in the future.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Navigate to the `package/feature-toggle` package in your terminal.
* Run `yarn test`.
  * Check that the coverage of the package is 100%.
* Run `yarn lint`.
  * Check that there are no linting errors or warnings.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #203 
