### PR TITLE
Create TwitterTextContainer component

### DIFF
--- a/packages/social-metadata-previews/src/twitter/TwitterDescription.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterDescription.js
@@ -14,12 +14,14 @@ const TwitterDescription = styled.p`
 	max-height: ${ props => props.isLarge ? "36px" : "55px" };
 	line-height: 18px;
 	overflow: hidden;
-	margin-bottom: 5px;
+	margin: 0;
+	margin-bottom: ${ props => props.hasDescription ? "5px" : "0px" };
 	width: ${ props => props.isLarge ? "476px" : "357px" };
 `;
 
 TwitterDescription.propTypes = {
 	isLarge: PropTypes.bool.isRequired,
+	hasDescription: PropTypes.string.isRequired,
 };
 
 export default TwitterDescription;

--- a/packages/social-metadata-previews/src/twitter/TwitterDescription.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterDescription.js
@@ -21,7 +21,7 @@ const TwitterDescription = styled.p`
 
 TwitterDescription.propTypes = {
 	isLarge: PropTypes.bool.isRequired,
-	hasDescription: PropTypes.string.isRequired,
+	hasDescription: PropTypes.bool.isRequired,
 };
 
 export default TwitterDescription;

--- a/packages/social-metadata-previews/src/twitter/TwitterPreview.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterPreview.js
@@ -3,10 +3,8 @@ import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 
 /* Internal dependencies */
-import TwitterTitle from "./TwitterTitle";
-import TwitterDescription from "./TwitterDescription";
-import TwitterSiteName from "./TwitterSiteName";
 import TwitterImage from "../twitter/TwitterImage";
+import TwitterTextContainer from "../twitter/TwitterTextContainer";
 
 /**
  * Renders a TwitterPreview component.
@@ -19,11 +17,12 @@ const TwitterPreview = ( props ) => {
 	return (
 		<Fragment>
 			<TwitterImage src={ props.src } alt={ props.alt } />
-			<TwitterTitle title={ props.title } />
-			<TwitterDescription isLarge={ props.isLarge }>
-				{ props.description }
-			</TwitterDescription>
-			<TwitterSiteName siteName={ props.siteName } />
+			<TwitterTextContainer
+				title={ props.title }
+				isLarge={ props.isLarge }
+				siteName={ props.siteName }
+				description={ props.description }
+			/>
 		</Fragment>
 	);
 };

--- a/packages/social-metadata-previews/src/twitter/TwitterSiteName.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterSiteName.js
@@ -11,7 +11,7 @@ const TwitterSiteNameWrapper = styled.p`
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	margin-top: 5px;
+	margin: 0;
 `;
 
 /**

--- a/packages/social-metadata-previews/src/twitter/TwitterTextContainer.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterTextContainer.js
@@ -1,0 +1,63 @@
+/* External dependencies */
+import React from "react";
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+/* Internal dependencies */
+import TwitterTitle from "./TwitterTitle";
+import TwitterDescription from "./TwitterDescription";
+import TwitterSiteName from "./TwitterSiteName";
+
+const TwitterTextContainerWrapper = styled.div`
+	background-color: #ffffff;
+	${props => props.isLarge && `
+		width: 504px;
+		height: ${ props.hasDescription ? "102px" : "61px" };
+	`}
+	${props => ! props.isLarge && `
+		width: 378px;
+		height: 120px;
+	`}
+	border-radius: ${ props => props.isLarge ? "0 0 .85714em .85714em" : "0 .85714em .85714em 0" };
+    border-width: 1px;
+    border-style: solid;
+    border-color: #e1e8ed;
+`;
+
+const TwitterTextContent = styled.div`
+	padding: .75em;
+`;
+
+/**
+ * Renders a TwitterTextContainer component.
+ *
+ * @param {object} props The props.
+ *
+ * @returns {React.Element} The rendered element.
+ */
+const TwitterTextContainer = ( props ) => {
+	return (
+		<TwitterTextContainerWrapper isLarge={ props.isLarge } hasDescription={ props.description !== "" }>
+			<TwitterTextContent>
+				<TwitterTitle title={ props.title } />
+				<TwitterDescription isLarge={ props.isLarge } hasDescription={ props.description !== ""}>
+					{ props.description }
+				</TwitterDescription>
+				<TwitterSiteName siteName={ props.siteName } />
+			</TwitterTextContent>
+		</TwitterTextContainerWrapper>
+	);
+};
+
+TwitterTextContainer.propTypes = {
+	title: PropTypes.string.isRequired,
+	isLarge: PropTypes.bool.isRequired,
+	description: PropTypes.string,
+	siteName: PropTypes.string.isRequired,
+};
+
+TwitterTextContainer.defaultProps = {
+	description: "",
+};
+
+export default TwitterTextContainer;

--- a/packages/social-metadata-previews/src/twitter/TwitterTitle.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterTitle.js
@@ -11,7 +11,8 @@ const TwitterTitleWrapper = styled.p`
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	margin-bottom: 2px;
+	margin: 0;
+	margin-bottom: 5px;
 `;
 
 /**


### PR DESCRIPTION
## Summary

Created a TwitterTextContainer component, which contains the title, description and site name.

## Relevant technical choices:

* Added a ternary operator to the styled component `TwitterTextContainerWrapper`
    * Determines whether there is a large or small image and if there is a description.
    * Sets the right height depending on the description being there (`hasDescription`).
    * Sets the right height/ width depending on the image size (`isLarge`).
* Modified margins of `TwitterTitle`, `TwitterSiteName` and `TwitterDescription` to match Twitters styling.
* If there is no description the `margin` of `TwitterDescription` will be 0, because the element is still there, with an empty `<p>`.
* A styled component `TwitterTextContent` has been made to correctly add `padding: .75em;` to the TextContainer. This matches Twitters' padding.
* A border with radius `.85714em` has been added, depending on the image size below or on the right side. The `border-color: #e1e8ed` is the same as Twitters'

