### PR TITLE
Re-added the refactored feature flag functionality.

### DIFF
--- a/packages/feature-flag/src/index.js
+++ b/packages/feature-flag/src/index.js
@@ -7,7 +7,10 @@
  * @returns {boolean} `true` when the feature is enabled, `false` if not.
  */
 const isFeatureEnabled = function( featureName ) {
-	return self.wpseoFeatureFlags.includes( featureName );
+	if ( self.wpseoFeatureFlags ) {
+		return self.wpseoFeatureFlags.includes( featureName );
+	}
+	return false;
 };
 
 /**

--- a/packages/feature-flag/src/index.js
+++ b/packages/feature-flag/src/index.js
@@ -7,7 +7,7 @@
  * @returns {boolean} `true` when the feature is enabled, `false` if not.
  */
 const isFeatureEnabled = function( featureName ) {
-	return self.yoastseoEnabledFeatures.includes( featureName );
+	return self.wpseoFeatureFlags.includes( featureName );
 };
 
 /**
@@ -19,14 +19,14 @@ const isFeatureEnabled = function( featureName ) {
  */
 const enableFeatures = function( featureNames ) {
 	// If no features have been enabled yet, initialize the global array.
-	if ( ! self.yoastseoEnabledFeatures ) {
-		self.yoastseoEnabledFeatures = [];
+	if ( ! self.wpseoFeatureFlags ) {
+		self.wpseoFeatureFlags = [];
 	}
 
 	// Check whether the features are already enabled, if not: add them.
 	featureNames.forEach( name => {
-		if ( ! self.yoastseoEnabledFeatures.includes( name ) ) {
-			self.yoastseoEnabledFeatures.push( name );
+		if ( ! self.wpseoFeatureFlags.includes( name ) ) {
+			self.wpseoFeatureFlags.push( name );
 		}
 	} );
 };
@@ -37,7 +37,7 @@ const enableFeatures = function( featureNames ) {
  * @returns {string[]} The list of enabled features.
  */
 const enabledFeatures = function() {
-	return self.yoastseoEnabledFeatures || [];
+	return self.wpseoFeatureFlags || [];
 };
 
 

--- a/packages/feature-flag/src/index.js
+++ b/packages/feature-flag/src/index.js
@@ -1,4 +1,3 @@
-
 /**
  * Checks whether the given feature is enabled.
  *

--- a/packages/feature-flag/src/index.js
+++ b/packages/feature-flag/src/index.js
@@ -1,39 +1,32 @@
-/**
- * Which features are currently enabled.
- *
- * @type {Object<string,string[]>}
- * @private
- */
-const _enabledFeatures = { };
 
 /**
  * Checks whether the given feature is enabled.
  *
  * @param {string} featureName      The name of the feature to check.
- * @param {string} [namespace=""]   An optional namespace to prepend to the feature name. To avoid possible conflicts between packages.
  *
  * @returns {boolean} `true` when the feature is enabled, `false` if not.
  */
-const isFeatureEnabled = function( featureName, namespace = "" ) {
-	return _enabledFeatures[ namespace ].includes( featureName );
+const isFeatureEnabled = function( featureName ) {
+	return self.yoastseoEnabledFeatures.includes( featureName );
 };
 
 /**
  * Enables the features with the given names.
  *
  * @param {string[]} featureNames   A list of names of the features to enable.
- * @param {string} [namespace=""]   An optional namespace to prepend to each feature name. To avoid possible conflicts between packages.
  *
  * @returns {void}
  */
-const enableFeatures = function( featureNames, namespace = "" ) {
+const enableFeatures = function( featureNames ) {
+	// If no features have been enabled yet, initialize the global array.
+	if ( ! self.yoastseoEnabledFeatures ) {
+		self.yoastseoEnabledFeatures = [];
+	}
+
 	// Check whether the features are already enabled, if not: add them.
 	featureNames.forEach( name => {
-		// Create the namespace if it does not exist yet.
-		_enabledFeatures[ namespace ] = _enabledFeatures[ namespace ] || [];
-
-		if ( ! _enabledFeatures[ namespace ].includes( name ) ) {
-			_enabledFeatures[ namespace ].push( name );
+		if ( ! self.yoastseoEnabledFeatures.includes( name ) ) {
+			self.yoastseoEnabledFeatures.push( name );
 		}
 	} );
 };
@@ -41,12 +34,10 @@ const enableFeatures = function( featureNames, namespace = "" ) {
 /**
  * Returns the list of enabled features.
  *
- * @param {string} [namespace=""] An optional namespace. If not provided, only the features on the global namespace are returned.
- *
  * @returns {string[]} The list of enabled features.
  */
-const enabledFeatures = function( namespace = "" ) {
-	return _enabledFeatures[ namespace ] || [];
+const enabledFeatures = function() {
+	return self.yoastseoEnabledFeatures || [];
 };
 
 


### PR DESCRIPTION
## Summary

* [not-user-facing] Re-adds the refactored feature flag functionality which accidentally got overwritten.

## Relevant technical choices:

* The refactored feature flag package accidentally got overwritten by the old version by a rename and merge from `develop`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

**Reproducing the bug**
* Checkout `feature/internal-linking`.
* Make sure that the `improvedInternalLinking` feature flag is enabled.
   * In other words, in your `wp-config.php` file, this line should exist:
     ```php
     define( 'YOAST_SEO_ENABLED_FEATURES', 'improvedInternalLinking' );
     ```
* Open a post.
* Open the _Insights_ collapsible inside of the metabox.
* See the post editor crash.

**Checking the fix**
* Checkout this branch (`fix-reverting-of-refactored-feature-toggle`)
* Open a post.
* Open the _Insights_ collapsible inside of the metabox.
* The collapsible should show a list of prominent, single words.

* Please check taxonomy pages as well!

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Changes should be confined to the javascript packages that currently use the feature flag functionality, so `yoastseo` and `components`.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
