### PR TITLE
Make sure node-sass is no longer installed when @yoast/style-guide is installed as a dependency

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -47,9 +47,6 @@
     "react": "^16.2.0",
     "react-dom": "16.2.0"
   },
-  "optionalDependencies": {
-    "grunt-scss-to-json": "^1.0.1"
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/style-guide/package.json
+++ b/packages/style-guide/package.json
@@ -12,9 +12,7 @@
   },
   "devDependencies": {
     "grunt": "^1.0.3",
-    "load-grunt-config": "^1.0.1"
-  },
-  "optionalDependencies": {
+    "load-grunt-config": "^1.0.1",
     "grunt-scss-to-json": "^1.0.1"
   },
   "publishConfig": {

--- a/packages/yoast-components/package.json
+++ b/packages/yoast-components/package.json
@@ -132,7 +132,7 @@
   "peerDependencies": {
     "material-ui": "^0.18.6",
     "react": "^16.2.0",
-    "react-dom": "16.2.0"
+    "react-dom": "^16.2.0"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
## Summary

* [components/style-guide] Fixes a bug where `node-sass` needed to be installed when adding dependencies that depend on `@yoast/style-guide`.

I thought this had something to do with windows machines at the time, so I attempted to install `grunt-scss-to-json` on a windows machine and it succeeded. It does require that your run `npm install --global --production windows-build-tools`.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* We should merge this and as soon as the first RC's for the next release have been created test whether it works.
* When installing this RC (can be in a empty project using `yarn init` and `yarn add @yoast/style-guide@{X.X-RCX}`) we should check `node-sass` is not installed as a dependency. Also check this for packages that have `@yoast/style-guide` as a dependency, like `yoast-components` for example.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #166 
