### PR TITLE
Create PaperParser class

### DIFF
--- a/packages/yoastseo/spec/parsedPaper/build/PaperParserSpec.js
+++ b/packages/yoastseo/spec/parsedPaper/build/PaperParserSpec.js
@@ -1,0 +1,17 @@
+describe( "PaperParser", () => {
+	describe( "constructor", () => {
+		it( "makes a new ParsedPaper", () => {
+			const paperParser = new PaperParser();
+			expect( paperParser ).toBeInstanceOf( PaperParser );
+		} );
+	} );
+
+	describe( "parse", () => {
+		it( "calls the build function of a TreeBuilder to parse the Paper's text", () => {
+			const paperParser = new PaperParser();
+			const TestPaper = new Paper(); // Is this even a class? Old Javascript.
+			paperParser.parse( TestPaper );
+			expect( TreeBuilder.build ).toHaveBeenCalledWith( Paper.text ); // Find out how this works.
+		} );
+	} );
+} );

--- a/packages/yoastseo/spec/parsedPaper/build/PaperParserSpec.js
+++ b/packages/yoastseo/spec/parsedPaper/build/PaperParserSpec.js
@@ -1,17 +1,83 @@
+import PaperParser from "../../../src/parsedPaper/build/PaperParser";
+import Paper from "../../../src/values/Paper";
+import buildTree from "../../../src/parsedPaper/build/tree/html/buildTree";
+
+const testPaper = new Paper( "text", {
+	keyword: "testing",
+	title: "Testing is nice",
+	description: "A description of the niceties of testing.",
+} );
+
+const initialMetaData = {
+	testKey: "testValue",
+};
+
 describe( "PaperParser", () => {
+	let paperParser;
+
+	beforeEach( () => {
+		paperParser = new PaperParser( buildTree );
+		console.warn = jest.fn();
+	} );
+
 	describe( "constructor", () => {
 		it( "makes a new ParsedPaper", () => {
-			const paperParser = new PaperParser();
 			expect( paperParser ).toBeInstanceOf( PaperParser );
 		} );
 	} );
 
 	describe( "parse", () => {
-		it( "calls the build function of a TreeBuilder to parse the Paper's text", () => {
-			const paperParser = new PaperParser();
-			const TestPaper = new Paper(); // Is this even a class? Old Javascript.
-			paperParser.parse( TestPaper );
-			expect( TreeBuilder.build ).toHaveBeenCalledWith( Paper.text ); // Find out how this works.
+		it( "calls the treeBuilder function to parse the Paper's text", () => {
+			const fakeTreeBuilder = jest.fn();
+			const testParser = new PaperParser( fakeTreeBuilder );
+			testParser.parse( testPaper );
+			expect( fakeTreeBuilder ).toHaveBeenCalledWith( testPaper._text );
+		} );
+
+		it( "calls ParsedPaper's constructMetaData method", () => {
+			const constructMetaDataSpy = jest.spyOn( PaperParser.prototype, "constructMetaData" );
+			paperParser.parse( testPaper );
+			expect( constructMetaDataSpy ).toHaveBeenCalledWith( testPaper );
+		} );
+	} );
+
+	describe( "constructMetaData", () => {
+		it( "returns an object from the paper", () => {
+			const metaData = paperParser.constructMetaData( testPaper );
+			expect( typeof metaData ).toEqual( "object" );
+		} );
+
+		it( "calls runMetaDataModifiers from paperParser", () => {
+			const runMetaDataModifiersSpy = jest.spyOn( PaperParser.prototype, "runMetaDataModifiers" );
+			paperParser.constructMetaData( testPaper );
+			expect( runMetaDataModifiersSpy )
+				.toHaveBeenCalledWith( {}, testPaper );
+		} );
+	} );
+
+	describe( "runMetaDataModifiers", () => {
+		it( "runs metaDataModifiers that are registered on the PaperParser", () => {
+			paperParser.registerMetaDataModifier( "testModifier", ( metaData ) => {
+				metaData.testModification = "success";
+				return metaData;
+			} );
+			expect( paperParser.runMetaDataModifiers( initialMetaData, testPaper ) )
+				.toEqual( {
+					testKey: "testValue",
+					testModification: "success",
+				} );
+		} );
+
+		it( "skips faulty metaDataModifiers registered on the PaperParser", () => {
+			paperParser.registerMetaDataModifier( "faultyTestModifier", ( metaData ) => {
+				metaData.modifcation = "success";
+				// Bad function call:
+				metaData.nonExistingFunc();
+				return metaData;
+			} );
+			expect( paperParser.runMetaDataModifiers( initialMetaData ) )
+				.toEqual( initialMetaData )
+			;
 		} );
 	} );
 } );

--- a/packages/yoastseo/src/parsedPaper/build/PaperParser.js
+++ b/packages/yoastseo/src/parsedPaper/build/PaperParser.js
@@ -44,6 +44,7 @@ class PaperParser {
 	 * Constructs the metaData from the Paper.
 	 *
 	 * @param {Paper} paper The paper to construct the metaData from.
+	 *
 	 * @returns {Object} The metaData.
 	 */
 	constructMetaData( paper ) {
@@ -60,14 +61,14 @@ class PaperParser {
 	/**
 	 * Sets a metaData modifying function behind a function name on the internal metaDataModifiers object.
 	 *
-	 * @param {string}   modifierName     The name of the to be registered function.
-	 * @param {Function} modifierFunction The function that modifies the metaData.Should accept a metaData object
-	 * 										and optionally the paper.
+	 * @param {string}   modifierName       The name of the to be registered function.
+	 * @param {Function} modifierFunction   The function that modifies the metaData. Should accept a metaData object
+	 * 									    and optionally the paper.
 	 * @returns {void}
 	 */
 	registerMetaDataModifier( modifierName, modifierFunction ) {
 		/*
-		The metaDataModifier should accept the metaData and return the altered metaData.
+		 * The metaDataModifier should accept the metaData and return the altered metaData.
 		 */
 		this._metaDataModifiers[ modifierName ] = modifierFunction;
 	}

--- a/packages/yoastseo/src/parsedPaper/build/PaperParser.js
+++ b/packages/yoastseo/src/parsedPaper/build/PaperParser.js
@@ -83,7 +83,6 @@ class PaperParser {
 	 */
 	runMetaDataModifiers( metaData, paper ) {
 		let modifiedMetaData = metaData;
-		// Perhaps just do a forEach here? You can then use try/catch to at least do all other modifiers.
 		forEach( this._metaDataModifiers, ( modifierFunction, modifierName ) => {
 			try {
 				const previousMetaData = Object.assign( {}, modifiedMetaData );

--- a/packages/yoastseo/src/parsedPaper/build/PaperParser.js
+++ b/packages/yoastseo/src/parsedPaper/build/PaperParser.js
@@ -1,0 +1,100 @@
+import ParsedPaper from "../ParsedPaper";
+import { forEach } from "lodash-es";
+
+/**
+ * A class responsible for pre-processing the Paper, returning a ParsedPaper;
+ */
+class PaperParser {
+	/**
+	 * Constructs a PaperParser class.
+	 *
+	 * @param {Function} treeBuilder A function that receives text and returns a tree.
+	 *
+	 * @returns {void}
+	 */
+	constructor( treeBuilder ) {
+		this._parsedPaper = new ParsedPaper();
+		this._treeBuilder = treeBuilder;
+
+		this._metaDataModifiers = {};
+	}
+
+	/**
+	 * Processes a Paper resulting in a ParsedPaper.
+	 *
+	 * @param {Paper} paper The Paper to parse.
+	 *
+	 * @returns {ParsedPaper} A parsedPaper instance.
+	 */
+	parse( paper ) {
+		// Build tree and set it to the ParsedPaper.
+		this._parsedPaper.setTree(
+			this._treeBuilder( paper.getText() )
+		);
+
+		// Build metaData and set it to the ParsedPaper.
+		this._parsedPaper.setMetaData(
+			this.constructMetaData( paper )
+		);
+
+		return this._parsedPaper;
+	}
+
+	/**
+	 * Constructs the metaData from the Paper.
+	 *
+	 * @param {Paper} paper The paper to construct the metaData from.
+	 * @returns {Object} The metaData.
+	 */
+	constructMetaData( paper ) {
+		let metaData = {};
+
+		// Map things to metaData.
+
+		// Run additional modifiers;
+		metaData = Object.assign( {}, this.runMetaDataModifiers( metaData, paper ) );
+
+		return metaData;
+	}
+
+	/**
+	 * Sets a metaData modifying function behind a function name on the internal metaDataModifiers object.
+	 *
+	 * @param {string}   modifierName     The name of the to be registered function.
+	 * @param {Function} modifierFunction The function that modifies the metaData.Should accept a metaData object
+	 * 										and optionally the paper.
+	 * @returns {void}
+	 */
+	registerMetaDataModifier( modifierName, modifierFunction ) {
+		/*
+		The metaDataModifier should accept the metaData and return the altered metaData.
+		 */
+		this._metaDataModifiers[ modifierName ] = modifierFunction;
+	}
+
+	/**
+	 * Runs all registered metaDataModifiers.
+	 * If one of the functions errors, it is skipped and its metaData changes are discarded.
+	 *
+	 * @param {Object} metaData The initial state of the metaData, that should be modified.
+	 * @param {Paper}  paper    The paper.
+	 *
+	 * @returns {Object} A modified metaData object.
+	 */
+	runMetaDataModifiers( metaData, paper ) {
+		let modifiedMetaData = metaData;
+		// Perhaps just do a forEach here? You can then use try/catch to at least do all other modifiers.
+		forEach( this._metaDataModifiers, ( modifierFunction, modifierName ) => {
+			try {
+				const previousMetaData = Object.assign( {}, modifiedMetaData );
+				modifiedMetaData = modifierFunction( previousMetaData, paper );
+			} catch ( modifierError ) {
+				console.warn( `An error with message "${ modifierError.message}" occurred in metaData modifier ` +
+				`function called ${ modifierName }. Skipping that function...` );
+			}
+		} );
+		return modifiedMetaData;
+	}
+}
+
+export default PaperParser;


### PR DESCRIPTION
## Summary
Creates a PaperParser class that can construct metaData and a tree.

## Relevant technical choices:

* We have decided that the TreeBuilder class is no longer sufficiently needed, and that instead we instantiate `paperParsers` by injecting a treeBuilder function. The TreeBuilder class will be removed in a separate issue.

## Test instructions
Make sure the content-analysis app doesn't fail (which verifies that this change touches nothing).
Make sure that all tests pass.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #188 