Right sizes:
* With description `hasDescription = true`:
    * ..and large image `isLarge = true`: 
         * `width: 504px` 
         * `height: 102px`
![image](https://user-images.githubusercontent.com/42736463/56968542-9f4bf380-6b63-11e9-9e36-242eb41eae16.png)
    * ..and small image `isLarge = false`: 
         * `width: 378px`
         * `height: 120px` 
![image](https://user-images.githubusercontent.com/42736463/56968975-75df9780-6b64-11e9-9554-3f6c948fe8b0.png)
* Without description `hasDescription = false`:
    * ..and large image `isLarge = true`: 
         * `width: 504px`
         * `height: 61px`
![image](https://user-images.githubusercontent.com/42736463/56968802-1bded200-6b64-11e9-825c-9bf99231c399.png)
    * ..and small image `isLarge = false`: 
         * `width: 378px`
         * `height: 120px`
![image](https://user-images.githubusercontent.com/42736463/56969122-cd7e0300-6b64-11e9-9bda-d8b0144eea15.png)

## Good to know

- The alignment of the small image TextContainer will be done in another wrapper, out of scope of this PR.
- The font-family and sizes are a little off, I created a separate issue for that [here](https://github.com/Yoast/javascript/issues/256).
- When there is just one line of description in a `card with large image`, the TwitterTextContainerWrapper should have a `height: 84px`. Perhaps when the truncation has been build (see #157 ), we know if the description has 1 or 2 lines, and we can fix this.  I also created an issue for this [here](https://github.com/Yoast/javascript/issues/257)

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch
* Run `yarn` and `yarn start` in `javascript/apps/components`
* Go to the test env, `0.0.0.0:3333` in my case (not sure if it's the case everywhere)
* Go to `TwitterPreview` in the navigation bar
* Check if all examples match with the screenshots above, and check them with Twitter. https://twitter.com/yoast We have both small and large image cards on our timeline). To check without description on Twitter, remove the description HTML element in Devtools.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #51 
