### PR TITLE
Added left-margin to the marker button

### DIFF
--- a/packages/analysis-report/src/AnalysisResult.js
+++ b/packages/analysis-report/src/AnalysisResult.js
@@ -17,7 +17,7 @@ const ScoreIcon = styled( SvgIcon )`
 `;
 
 const AnalysisResultText = styled.p`
-	margin: 0 8px 0 0;
+	margin: 0 16px 0 0;
 	flex: 1 1 auto;
 `;
 

--- a/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -43,7 +43,7 @@ exports[`the AnalysisResult component matches the snapshot 1`] = `
 }
 
 .c2 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -145,7 +145,7 @@ exports[`the AnalysisResult component with disabled buttons matches the snapshot
 }
 
 .c2 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -223,7 +223,7 @@ exports[`the AnalysisResult component with hidden buttons matches the snapshot 1
 }
 
 .c2 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;

--- a/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/AnalysisResultTest.js.snap
@@ -301,7 +301,7 @@ exports[`the AnalysisResult component with html in the text matches the snapshot
 }
 
 .c2 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;

--- a/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
+++ b/packages/analysis-report/tests/__snapshots__/ContentAnalysisTest.js.snap
@@ -168,7 +168,7 @@ exports[`ContentAnalysis the ContentAnalysis component with disabled buttons mat
 }
 
 .c12 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -787,7 +787,7 @@ exports[`ContentAnalysis the ContentAnalysis component with hidden buttons match
 }
 
 .c12 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -1382,7 +1382,7 @@ exports[`ContentAnalysis the ContentAnalysis component with specified header lev
 }
 
 .c12 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -2025,7 +2025,7 @@ exports[`ContentAnalysis the ContentAnalysis component without language notice m
 }
 
 .c12 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -2668,7 +2668,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and cons
 }
 
 .c12 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -3145,7 +3145,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems and impr
 }
 
 .c12 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -3622,7 +3622,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems matches 
 }
 
 .c12 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;
@@ -4170,7 +4170,7 @@ exports[`ContentAnalysis the ContentAnalysis component without problems, improve
 }
 
 .c12 {
-  margin: 0 8px 0 0;
+  margin: 0 16px 0 0;
   -webkit-flex: 1 1 auto;
   -ms-flex: 1 1 auto;
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
Added a margin of 16px to the left of the marker button, so the link and button are not too close.

_Minimal margin before_ "Try" _pops to the next line:_
**Before**
![image](https://user-images.githubusercontent.com/42736463/57776073-e36ff400-771e-11e9-8a28-e641b6094bdd.png)

**After**
![image](https://user-images.githubusercontent.com/42736463/57776031-c4716200-771e-11e9-9128-2ae8e3a991e1.png)

<!--
Copy and fill in the following template as many times as there are individual changes.
-->
  * Package(s) involved:
<!-- Please write only one package, except when the same change is applied to multiple packages. -->
Analysis-report
  * Should the change be included in the package changelog?
    * [x] No
    * [ ] Yes
  * Should the change be included in one or more plugin changelogs?
    * [x] No
    * [ ] Free
    * [ ] Premium
    * [ ] Other (please specify)
  * Package changelog item (if applicable): 
  * Plugin changelog item (if applicable): 

## Relevant technical choices:

* Changed the `right-margin` of the `AnalysisResultsText` styled component, from `8px` to `16px`. This matches the `padding` of the `Readability Analysis` box, which is also `16px`. The marker button now has a margin of `16px` on both sides.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new post in the text editor
* Input some text so a marker button shows up next to an analysis results text
* Check the following in the Gutenburg sidebar AND the metabox below the post
* Check (with DevTools) if the right-margin of that text is 16px
* Check whether the button is still in the same spot and if nothing unusual happened to the styling. (see screenshot '**After**' above for correct styling).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Readability analysis

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/12608
