### PR TITLE
2432 bump minimum number of word occurrences for prominent word for internal linking.

### DIFF
--- a/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
+++ b/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
@@ -9,13 +9,13 @@ const morphologyData = getMorphologyData( "en" );
 
 describe( "relevantWords research", function() {
 	it( "does not break if no morphology support is added for the language", function() {
-		const paper = new Paper( "texte et texte", { locale: "fr_FR" } );
+		const paper = new Paper( "texte et texte et texte et texte", { locale: "fr_FR" } );
 
 		const researcher = new Researcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
 
 		const expected = [
-			new ProminentWord( "texte", "texte", 2 ),
+			new ProminentWord( "texte", "texte", 4 ),
 		];
 
 		const words = prominentWordsResearch( paper, researcher );
@@ -25,14 +25,15 @@ describe( "relevantWords research", function() {
 
 	it( "returns relevant words from the text alone if no attributes are available", function() {
 		const paper = new Paper( "Here are a ton of syllables. Syllables are very important. I think the syllable " +
-			"combinations are even more important. Syllable combinations for the win!" );
+			"combinations are even more important. Syllable combinations for the win! Combinations are awesome. " +
+			"So many combinations!" );
 
 		const researcher = new Researcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
 
 		const expected = [
+			new ProminentWord( "combinations", "combination", 4 ),
 			new ProminentWord( "syllable", "syllable", 4 ),
-			new ProminentWord( "combinations", "combination", 2 ),
 		];
 
 		const words = prominentWordsResearch( paper, researcher );
@@ -74,20 +75,6 @@ describe( "relevantWords research", function() {
 			// The stems "seo" and "yoast" occur once in the text and once in the attributes: 1 + 1 * 3 = 4
 			new ProminentWord( "SEO", "seo", 4 ),
 			new ProminentWord( "yoast", "yoast", 4 ),
-			// The stems "amaze", "metadescription", "subhead", and "title" occur once in the attributes: 0 + 1 * 3 = 3
-			new ProminentWord( "amazing", "amaze", 3 ),
-			new ProminentWord( "metadescription", "metadescription", 3 ),
-			new ProminentWord( "subheading", "subhead", 3 ),
-			new ProminentWord( "title", "title", 3 ),
-			// All following stems occur twice in the text each: 2 + 0 * 3 = 2
-			new ProminentWord( "allow", "allow", 2 ),
-			new ProminentWord( "bing", "bing", 2 ),
-			new ProminentWord( "connect", "connect", 2 ),
-			new ProminentWord( "google", "google", 2 ),
-			new ProminentWord( "myyoast", "myyoast", 2 ),
-			new ProminentWord( "site", "site", 2 ),
-			new ProminentWord( "update", "update", 2 ),
-			new ProminentWord( "work", "work", 2 ),
 		];
 
 		const words = prominentWordsResearch( paper, researcher );

--- a/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
+++ b/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
@@ -51,7 +51,7 @@ function getProminentWordsForInternalLinking( paper, researcher ) {
 	 * Return the 100 top items from the collapsed and sorted list. The number is picked deliberately to prevent larger
 	 * articles from getting too long of lists.
 	 */
-	return take( filterProminentWords( collapsedWords, 2 ), 100 );
+	return take( filterProminentWords( collapsedWords, 4 ), 100 );
 }
 
 

--- a/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
+++ b/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
@@ -50,6 +50,9 @@ function getProminentWordsForInternalLinking( paper, researcher ) {
 	/*
 	 * Return the 100 top items from the collapsed and sorted list. The number is picked deliberately to prevent larger
 	 * articles from getting too long of lists.
+	 *
+	 * Minimum required occurrences set to 4 in order to avoid premature suggestions of words fro  the paper attributes.
+	 * These get a times-3 boost and would therefore be prominent with just 1 occurrence.
 	 */
 	return take( filterProminentWords( collapsedWords, 4 ), 100 );
 }


### PR DESCRIPTION
## Summary
Bumps the minimum number of word occurrences from 2 to 4 (when extracting prominent words for internal linking).
<!--
Copy and fill in the following template as many times as there are individual changes.
-->
  * Package(s) involved:
<!-- Please write only one package, except when the same change is applied to multiple packages. -->
  * Should the change be included in the package changelog?
    * [ ] No
    * [x] Yes
  * Should the change be included in one or more plugin changelogs?
    * [x] No
    * [ ] Free
    * [ ] Premium
    * [ ] Other (please specify)
  * Package changelog item (if applicable): Behind internal linking feature flag (currently disabled by default): Bumps the minimum number of required word occurrences from 2 to 4 (when extracting prominent words for internal linking).
  * Plugin changelog item (if applicable): 

## Relevant technical choices:

* Updated the test for `getProminentWordsForInternalLinking` to match the changes.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Test if no internal linking suggestions are generated for empty posts.

#### Reproduce the bug.

* Checkout the `feature/internal-linking` branch in this repository.
* Create a new (and thus empty) post.
* Wait 15 seconds.
* You should see suggestions inside the internal linking metabox / sidebar.
* Open the developer console.
* You should see an incoming `runResearch`-request to the `AnalysisWebWorker`.
   * Note its ID-number.
* You should see an outgoing `runResearch:done`-request from the `AnalysisWebWorker` with the same ID-number as you noted down in the previous step.
   * Check that it contains a list of `ProminentWord`s.

#### Check if the bug has been fixed.

* Checkout this branch (`2432-avoid-premature-internal-linking-suggestions`).
* Create a new (and thus empty) post.
* Wait 15 seconds.
* You should **not** see suggestions inside the internal linking metabox / sidebar.
* Open the developer console.
* You should see an incoming `runResearch`-request to the `AnalysisWebWorker`.
   * Note its ID-number.
* You should see an outgoing `runResearch:done`-request from the `AnalysisWebWorker` with the same ID-number as you noted down in the previous step.
   * Check that it contains an empty list.

### Check if all prominent words with less than 4 occurrences are filtered out.

* Checkout this branch (`2432-avoid-premature-internal-linking-suggestions`).
* Open a post.
* Wait 15 seconds.
* You should see an incoming `runResearch`-request to the `AnalysisWebWorker`.
   * Note its ID-number.
* You should see an outgoing `runResearch:done`-request from the `AnalysisWebWorker` with the same ID-number as you noted down in the previous step.
   * Check that it contains a list of `ProminentWord`s, and that all of them have 4 or more occurrences. 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * The impact should be small, since this only changes the prominent words for internal linking generation. 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2432
