### PR TITLE
i18n: split translation strings to reduce the number of strings

### DIFF
--- a/packages/yoastseo/src/config/presenter.js
+++ b/packages/yoastseo/src/config/presenter.js
@@ -8,25 +8,25 @@ export default function( i18n ) {
 		feedback: {
 			className: "na",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "Feedback" ),
-			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: Has feedback" ),
+			fullText: i18n.dgettext( "js-text-analysis", "Content optimization:" ) + ' ' + i18n.dgettext( "js-text-analysis", "Has feedback" ),
 			screenReaderReadabilityText: "",
 		},
 		bad: {
 			className: "bad",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "Needs improvement" ),
-			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: Needs improvement" ),
+			fullText: i18n.dgettext( "js-text-analysis", "Content optimization:" ) + ' ' + i18n.dgettext( "js-text-analysis", "Needs improvement" ),
 			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "Needs improvement" ),
 		},
 		ok: {
 			className: "ok",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "OK SEO score" ),
-			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: OK SEO score" ),
+			fullText: i18n.dgettext( "js-text-analysis", "Content optimization:" ) + ' ' + i18n.dgettext( "js-text-analysis", "OK SEO score" ),
 			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "OK" ),
 		},
 		good: {
 			className: "good",
 			screenReaderText: i18n.dgettext( "js-text-analysis", "Good SEO score" ),
-			fullText: i18n.dgettext( "js-text-analysis", "Content optimization: Good SEO score" ),
+			fullText: i18n.dgettext( "js-text-analysis", "Content optimization:" ) + ' ' + i18n.dgettext( "js-text-analysis", "Good SEO score" ),
 			screenReaderReadabilityText: i18n.dgettext( "js-text-analysis", "Good" ),
 		},
 	};


### PR DESCRIPTION
## Summary

![yoast29](https://user-images.githubusercontent.com/576623/57283983-fb110200-70b8-11e9-86de-d3c0e4979fbb.png)

Old translation strings:

* `Content optimization: Has feedback`
* `Content optimization: Needs improvement`
* `Content optimization: OK SEO score`
* `Content optimization: Good SEO score`

New translation strings:

* `Content optimization:` - **New**
* `Has feedback` - **New**
* `Needs improvement` - **Already Exist**
* `OK SEO score` - **Already Exist**
* `Good SEO score` - **Already Exist**

This PR replaces 4 translation strings with 2 strings by splitting them and using existing translation strings.

I did the same in https://github.com/Yoast/wordpress-seo/pull/12781, replacing 19 strings with only 3.


## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
