### PR TITLE
Change German morphology data import in spec helper

### DIFF
--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -115,6 +115,6 @@
     }
   },
   "yoast": {
-    "premiumConfiguration": "master"
+    "premiumConfiguration": ""
   }
 }

--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -115,6 +115,6 @@
     }
   },
   "yoast": {
-    "premiumConfiguration": "release-yoast-seo/11.1"
+    "premiumConfiguration": "master"
   }
 }

--- a/packages/yoastseo/spec/specHelpers/getMorphologyData.js
+++ b/packages/yoastseo/spec/specHelpers/getMorphologyData.js
@@ -1,5 +1,5 @@
 import en from "../../premium-configuration/data/morphologyData.json";
-import de from "../../premium-configuration/data/morphologyData-de.json";
+import de from "../../premium-configuration/data/morphologyData-de-v2.json";
 
 
 const morphologyData = {


### PR DESCRIPTION
## Summary
* [non-user-facing] Fixes the morphology data import in the spec helper after the German file has been renamed.

## Relevant technical choices:

* The German morphology data file has (temporarily) been renamed to `morphologyData-de-v2.json`. The deploy script and the download request in the plugin have been adapted accordingly. This PR also fixes it in the spec.
* Merging into `master` since otherwise builds of `master` will fail with the changed morphology data. Afterwards, `master` needs to be merged into `develop`.
* After having merged this PR please delete the branch `fix-premium-configuration-import` in `YoastSEO.js-premium-configuration`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `yarn test` in the `yoastseo` package and make sure that all specs pass.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
