### PR TITLE
Add missing, but required, dependencies

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@wordpress/a11y": "^1.1.3",
     "@wordpress/i18n": "^1.2.3",
+    "@yoast/feature-flag": "^0.1.0-rc.1",
     "@yoast/helpers": "^0.4.0-rc.2",
     "@yoast/style-guide": "^0.4.0-rc.1",
     "interpolate-components": "^1.1.1",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -20,7 +20,8 @@
     "@wordpress/i18n": "^1.2.3",
     "prop-types": "^15.7.2",
     "styled-components": "^2.4.1",
-    "whatwg-fetch": "1.1.1"
+    "whatwg-fetch": "1.1.1",
+    "wicked-good-xpath": "^1.3.0"
   },
   "peerDependencies": {
     "react": "^16.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1903,6 +1903,11 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.1.tgz#5c85d662f76fa1d34575766c5dcd6615abcd30d8"
   integrity sha512-FZdkNBDqBRHKQ2MEbSC17xnPFOhZxeJ2YGSfr2BKf3sujG49Qe3bB+rGCwQfIaA7WHnGeGkSijX4FuBCdrzW/g==
 
+"@yoast/feature-flag@^0.1.0-rc.1":
+  version "0.1.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@yoast/feature-flag/-/feature-flag-0.1.0-rc.1.tgz#0ce23069c1f6e34f1f5105ebe6934efbbb8bc16e"
+  integrity sha512-jrdans/PMgGULhfdWi4hiTf7ur1jz1Kj+4omv070T6W4vqZuJ1v3ahZiBfvCiNPjC4KJm72AkaLiTbNhzukZIQ==
+
 JSONStream@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.10.0.tgz#74349d0d89522b71f30f0a03ff9bd20ca6f12ac0"


### PR DESCRIPTION
## Summary

Added two missing dependencies that are required but not included: @yoast/feature-flag to components, wicked-good-xpath to helpers.

  * Package(s) involved:
-components
-helpers

  * Should the change be included in the package changelog?
    * [ ] No
    * [x] Yes
  * Should the change be included in one or more plugin changelogs?
    * [x] No
    * [ ] Free
    * [ ] Premium
    * [ ] Other (please specify)
  * Package changelog item (if applicable): 
  * Plugin changelog item (if applicable): 

## Test instructions

This PR can be tested by following these steps:

* The original issue was the following when using the monorepo in myyoast: 
```
Error in ./~/@yoast/components/KeywordSuggestions.js
Module not found: '@yoast/feature-flag' in /Users/dieterschalk/Code/Yoast/my-yoast/client/node_modules/@yoast/components

 @ ./~/@yoast/components/KeywordSuggestions.js 21:19-49

Error in ./~/@yoast/components/~/@yoast/helpers/getFeed.js
Module not found: 'wicked-good-xpath' in /Users/dieterschalk/Code/Yoast/my-yoast/client/node_modules/@yoast/components/node_modules/@yoast/helpers

 @ ./~/@yoast/components/~/@yoast/helpers/getFeed.js 10:23-51
```

Technically this could be reproduced but it's very specific. A better way to test may be to yarn link this branch to an installation with wordpress-seo and make sure nothing changes. In wordpress-seo the error did not appear because it already included the packages itself. 

Also make sure there are no build errors.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
