### PR TITLE
Fix content analysis app morphology data imports

### DIFF
--- a/apps/content-analysis/src/utils/getMorphologyData.js
+++ b/apps/content-analysis/src/utils/getMorphologyData.js
@@ -12,7 +12,7 @@ function loadLocalMorphologyData() {
 		// eslint-disable-next-line global-require
 		data = require( "../../../../packages/yoastseo/premium-configuration/data/morphologyData.json" );
 		// eslint-disable-next-line global-require
-		dataDe = require( "../../../../packages/yoastseo/premium-configuration/data/morphologyData-de.json" );
+		dataDe = require( "../../../../packages/yoastseo/premium-configuration/data/morphologyData-de-v3.json" );
 	} catch ( error ) {
 		// Falling back to empty data.
 	}

--- a/packages/yoastseo/spec/stringProcessing/determineProminentWordsGermanSpec.js
+++ b/packages/yoastseo/spec/stringProcessing/determineProminentWordsGermanSpec.js
@@ -1,6 +1,8 @@
 import ProminentWord from "../../src/values/ProminentWord";
 import { getProminentWords } from "../../src/stringProcessing/determineProminentWords";
-import { de as morphologyData } from "../../premium-configuration/data/morphologyData-de-v2.json";
+import getMorphologyData from "../specHelpers/getMorphologyData";
+
+const morphologyData = getMorphologyData( "de" ).de;
 
 describe( "gets German prominent words", function() {
 	it( "returns prominent words", function() {


### PR DESCRIPTION
## Summary
* [non-user-facing] Fixes the bug when the morphology data currently available in `feature/internal-linking` `premium-configuration` was not imported correctly to the `content-analysis` app.

<!--
Copy and fill in the following template as many times as there are individual changes.
-->
  * Package(s) involved: yoastseo
<!-- Please write only one package, except when the same change is applied to multiple packages. -->
  * Should the change be included in the package changelog?
    * [x] No
    * [ ] Yes
  * Should the change be included in one or more plugin changelogs?
    * [x] No
    * [ ] Free
    * [ ] Premium
    * [ ] Other (please specify)
  * Package changelog item (if applicable): 
  * Plugin changelog item (if applicable): 

  * Package(s) involved: components
<!-- Please write only one package, except when the same change is applied to multiple packages. -->
  * Should the change be included in the package changelog?
    * [x] No
    * [ ] Yes
  * Should the change be included in one or more plugin changelogs?
    * [x] No
    * [ ] Free
    * [ ] Premium
    * [ ] Other (please specify)
  * Package changelog item (if applicable): 
  * Plugin changelog item (if applicable): 

## Relevant technical choices:

* We need to improve our procedure with updating the version numbers for morphologyData files so that it does not impact the `app` functioning. @manuelaugustin Could you please add this point to your checklist?

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check out the branch
* Run `yarn` in the `root`
* Run `yarn start` in the `apps/content-analysis`
* Make sure you get no errors in the console that concern `morphologyData` imports failures
* Note that you are likely to get a `components` error that affect the `Results` collapsible. This is a separate problem and I created [an issue](https://github.com/Yoast/javascript/issues/286) about it.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * content-analysis app

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
