### PR TITLE
Make excerpt, page title, SEO title and metadescription without replacements available for prominent words.

### DIFF
--- a/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
+++ b/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
@@ -50,8 +50,8 @@ describe( "relevantWords research", function() {
 			"Bing and Google’s indices. How does this work? When you connect your site to MyYoast...", {
 			keyword: "live indexing Yoast SEO",
 			synonyms: "live index",
-			title: "Amazing title",
-			description: "Awesome metadescription",
+			titleWithoutReplacements: "Amazing title",
+			descriptionWithoutReplacements: "Awesome metadescription",
 			locale: "en_EN",
 		} );
 

--- a/packages/yoastseo/spec/values/paperSpec.js
+++ b/packages/yoastseo/spec/values/paperSpec.js
@@ -67,6 +67,42 @@ describe( "Paper", function() {
 			expect( paper.hasTitleWidth() ).toBe( true );
 		} );
 
+		it( "returns the SEO title without replacement variables", function() {
+			const attributes = {
+				titleWithoutReplacements: "title without replacements",
+			};
+			const paper = new Paper( "text", attributes );
+			expect( paper.hasTitleWithoutReplacements() ).toBe( true );
+			expect( paper.getTitleWithoutReplacements() ).toBe( "title without replacements" );
+		} );
+
+		it( "returns the meta description without replacement variables", function() {
+			const attributes = {
+				descriptionWithoutReplacements: "description without replacements",
+			};
+			const paper = new Paper( "text", attributes );
+			expect( paper.hasDescriptionWithoutReplacements() ).toBe( true );
+			expect( paper.getDescriptionWithoutReplacements() ).toBe( "description without replacements" );
+		} );
+
+		it( "returns the post / page title", function() {
+			const attributes = {
+				pageTitle: "page title",
+			};
+			const paper = new Paper( "text", attributes );
+			expect( paper.hasPageTitle() ).toBe( true );
+			expect( paper.getPageTitle() ).toBe( "page title" );
+		} );
+
+		it( "returns the excerpt", function() {
+			const attributes = {
+				excerpt: "excerpt",
+			};
+			const paper = new Paper( "text", attributes );
+			expect( paper.hasExcerpt() ).toBe( true );
+			expect( paper.getExcerpt() ).toBe( "excerpt" );
+		} );
+
 		it( "returns nothing", function() {
 			var paper = new Paper( "text" );
 			expect( paper.hasTitle() ).toBe( false );

--- a/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
+++ b/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
@@ -27,8 +27,10 @@ function getProminentWordsForInternalLinking( paper, researcher ) {
 	const attributes = [
 		paper.getKeyword(),
 		paper.getSynonyms(),
-		paper.getTitle(),
-		paper.getDescription(),
+		paper.getTitleWithoutReplacements(),
+		paper.getDescriptionWithoutReplacements(),
+		paper.getPageTitle(),
+		paper.getExcerpt(),
 		subheadings.join( " " ),
 	];
 

--- a/packages/yoastseo/src/values/Paper.js
+++ b/packages/yoastseo/src/values/Paper.js
@@ -200,6 +200,70 @@ Paper.prototype.getPermalink = function() {
 	return this._attributes.permalink;
 };
 
+/**
+ * Check whether the SEO title (without replacements like the website name or the current data) is available.
+ * @returns {boolean} Returns true if the Paper has a title without replacements.
+ */
+Paper.prototype.hasTitleWithoutReplacements = function() {
+	return this._attributes.titleWithoutReplacements !== "";
+};
+
+/**
+ * Returns the SEO title (without replacements like the website name or the current data).
+ * @returns {string} Returns the title without replacements.
+ */
+Paper.prototype.getTitleWithoutReplacements = function() {
+	return this._attributes.titleWithoutReplacements;
+};
+
+/**
+ * Check whether the meta description (without replacements like the website name or the current data) is available.
+ * @returns {boolean} Returns true if the Paper has a title without replacements.
+ */
+Paper.prototype.hasDescriptionWithoutReplacements = function() {
+	return this._attributes.descriptionWithoutReplacements !== "";
+};
+
+/**
+ * Returns the meta description (without replacements like the website name or the current data).
+ * @returns {string} Returns the title without replacements.
+ */
+Paper.prototype.getDescriptionWithoutReplacements = function() {
+	return this._attributes.descriptionWithoutReplacements;
+};
+
+/**
+ * Check whether the excerpt is available.
+ * @returns {boolean} Returns true if the Paper has a title without replacements.
+ */
+Paper.prototype.hasExcerpt = function() {
+	return this._attributes.excerpt !== "";
+};
+
+/**
+ * Returns the excerpt.
+ * @returns {string} Returns the title without replacements.
+ */
+Paper.prototype.getExcerpt = function() {
+	return this._attributes.excerpt;
+};
+
+/**
+ * Check whether the title of the post or page is available.
+ * @returns {boolean} Returns true if the Paper has a title without replacements.
+ */
+Paper.prototype.hasPageTitle = function() {
+	return this._attributes.pageTitle !== "";
+};
+
+/**
+ * Returns the title of the post or page.
+ * @returns {string} Returns the title without replacements.
+ */
+Paper.prototype.getPageTitle = function() {
+	return this._attributes.pageTitle;
+};
+
 /*
  * Serializes the Paper instance to an object.
  *

--- a/packages/yoastseo/src/values/Paper.js
+++ b/packages/yoastseo/src/values/Paper.js
@@ -20,16 +20,20 @@ var defaultAttributes = {
 /**
  * Construct the Paper object and set the keyword property.
  *
- * @param {string} text                     The text to use in the analysis.
- * @param {object} [attributes]             The object containing all attributes.
- * @param {Object} [attributes.keyword]     The main keyword.
- * @param {Object} [attributes.synonyms]    The main keyword's synonyms.
- * @param {Object} [attributes.title]       The SEO title.
- * @param {Object} [attributes.description] The SEO description.
- * @param {Object} [attributes.titleWidth]  The width of the title in pixels.
- * @param {Object} [attributes.url]         The slug.
- * @param {Object} [attributes.permalink]   The base url + slug.
- * @param {Object} [attributes.locale]      The locale.
+ * @param {string} text                                        The text to use in the analysis.
+ * @param {object} [attributes]                                The object containing all attributes.
+ * @param {Object} [attributes.keyword]                        The main keyword.
+ * @param {Object} [attributes.synonyms]                       The main keyword's synonyms.
+ * @param {Object} [attributes.title]                          The SEO title.
+ * @param {Object} [attributes.description]                    The SEO description.
+ * @param {Object} [attributes.titleWidth]                     The width of the title in pixels.
+ * @param {Object} [attributes.url]                            The slug.
+ * @param {Object} [attributes.permalink]                      The base url + slug.
+ * @param {Object} [attributes.locale]                         The locale.
+ * @param {string} [attributes.titleWithoutReplacements]       The SEO title, without any replacement variables.
+ * @param {string} [attributes.descriptionWithoutReplacements] The SEO description, without any replacement variables.
+ * @param {string} [attributes.pageTitle]                      The title of this post, page or article.
+ * @param {string} [attributes.excerpt]                        The excerpt.
  *
  * @constructor
  */


### PR DESCRIPTION
## Summary
The excerpt, page title, SEO title without replacements and metadescription without replacements are now used when generating prominent words for internal linking.
<!--
Copy and fill in the following template as many times as there are individual changes.
-->
  * Package(s) involved: YoastSEO.js
  * Should the change be included in the package changelog?
    * [x] No
    * [ ] Yes
  * Should the change be included in one or more plugin changelogs?
    * [ ] No
    * [ ] Free
    * [ ] Premium
    * [ ] Other (please specify)

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
**Note**: This PR needs to be tested in tandem with the `premium/2401-seo-title-without-replacevars-for-analysis` branch in `wordpress-seo`.


This PR can be tested by following these steps:

We need to use Yoast SEO Premium, since it contains the internal linking suggestion functionality.
* Build `wordpress-seo-premium/premium` by running `grunt build` inside the directory in your terminal.
* Start your local `wordpress-seo` development environment.
   * **Note**: Yoast SEO Free, not Premium! Make sure that you are on the `premium/2401-seo-title-without-replacevars-for-analysis` branch in Free.
* Make sure that the necessary feature flags are set in your `wp-config.php`.

### Test if the excerpt is used when generating prominent words for internal linking.
* Open a post.
* Add a text to the excerpt with many repeated words.
  * A text like `excerpt excerpt excerpt excerpt`.
     * To make sure that `excerpt` is considered prominent.
  * The excerpt editor can be found in the sidebar of the Gutenberg editor.
     * On the 'Document' tab, inside of the 'Excerpt' collapsible.
* Open the browser's development console.
* You should see results of the prominent words for internal linking research in the form: 
  ```
  AnalysisWebWorker outgoing: runResearch:done 58 (47) [ProminentWord, ProminentWord, ProminentWord, ...
  ```
   * **Note**: there are two sorts of results that look like this, one for insights with always 5 prominent words, and one for internal linking with more words. You should check the internal linking one.
* Check the results. It should have `excerpt` as a prominent word.
  * The amount of occurrences should be the same as the number of `excerpt`s in the excerpt times 3.

### Test if the post's title is used when generating prominent words for internal linking.
* Follow the same steps as in _Test if the excerpt is used..._
  * However, use the post's title instead of the excerpt.

### Test if replacement variables are not included in the prominent words.
* Add a couple of replacement variables, like `%%title%%` and `%%sitename%%`, to the SEO title and meta description.
* Check the results of the prominent words for internal linking research inside the browser's development console.
  * It should not contain the replacement variables.
  * (If they do: make sure that you have not added them in your post, title or excerpt!)


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #Yoast/wordpress-seo-premium#2401
