### PR TITLE
Add feature-flag dependency to yoastseo

### DIFF
--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -67,6 +67,7 @@
   },
   "dependencies": {
     "@wordpress/autop": "^2.0.2",
+    "@yoast/feature-flag": "^0.1.0-rc.1",
     "htmlparser2": "^3.9.2",
     "jed": "^1.1.0",
     "lodash-es": "^4.17.10",


### PR DESCRIPTION
## Summary
* n/a

## Relevant technical choices:

* Adds the feature flag package as a dependency of yoastseo.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `yarn test` in the `yoastseo` package and make sure that all tests pass.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
