### PR TITLE
Change German morphology data import in spec helper for German v3

### DIFF
--- a/packages/yoastseo/spec/specHelpers/getMorphologyData.js
+++ b/packages/yoastseo/spec/specHelpers/getMorphologyData.js
@@ -1,5 +1,5 @@
 import en from "../../premium-configuration/data/morphologyData.json";
-import de from "../../premium-configuration/data/morphologyData-de-v2.json";
+import de from "../../premium-configuration/data/morphologyData-de-v3.json";
 
 
 const morphologyData = {


### PR DESCRIPTION
## Summary
* [non-user-facing] Fixes the morphology data import in the spec helper after the German file has been renamed from `v2` to `v3`.

## Relevant technical choices:

* The German morphology data file has been renamed from `morphologyData-de-v2.json` to `morphologyData-de-v3.json`. The deploy script and the download request in the plugin have been adapted accordingly. This PR also fixes it in the spec.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `yarn test` in the `yoastseo` package and make sure that all specs pass.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
