### PR TITLE
2360 feature flag site wide analysis

### DIFF
--- a/packages/yoastseo/src/stringProcessing/index.js
+++ b/packages/yoastseo/src/stringProcessing/index.js
@@ -4,6 +4,8 @@ import transliterate from "./transliterate";
 import replaceDiacritics from "./replaceDiacritics";
 import imageInText from "./imageInText";
 import relevantWords from "./relevantWords";
+import getSubheadings from "./getSubheadings";
+import determineProminentWords from "./determineProminentWords";
 import removeHtmlBlocks from "./htmlParser";
 import createWordRegex from "./createWordRegex";
 import wordBoundaries from "../config/wordBoundaries";
@@ -17,6 +19,8 @@ export {
 	relevantWords,
 	removeHtmlBlocks,
 	wordBoundaries,
+	getSubheadings,
+	determineProminentWords,
 
 	// We don't want to expose this, but yoast-components needs it.
 	createWordRegex as __createWordRegex,


### PR DESCRIPTION
## Summary

* [non-user-facing] Exposes some stringProcessing files to be able to use their functions in site-wide analysis in `wordpress-seo-premium`

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Please see https://github.com/Yoast/wordpress-seo-premium/pull/2365

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Not to my knowledge.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2360