### PR TITLE
CSS autoprefixer drop support for IE less than 11.

### DIFF
--- a/packages/yoast-components/grunt/config/postcss.js
+++ b/packages/yoast-components/grunt/config/postcss.js
@@ -4,7 +4,7 @@ var autoprefixer = require( "autoprefixer" );
 module.exports = {
 	options: {
 		processors: [
-			autoprefixer( { browsers: "last 2 versions, IE >= 9" } ),
+			autoprefixer( { browsers: "last 2 versions, IE >= 11" } ),
 		],
 	},
 	build: {

--- a/packages/yoast-social-previews/grunt/config/postcss.js
+++ b/packages/yoast-social-previews/grunt/config/postcss.js
@@ -4,7 +4,7 @@ var autoprefixer = require( "autoprefixer" );
 module.exports = {
 	options: {
 		processors: [
-			autoprefixer( { browsers: "last 2 versions, IE >= 9" } ),
+			autoprefixer( { browsers: "last 2 versions, IE >= 11" } ),
 		],
 	},
 	build: {

--- a/packages/yoastseo/grunt/config/postcss.js
+++ b/packages/yoastseo/grunt/config/postcss.js
@@ -4,7 +4,7 @@ var autoprefixer = require( "autoprefixer" );
 module.exports = {
 	options: {
 		processors: [
-			autoprefixer( { browsers: "last 2 versions, IE >= 9" } ),
+			autoprefixer( { browsers: "last 2 versions, IE >= 11" } ),
 		],
 	},
 	build: {


### PR DESCRIPTION
## Summary

* Updated the CSS autoprefixer configuration to drop support for old Internet Explorer versions.

  * Package(s) involved: yoast-components, yoast-social-previews, yoastseo
  * Should the change be included in the package changelog?
    * [ ] No
    * [x] Yes
  * Should the change be included in one or more plugin changelogs?
    * [x] No
    * [ ] Free
    * [ ] Premium
    * [ ] Other (please specify)
  * Package changelog item (if applicable): Updated the CSS autoprefixer configuration to drop support for old Internet Explorer versions.
  * Plugin changelog item (if applicable): 


## Test instructions
No special testing necessary. This change saves a few KB in the built CSS files.


Fixes #294