### PR TITLE
Default height instead of null

### DIFF
--- a/packages/analysis-report/src/SiteSEOReport.js
+++ b/packages/analysis-report/src/SiteSEOReport.js
@@ -64,7 +64,7 @@ SiteSEOReport.defaultProps = {
 	className: "seo-assessment",
 	seoAssessmentText: "SEO Assessment",
 	seoAssessmentItems: null,
-	barHeight: null,
+	barHeight: "24px",
 };
 
 export default SiteSEOReport;


### PR DESCRIPTION
Partially fixes https://github.com/Yoast/javascript/issues/205

## Summary
The SiteSEOReport bar defaulted to `height:null`, which made it 0px tall. I'm now passing 24px as a default value. 24px because it used to be 24px.

OLD
-
![image](https://user-images.githubusercontent.com/5352634/55705940-406de100-59e0-11e9-9f1f-e8f945bb562c.png)
NEW
-
![image](https://user-images.githubusercontent.com/5352634/55705957-4b287600-59e0-11e9-80c3-58caa5de6bfd.png)


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check the wpseo dashboard widget.
* It should match the screenshot.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

