### PR TITLE
Fix HelpCenter Tabs import.

### DIFF
--- a/packages/yoast-components/composites/Plugin/HelpCenter/HelpCenter.js
+++ b/packages/yoast-components/composites/Plugin/HelpCenter/HelpCenter.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import { __ } from "@wordpress/i18n";
 
 /* Yoast dependencies */
-import { Paper, YoastTabs, HelpCenterButton } from "@yoast/components";
+import { Paper, Tabs, HelpCenterButton } from "@yoast/components";
 import { colors, breakpoints } from "@yoast/style-guide";
 
 export const HelpCenterContainer = styled.div`
@@ -78,7 +78,7 @@ class HelpCenter extends React.Component {
 					{ __( "Need help?", "yoast-components" ) }
 				</HelpCenterButton>
 				{ this.state.isExpanded && <HelpCenterPaper minHeight="432px">
-					<YoastTabs
+					<Tabs
 						items={ this.props.items }
 						tabsTextColor={ this.props.tabsTextColor }
 						tabsTextTransform={ this.props.tabsTextTransform }

--- a/packages/yoast-components/package.json
+++ b/packages/yoast-components/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "start": "echo 'The yoast-components demo app has been moved to javascript/apps/components (https://github.com/Yoast/javascript/tree/develop/apps/components). Please run yarn start there.'",
     "test": "jest",
-    "lint": "eslint . --max-warnings=44",
+    "lint": "eslint . --max-warnings=34",
     "prepublishOnly": "grunt publish"
   },
   "jest": {


### PR DESCRIPTION
## Summary

## Relevant technical choices:

Fixes the Tabs component import in the HelpCenter.

## Test instructions
- first test on `develop`
- start the standalone app from `apps/components` running `yarn start`
- go to http://localhost:3333/ > Help center" tab
- click the "Need Help?" button
- see it's broken
- switch to this branch
- repeat the steps above, see it works


## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

Fixes https://github.com/Yoast/wordpress-seo/issues/12679
