### PR TITLE
Add Dutch adjective suffixes to make forms

### DIFF
--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -116,6 +116,6 @@
     }
   },
   "yoast": {
-    "premiumConfiguration": "feature/Dutch-morphology"
+    "premiumConfiguration": ""
   }
 }

--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -116,6 +116,6 @@
     }
   },
   "yoast": {
-    "premiumConfiguration": ""
+    "premiumConfiguration": "46-dutch-morphology-data"
   }
 }

--- a/packages/yoastseo/spec/morphology/dutch/addAdjectiveSuffixesSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/addAdjectiveSuffixesSpec.js
@@ -1,0 +1,188 @@
+import {
+	getSuffixesInflected,
+	getSuffixesComparative,
+	getSuffixesSuperlative,
+	addPartitiveSuffix,
+	addInflectedSuffix,
+	addComparativeSuffixes,
+	addSuperlativeSuffixes,
+	addAllAdjectiveSuffixes,
+} from "../../../src/morphology/dutch/addAdjectiveSuffixes";
+
+import getMorphologyData from "../../specHelpers/getMorphologyData";
+
+const morphologyDataNL = getMorphologyData( "nl" ).nl;
+
+describe( "Test for getting the right comparative suffixes for various types of adjectives", () => {
+	/*
+	 *In practice, the -e ending will ususally be deleted by the stemmer. In that case, the adjective
+	 * will receive the -er- endings, meaning that the -e will be restored.
+	 */
+	it( "returns comparative -r- suffixes for a stem that ends with a consonant and -e", () => {
+		expect( getSuffixesComparative( morphologyDataNL.adjectives, "beige" ) ).toEqual(
+			[ "r", "rs", "re", "res" ]
+		);
+	} );
+
+	it( "returns comparative -der- suffixes for a stem that ends with -r", () => {
+		expect( getSuffixesComparative( morphologyDataNL.adjectives, "lekker" ) ).toEqual(
+			[ "der", "ders", "dere", "deres" ]
+		);
+	} );
+
+	it( "returns comparative -ër- suffixes for a stem that ends with a vowel + e", () => {
+		expect( getSuffixesComparative( morphologyDataNL.adjectives, "tevree" ) ).toEqual(
+			[ "ër", "ërs", "ëre", "ëres" ]
+		);
+	} );
+
+	it( "returns comparative -er- suffixes for a stem that has an ending not defined in any of the other groups ", () => {
+		expect( getSuffixesComparative( morphologyDataNL.adjectives, "bang" ) ).toEqual(
+			[ "er", "ers", "ere", "eres" ]
+		);
+	} );
+} );
+
+describe( "Test for getting the right superlative suffixes for various types of adjectives", () => {
+	it( "returns superlative -t- suffixes for a stem that ends with an -s", () => {
+		expect( getSuffixesSuperlative( morphologyDataNL.adjectives, "boos" ) ).toEqual(
+			[ "t", "te" ]
+		);
+	} );
+
+	it( "returns superlative -st- suffixes for a stem that ends with a character other than s", () => {
+		expect( getSuffixesSuperlative( morphologyDataNL.adjectives, "groen" ) ).toEqual(
+			[ "st", "ste" ]
+		);
+	} );
+} );
+
+describe( "Test for getting the right inflected suffixes for various types of adjectives", () => {
+	it( "returns inflected -ë- suffix for a stem that ends with a vowel followed by e", () => {
+		expect( getSuffixesInflected( morphologyDataNL.adjectives, "tevree" ) ).toEqual(
+			"ë"
+		);
+	} );
+
+	it( "returns inflected -e- suffix for a stem that has an ending other than vowel followed by e", () => {
+		expect( getSuffixesInflected( morphologyDataNL.adjectives, "grappig" ) ).toEqual(
+			"e"
+		);
+	} );
+} );
+
+describe( "Adds adjective suffixes", () => {
+	it( "Adds the partitive suffix to a given Dutch stem", () => {
+		expect( addPartitiveSuffix( morphologyDataNL.adjectives, "groen" ) ).toEqual(
+			"groens" );
+	} );
+	it( "Adds the inflected suffix to a given Dutch stem that does not require a stem modification", () => {
+		expect( addInflectedSuffix( morphologyDataNL, "groen" ) ).toEqual(
+			"groene" );
+	} );
+	it( "Adds the inflected suffix to a given Dutch stem that requires replacing -ieel with -ïel", () => {
+		expect( addInflectedSuffix( morphologyDataNL, "officieel" ) ).toEqual(
+			"officiële" );
+	} );
+	it( "Adds the inflected suffix to a given Dutch stem that needs to have the final consonant doubled", () => {
+		expect( addInflectedSuffix( morphologyDataNL, "zwak" ) ).toEqual(
+			"zwakke" );
+	} );
+	it( "Adds the inflected suffix to a given Dutch stem that needs to have the final consonant voiced", () => {
+		expect( addInflectedSuffix( morphologyDataNL, "grijs" ) ).toEqual(
+			"grijze" );
+	} );
+	it( "Adds the inflected suffix to a given Dutch stem that needs to have a vowel undoubled", () => {
+		expect( addInflectedSuffix( morphologyDataNL, "zwaar" ) ).toEqual(
+			"zware" );
+	} );
+	it( "Adds comparative suffixes to a given Dutch stem that does not require a stem modification", () => {
+		expect( addComparativeSuffixes( morphologyDataNL, "groen" ) ).toEqual( [
+			"groener",
+			"groeners",
+			"groenere",
+			"groeneres",
+		], );
+	} );
+	it( "Adds comparative suffixes to a given Dutch stem that requires replacing -ieel with -ïel", () => {
+		expect( addComparativeSuffixes( morphologyDataNL, "officieel" ) ).toEqual( [
+			"officiëler",
+			"officiëlers",
+			"officiëlere",
+			"officiëleres",
+		], );
+	} );
+	it( "Adds comparative suffixes to a given Dutch stem that needs to have the final consonant doubled", () => {
+		expect( addComparativeSuffixes( morphologyDataNL, "zwak" ) ).toEqual( [
+			"zwakker",
+			"zwakkers",
+			"zwakkere",
+			"zwakkeres",
+		], );
+	} );
+	it( "Adds comparative suffixes to a given Dutch stem that needs to have the final consonant voiced", () => {
+		expect( addComparativeSuffixes( morphologyDataNL, "grijs" ) ).toEqual( [
+			"grijzer",
+			"grijzers",
+			"grijzere",
+			"grijzeres",
+		], );
+	} );
+	it( "Adds comparative suffixes to a given Dutch stem that needs to have a vowel undoubled", () => {
+		expect( addComparativeSuffixes( morphologyDataNL, "heet" ) ).toEqual( [
+			"heter",
+			"heters",
+			"hetere",
+			"heteres",
+		], );
+	} );
+	it( "Does not undoubled the vowel in a Dutch stem ending in -r before adding comparative suffixes", () => {
+		expect( addComparativeSuffixes( morphologyDataNL, "zwaar" ) ).toEqual( [
+			"zwaarder",
+			"zwaarders",
+			"zwaardere",
+			"zwaarderes",
+		], );
+	} );
+	it( "Adds superlative suffixes to a given Dutch stem", () => {
+		expect( addSuperlativeSuffixes( morphologyDataNL.adjectives, "groen" ) ).toEqual( [
+			"groenst",
+			"groenste",
+		], );
+	} );
+	it( "Adds all adjective suffixes to a given Dutch stem", () => {
+		expect( addAllAdjectiveSuffixes( morphologyDataNL, "groen" ) ).toEqual( [
+			"groener",
+			"groeners",
+			"groenere",
+			"groeneres",
+			"groenst",
+			"groenste",
+			"groene",
+			"groens",
+		], );
+	} );
+	it( "Does not make a partitive form if stem ends with an s", () => {
+		expect( addAllAdjectiveSuffixes( morphologyDataNL, "boos" ) ).toEqual( [
+			"bozer",
+			"bozers",
+			"bozere",
+			"bozeres",
+			"boost",
+			"booste",
+			"boze",
+		], );
+	} );
+	it( "Adds all adjective suffixes to a given Dutch stem that requires stem modifications", () => {
+		expect( addAllAdjectiveSuffixes( morphologyDataNL, "hoog" ) ).toEqual( [
+			"hoger",
+			"hogers",
+			"hogere",
+			"hogeres",
+			"hoogst",
+			"hoogste",
+			"hoge",
+			"hoogs",
+		], );
+	} );
+} );

--- a/packages/yoastseo/spec/morphology/dutch/addAdjectiveSuffixesSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/addAdjectiveSuffixesSpec.js
@@ -7,6 +7,7 @@ import {
 	addComparativeSuffixes,
 	addSuperlativeSuffixes,
 	addAllAdjectiveSuffixes,
+	findAndApplyModifications,
 } from "../../../src/morphology/dutch/addAdjectiveSuffixes";
 
 import getMorphologyData from "../../specHelpers/getMorphologyData";
@@ -71,77 +72,69 @@ describe( "Test for getting the right inflected suffixes for various types of ad
 	} );
 } );
 
+describe( "Applies stem modifications", () => {
+	it( "Replaces -ieel with -iël", () => {
+		expect( findAndApplyModifications( "officieel", [ "er", "ers", "ere", "eres" ], morphologyDataNL.addSuffixes.stemModifications ) ).toEqual(
+			"officiël" );
+	} );
+	it( "Doubles the last consonant of a stem", () => {
+		expect( findAndApplyModifications( "zwak", [ "er", "ers", "ere", "eres" ], morphologyDataNL.addSuffixes.stemModifications ) ).toEqual(
+			"zwakk" );
+	} );
+	it( "Changes the -s at the end of the stem to -z", () => {
+		expect( findAndApplyModifications( "grijs", [ "er", "ers", "ere", "eres" ], morphologyDataNL.addSuffixes.stemModifications ) ).toEqual(
+			"grijz" );
+	} );
+	it( "Undoubles a double vowel in a stem", () => {
+		expect( findAndApplyModifications( "zwaar", "e", morphologyDataNL.addSuffixes.stemModifications ) ).toEqual(
+			"zwar" );
+	} );
+	it( "Does not double the last consonant of a stem", () => {
+		expect( findAndApplyModifications( "zwart", [ "er", "ers", "ere", "eres" ], morphologyDataNL.addSuffixes.stemModifications ) ).toEqual(
+			"zwart" );
+	} );
+	it( "Does not change the -s at the end of the stem into -z", () => {
+		expect( findAndApplyModifications( "trots", [ "er", "ers", "ere", "eres" ], morphologyDataNL.addSuffixes.stemModifications ) ).toEqual(
+			"trots" );
+	} );
+	it( "Does not undouble a double vowel", () => {
+		expect( findAndApplyModifications( "zwaar", [ "der", "ders", "dere", "deres" ], morphologyDataNL.addSuffixes.stemModifications ) ).toEqual(
+			"zwaar" );
+	} );
+} );
+
+
 describe( "Adds adjective suffixes", () => {
 	it( "Adds the partitive suffix to a given Dutch stem", () => {
 		expect( addPartitiveSuffix( morphologyDataNL.adjectives, "groen" ) ).toEqual(
 			"groens" );
 	} );
-	it( "Adds the inflected suffix to a given Dutch stem that does not require a stem modification", () => {
-		expect( addInflectedSuffix( morphologyDataNL, "groen" ) ).toEqual(
+	it( "Adds the inflected suffix to an unmodified Dutch stem", () => {
+		expect( addInflectedSuffix( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "groen" ) ).toEqual(
 			"groene" );
 	} );
-	it( "Adds the inflected suffix to a given Dutch stem that requires replacing -ieel with -ïel", () => {
-		expect( addInflectedSuffix( morphologyDataNL, "officieel" ) ).toEqual(
+	it( "Adds the inflected suffix to a modified Dutch stem", () => {
+		expect( addInflectedSuffix( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "officieel" ) ).toEqual(
 			"officiële" );
 	} );
-	it( "Adds the inflected suffix to a given Dutch stem that needs to have the final consonant doubled", () => {
-		expect( addInflectedSuffix( morphologyDataNL, "zwak" ) ).toEqual(
-			"zwakke" );
-	} );
-	it( "Adds the inflected suffix to a given Dutch stem that needs to have the final consonant voiced", () => {
-		expect( addInflectedSuffix( morphologyDataNL, "grijs" ) ).toEqual(
-			"grijze" );
-	} );
-	it( "Adds the inflected suffix to a given Dutch stem that needs to have a vowel undoubled", () => {
-		expect( addInflectedSuffix( morphologyDataNL, "zwaar" ) ).toEqual(
+	it( "Adds the inflected suffix to a stem that should have the vowel doubled", () => {
+		expect( addInflectedSuffix( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "zwaar" ) ).toEqual(
 			"zware" );
 	} );
-	it( "Adds comparative suffixes to a given Dutch stem that does not require a stem modification", () => {
-		expect( addComparativeSuffixes( morphologyDataNL, "groen" ) ).toEqual( [
+	it( "Adds comparative suffixes to an unmodified Dutch stem", () => {
+		expect( addComparativeSuffixes( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "groen" ) ).toEqual( [
 			"groener",
 			"groeners",
 			"groenere",
 			"groeneres",
 		], );
 	} );
-	it( "Adds comparative suffixes to a given Dutch stem that requires replacing -ieel with -ïel", () => {
-		expect( addComparativeSuffixes( morphologyDataNL, "officieel" ) ).toEqual( [
-			"officiëler",
-			"officiëlers",
-			"officiëlere",
-			"officiëleres",
-		], );
-	} );
-	it( "Adds comparative suffixes to a given Dutch stem that needs to have the final consonant doubled", () => {
-		expect( addComparativeSuffixes( morphologyDataNL, "zwak" ) ).toEqual( [
+	it( "Adds comparative suffixes to a modified  Dutch stem", () => {
+		expect( addComparativeSuffixes( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "zwak" ) ).toEqual( [
 			"zwakker",
 			"zwakkers",
 			"zwakkere",
 			"zwakkeres",
-		], );
-	} );
-	it( "Adds comparative suffixes to a given Dutch stem that needs to have the final consonant voiced", () => {
-		expect( addComparativeSuffixes( morphologyDataNL, "grijs" ) ).toEqual( [
-			"grijzer",
-			"grijzers",
-			"grijzere",
-			"grijzeres",
-		], );
-	} );
-	it( "Adds comparative suffixes to a given Dutch stem that needs to have a vowel undoubled", () => {
-		expect( addComparativeSuffixes( morphologyDataNL, "heet" ) ).toEqual( [
-			"heter",
-			"heters",
-			"hetere",
-			"heteres",
-		], );
-	} );
-	it( "Does not undoubled the vowel in a Dutch stem ending in -r before adding comparative suffixes", () => {
-		expect( addComparativeSuffixes( morphologyDataNL, "zwaar" ) ).toEqual( [
-			"zwaarder",
-			"zwaarders",
-			"zwaardere",
-			"zwaarderes",
 		], );
 	} );
 	it( "Adds superlative suffixes to a given Dutch stem", () => {
@@ -151,7 +144,7 @@ describe( "Adds adjective suffixes", () => {
 		], );
 	} );
 	it( "Adds all adjective suffixes to a given Dutch stem", () => {
-		expect( addAllAdjectiveSuffixes( morphologyDataNL, "groen" ) ).toEqual( [
+		expect( addAllAdjectiveSuffixes( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "groen" ) ).toEqual( [
 			"groener",
 			"groeners",
 			"groenere",
@@ -163,7 +156,7 @@ describe( "Adds adjective suffixes", () => {
 		], );
 	} );
 	it( "Does not make a partitive form if stem ends with an s", () => {
-		expect( addAllAdjectiveSuffixes( morphologyDataNL, "boos" ) ).toEqual( [
+		expect( addAllAdjectiveSuffixes( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "boos" ) ).toEqual( [
 			"bozer",
 			"bozers",
 			"bozere",
@@ -174,7 +167,7 @@ describe( "Adds adjective suffixes", () => {
 		], );
 	} );
 	it( "Adds all adjective suffixes to a given Dutch stem that requires stem modifications", () => {
-		expect( addAllAdjectiveSuffixes( morphologyDataNL, "hoog" ) ).toEqual( [
+		expect( addAllAdjectiveSuffixes( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "hoog" ) ).toEqual( [
 			"hoger",
 			"hogers",
 			"hogere",

--- a/packages/yoastseo/spec/morphology/dutch/addAdjectiveSuffixesSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/addAdjectiveSuffixesSpec.js
@@ -61,13 +61,13 @@ describe( "Test for getting the right superlative suffixes for various types of 
 describe( "Test for getting the right inflected suffixes for various types of adjectives", () => {
 	it( "returns inflected -ë- suffix for a stem that ends with a vowel followed by e", () => {
 		expect( getSuffixesInflected( morphologyDataNL.adjectives, "tevree" ) ).toEqual(
-			"ë"
+			[ "ë" ]
 		);
 	} );
 
 	it( "returns inflected -e- suffix for a stem that has an ending other than vowel followed by e", () => {
 		expect( getSuffixesInflected( morphologyDataNL.adjectives, "grappig" ) ).toEqual(
-			"e"
+			[ "e" ]
 		);
 	} );
 } );
@@ -86,7 +86,7 @@ describe( "Applies stem modifications", () => {
 			"grijz" );
 	} );
 	it( "Undoubles a double vowel in a stem", () => {
-		expect( findAndApplyModifications( "zwaar", "e", morphologyDataNL.addSuffixes.stemModifications ) ).toEqual(
+		expect( findAndApplyModifications( "zwaar", [ "e" ], morphologyDataNL.addSuffixes.stemModifications ) ).toEqual(
 			"zwar" );
 	} );
 	it( "Does not double the last consonant of a stem", () => {

--- a/packages/yoastseo/spec/specHelpers/getMorphologyData.js
+++ b/packages/yoastseo/spec/specHelpers/getMorphologyData.js
@@ -1,10 +1,11 @@
 import en from "../../premium-configuration/data/morphologyData-v2.json";
 import de from "../../premium-configuration/data/morphologyData-de-v3.json";
-
+import nl from "../../premium-configuration/data/morphologyData-nl-v3.json";
 
 const morphologyData = {
 	en,
 	de,
+	nl,
 };
 
 /**

--- a/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
+++ b/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
@@ -1,0 +1,218 @@
+import { uniq as unique } from "lodash-es";
+
+
+/**
+ * Returns the inflected suffix depending on the ending of the stem.
+ *
+ * @param {Object}  morphologyDataAdjectives    The Dutch morphology data for adjectives.
+ * @param {string}  stemmedWord                 The stemmed word for which to get suffixes.
+ *
+ * @returns {string} The correct inflected suffixes for the given stem.
+ */
+export function getSuffixesInflected( morphologyDataAdjectives, stemmedWord ) {
+	const takesUmlautEnding = morphologyDataAdjectives.takesUmlautEnding.slice();
+
+	if ( takesUmlautEnding.some( ending => stemmedWord.endsWith( ending ) ) ) {
+		return "ë";
+	}
+
+	return "e";
+}
+
+/**
+ * Returns a set of comparative suffixes depending on the ending of the stem.
+ *
+ * @param {Object}  morphologyDataAdjectives    The Dutch morphology data for adjectives.
+ * @param {string}  stemmedWord                 The stemmed word for which to get suffixes.
+ *
+ * @returns {string[]} The correct comparative suffixes for the given stem.
+ */
+export function getSuffixesComparative( morphologyDataAdjectives, stemmedWord ) {
+	const takesREnding = morphologyDataAdjectives.takesComparativeREnding.slice();
+	const takesDerEnding = morphologyDataAdjectives.takesComparativeDerEnding.slice();
+	const takesUmlautEnding = morphologyDataAdjectives.takesUmlautEnding.slice();
+
+	if ( takesREnding.some( ending => stemmedWord.endsWith( ending ) ) ) {
+		return morphologyDataAdjectives.comparativeSuffixesR;
+	} else if ( takesDerEnding.some( ending => stemmedWord.endsWith( ending ) ) ) {
+		return morphologyDataAdjectives.comparativeSuffixesDer;
+	} else if ( takesUmlautEnding.some( ending => stemmedWord.endsWith( ending ) ) ) {
+		return morphologyDataAdjectives.comparativeSuffixesUmlaut;
+	}
+
+	return morphologyDataAdjectives.comparativeSuffixesEr;
+}
+
+/**
+ * Returns a set of superlative suffixes depending on the ending of the stem.
+ *
+ * @param {Object}  morphologyDataAdjectives    The Dutch morphology data for adjectives.
+ * @param {string}  stemmedWord                 The stemmed word for which to get suffixes.
+ *
+ * @returns {string[]} The correct superlative suffixes for the given stem.
+ */
+export function getSuffixesSuperlative( morphologyDataAdjectives, stemmedWord ) {
+	const takesTEnding = morphologyDataAdjectives.takesSuperlativeEstTEnding.slice();
+
+	if ( takesTEnding.some( ending => stemmedWord.endsWith( ending ) ) ) {
+		return morphologyDataAdjectives.superlativeSuffixesT;
+	}
+
+	return morphologyDataAdjectives.superlativeSuffixesT;
+}
+
+/**
+ * Undoubles vowel in the last syllable of the stem before adding the inflected suffix.
+ * @param {string} stemmedWord The stemmed word that should have the vowel undoubled.
+ * @returns {string} The stem with the undoubled vowel.
+ */
+const undoubleVowelInflected = function( stemmedWord ) {
+	stemmedWord = stemmedWord.replace( /(aa)([^i])$/, "a$2" );
+	stemmedWord = stemmedWord.replace( /(oo)([^i])$/, "o$2" );
+	stemmedWord = stemmedWord.replace( /(uu)([^i])$/, "u$2" );
+	stemmedWord = stemmedWord.replace( /(ee)([^i])$/, "e$2" );
+
+	return stemmedWord;
+};
+
+/**
+ * Undoubles vowel in the last syllable of the stem before adding comparative suffixes.
+ * @param {string} stemmedWord The stemmed word that should have the vowel undoubled.
+ * @returns {string} The stem with the undoubled vowel.
+ */
+const undoubleVowelComparative = function( stemmedWord ) {
+	stemmedWord = stemmedWord.replace( /(aa)([^ir])$/, "a$2" );
+	stemmedWord = stemmedWord.replace( /(oo)([^ir])$/, "o$2" );
+	stemmedWord = stemmedWord.replace( /(uu)([^ir])$/, "u$2" );
+	stemmedWord = stemmedWord.replace( /(ee)([^ir])$/, "e$2" );
+
+	return stemmedWord;
+};
+
+/**
+ * Doubles the consonant at the end of the stem.
+ * @param {string} stemmedWord The stemmed word that should have the consonant doubled.
+ * @returns {string} The stem with the doubled consonant.
+ */
+const doubleConsonant = function( stemmedWord ) {
+	const finalConsonant = stemmedWord.slice( -1 );
+
+	return stemmedWord.concat( finalConsonant );
+};
+
+/**
+ * Changes word-final f to v, and s to z.
+ * @param {string} stemmedWord The stemmed word that should have the consonant replaced.
+ * @returns {string} The stem with the replaced consonant.
+ */
+const voiceConsonant = function( stemmedWord ) {
+	stemmedWord = stemmedWord.replace( /f$/, "v" );
+	stemmedWord = stemmedWord.repace( /s$/, "z" );
+
+	return stemmedWord;
+};
+
+/**
+ * Creates the second stem of words that have two possible stems (this includes stem ending in -ieel or -iël;
+ * stem with double or single vowel; double or single consonant; s/f or z/v).
+ *
+ * @param {string} stemmedWord The stem
+ * @param {string} typeSuffix The type of suffix that should be added to the inputted stem.
+ * @returns {string} The modified stem, or the original stem if no modifications had to be made.
+ */
+const modifyStem = function( stemmedWord, typeSuffix ) {
+	if ( stemmedWord.endsWith( "ieel" ) ) {
+		stemmedWord = stemmedWord.replace( "ieel", "iël" );
+	} else if ( stemmedWord.search( /([aeoiuyèäüëïöáéíóú]?)([^aeoiuyèäüëïöáéíóú])([aeoiuáéíóú])([bdfgklmnpst])$/ ) ) {
+		stemmedWord = doubleConsonant( stemmedWord );
+	} else if ( stemmedWord.search( /(aa|oo|uu|ee)(^i)$/ ) ) {
+		if ( typeSuffix === "e" ) {
+			stemmedWord = undoubleVowelInflected( stemmedWord );
+		}   stemmedWord = undoubleVowelComparative( stemmedWord );
+
+		if ( stemmedWord.endsWith( "f" ) || stemmedWord.endsWith( "s" ) ) {
+			stemmedWord = voiceConsonant( stemmedWord );
+		}
+	} else if ( stemmedWord.search( /(ie|eu|ij|oe)([fs])/ ) ) {
+		stemmedWord = voiceConsonant( stemmedWord );
+	}
+	return stemmedWord;
+};
+
+/**
+ * Adds partitive suffix to the stem.
+ *
+ * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
+ *
+ * @returns {string} The suffixed adjective form.
+ */
+export function addPartitiveSuffix( stemmedWord ) {
+	if ( stemmedWord.endsWith( "s" ) ) {
+		return stemmedWord;
+	}
+	const partitiveSuffix = "s";
+	return stemmedWord.concat( partitiveSuffix );
+}
+
+/**
+ * Adds the inflected suffix to the stem.
+ *
+ * @param {Object}      morphologyDataAdjectives    The Dutch morphology data for adjectives.
+ * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
+ *
+ * @returns {string} The suffixed adjective form.
+ */
+export function addInflectedSuffix( morphologyDataAdjectives, stemmedWord ) {
+	const inflectedSuffix = getSuffixesInflected( morphologyDataAdjectives, stemmedWord );
+
+	stemmedWord = modifyStem( stemmedWord, inflectedSuffix );
+
+	return stemmedWord.concat( inflectedSuffix );
+}
+
+/**
+ * Adds the comparative suffixes to the stem. Before adding the suffixes, the stem is modified if needed.
+ *
+ * @param {Object}      morphologyDataAdjectives    The Dutch morphology data for adjectives.
+ * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
+ *
+ * @returns {string[]} The suffixed adjective forms.
+ */
+export function addComparativeSuffixes( morphologyDataAdjectives, stemmedWord ) {
+	const comparativeSuffixes = getSuffixesComparative( morphologyDataAdjectives, stemmedWord );
+
+	stemmedWord = modifyStem( stemmedWord, comparativeSuffixes );
+
+	return unique( comparativeSuffixes.map( suffix => stemmedWord.concat( suffix ) ) );
+}
+
+/**
+ * Adds the superlative suffixes to the stem. Before adding the suffixes, the stem is modified if needed.
+ *
+ * @param {Object}      morphologyDataAdjectives    The Dutch morphology data for adjectives.
+ * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
+ *
+ * @returns {string[]} The suffixed adjective forms.
+ */
+export function addSuperlativeSuffixes( morphologyDataAdjectives, stemmedWord ) {
+	const superlativeSuffixes = getSuffixesSuperlative( morphologyDataAdjectives, stemmedWord );
+
+	return unique( superlativeSuffixes.map( suffix => stemmedWord.concat( suffix ) ) );
+}
+
+/**
+ * Adds all suffixes (partitive, inflected, comparative, superlative) to the stem.
+ *
+ * @param {Object}      morphologyDataAdjectives    The German morphology data for adjectives.
+ * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
+ *
+ * @returns {string[]} The suffixed adjective forms.
+ */
+export function addAllAdjectiveSuffixes( morphologyDataAdjectives, stemmedWord ) {
+	const partitiveForm = addPartitiveSuffix( stemmedWord );
+	const inflectedForm = addInflectedSuffix( morphologyDataAdjectives, stemmedWord );
+	const comparativeForms = addComparativeSuffixes( morphologyDataAdjectives, stemmedWord );
+	const superlativeForms = addSuperlativeSuffixes( morphologyDataAdjectives, stemmedWord );
+
+	return unique( partitiveForm.concat( inflectedForm, comparativeForms, superlativeForms ) );
+}

--- a/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
+++ b/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
@@ -6,7 +6,7 @@ import { modifyStem } from "../morphoHelpers/suffixHelpers";
  * @param {Object}  morphologyDataAdjectives    The Dutch morphology data for adjectives.
  * @param {string}  stemmedWord                 The stemmed word for which to get suffixes.
  *
- * @returns {string} The correct inflected suffixes for the given stem.
+ * @returns {string[]} The correct inflected suffixe for the given stem.
  */
 export function getSuffixesInflected( morphologyDataAdjectives, stemmedWord ) {
 	const takesTremaEnding = morphologyDataAdjectives.takesTremaEnding.slice();
@@ -124,6 +124,7 @@ export function addInflectedSuffix( morphologyDataAdjectives, morphologyDataStem
 	stemmedWord = findAndApplyModifications( stemmedWord, inflectedSuffix, morphologyDataStemModifications );
 
 	return stemmedWord.concat( inflectedSuffix );
+
 }
 
 /**

--- a/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
+++ b/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
@@ -124,7 +124,6 @@ export function addInflectedSuffix( morphologyDataAdjectives, morphologyDataStem
 	stemmedWord = findAndApplyModifications( stemmedWord, inflectedSuffix, morphologyDataStemModifications );
 
 	return stemmedWord.concat( inflectedSuffix );
-
 }
 
 /**

--- a/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
+++ b/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
@@ -1,3 +1,4 @@
+import { modifyStem } from "../morphoHelpers/suffixHelpers";
 
 /**
  * Returns the inflected suffix depending on the ending of the stem.
@@ -8,10 +9,10 @@
  * @returns {string} The correct inflected suffixes for the given stem.
  */
 export function getSuffixesInflected( morphologyDataAdjectives, stemmedWord ) {
-	const takesUmlautEnding = morphologyDataAdjectives.takesUmlautEnding.slice();
+	const takesTremaEnding = morphologyDataAdjectives.takesTremaEnding.slice();
 
-	if ( stemmedWord.search( new RegExp( takesUmlautEnding ) ) !== -1 ) {
-		return morphologyDataAdjectives.inflectedSuffixUmlautE;
+	if ( stemmedWord.search( new RegExp( takesTremaEnding ) ) !== -1 ) {
+		return morphologyDataAdjectives.inflectedSuffixTremaE;
 	}
 
 	return morphologyDataAdjectives.inflectedSuffixE;
@@ -28,14 +29,14 @@ export function getSuffixesInflected( morphologyDataAdjectives, stemmedWord ) {
 export function getSuffixesComparative( morphologyDataAdjectives, stemmedWord ) {
 	const takesDerEnding = morphologyDataAdjectives.takesComparativeDerEnding.slice();
 	const takesREnding = morphologyDataAdjectives.takesComparativeREnding.slice();
-	const takesUmlautEnding = morphologyDataAdjectives.takesUmlautEnding.slice();
+	const takesTremaEnding = morphologyDataAdjectives.takesTremaEnding.slice();
 
 	if ( stemmedWord.endsWith( takesDerEnding ) ) {
 		return morphologyDataAdjectives.comparativeSuffixesDer;
 	} else if ( stemmedWord.search( new RegExp( takesREnding ) ) !== -1 ) {
 		return morphologyDataAdjectives.comparativeSuffixesR;
-	} else if ( stemmedWord.search( new RegExp( takesUmlautEnding ) ) !== -1 ) {
-		return morphologyDataAdjectives.comparativeSuffixesUmlaut;
+	} else if ( stemmedWord.search( new RegExp( takesTremaEnding ) ) !== -1 ) {
+		return morphologyDataAdjectives.comparativeSuffixesTrema;
 	}
 
 	return morphologyDataAdjectives.comparativeSuffixesEr;
@@ -59,85 +60,46 @@ export function getSuffixesSuperlative( morphologyDataAdjectives, stemmedWord ) 
 }
 
 /**
- * Doubles the final letter of the word.
- *
- * @param {string} stemmedWord The stemmed word that should have its final consonant doubled.
- * @returns {string} The stem with the final letter of the word doubled.
- */
-const doubleFinalLetter = function( stemmedWord ) {
-	const finalLetter = stemmedWord.slice( -1 );
-
-	return stemmedWord.concat( finalLetter );
-};
-
-/**
- * Modifies the stem if the stem ending matches one of the regexes from a given modification group.
- *
- * @param {string} stemmedWord The stem.
- * @param {string[]} modificationGroup The type of modification
- * @returns {{stemmedWord: string, foundModification: boolean}} The stem and information about whether a modification was
- * performed or not.
- */
-const modifyStem = function( stemmedWord, modificationGroup ) {
-	const neededReplacement = modificationGroup.find( replacement => stemmedWord.search( new RegExp( replacement[ 0 ] ) ) !== -1 );
-	let foundModification = false;
-
-	if ( typeof neededReplacement !== "undefined" ) {
-		stemmedWord = stemmedWord.replace( new RegExp( neededReplacement[ 0 ] ), neededReplacement[ 1 ] );
-		foundModification = true;
-
-		return { stemmedWord, foundModification };
-	}
-	return { stemmedWord, foundModification };
-};
-
-/**
  * Creates the second stem of words that have two possible stems (this includes stem ending in -ieel or -iël;
  * stem with double or single vowel; ending in double or single consonant; ending in s/f or z/v). The inflected and comparative
  * suffixes are then added to the modified stem.
  *
- * @param {string} stemmedWord The stem
- * @param {string} typeSuffix The type of suffix that should be added to the inputted stem.
- * @param {object} morphologyDataNL The Dutch morphology data file
+ * @param {string} stemmedWord 					   The stem
+ * @param {string[]} typeSuffix 				   The type of suffix that should be added to the inputted stem.
+ * @param {object} morphologyDataStemModifications The Dutch stem modifications data.
  * @returns {string} The modified stem, or the original stem if no modifications were made.
  */
-const findAndApplyModifications = function( stemmedWord, typeSuffix, morphologyDataNL ) {
-	const ieelToIelModification = modifyStem( stemmedWord, morphologyDataNL.addSuffixes.stemModifications.ieelToIel );
-	if ( ieelToIelModification.foundModification === true ) {
-		stemmedWord = ieelToIelModification.stemmedWord;
-		return stemmedWord;
+export function findAndApplyModifications( stemmedWord, typeSuffix, morphologyDataStemModifications ) {
+	const triedToChangeIeelToIel = modifyStem( stemmedWord, morphologyDataStemModifications.ieelToIel );
+	if ( triedToChangeIeelToIel ) {
+		return triedToChangeIeelToIel;
 	}
-	const doubleConsonantModification = modifyStem( stemmedWord, morphologyDataNL.addSuffixes.stemModifications.doublingConsonant );
-	if ( doubleConsonantModification.foundModification === true ) {
-		stemmedWord = doubleFinalLetter( stemmedWord );
-		return stemmedWord;
+
+	const triedToDoubleConsonant = modifyStem( stemmedWord, morphologyDataStemModifications.doublingConsonant );
+	if ( triedToDoubleConsonant ) {
+		return triedToDoubleConsonant;
 	}
-	const voiceConsonantModification = modifyStem( stemmedWord, morphologyDataNL.addSuffixes.stemModifications.consonantVoicing );
-	if ( voiceConsonantModification.foundModification === true ) {
-		stemmedWord = voiceConsonantModification.stemmedWord;
-		return stemmedWord;
+
+	const triedToVoiceConsonant = modifyStem( stemmedWord, morphologyDataStemModifications.consonantVoicing );
+	if ( triedToVoiceConsonant ) {
+		return triedToVoiceConsonant;
 	}
-	if ( typeSuffix === "e" ) {
-		const undoubleVowelModificationOther = modifyStem( stemmedWord, morphologyDataNL.addSuffixes.stemModifications.vowelUndoublingOther );
-		if ( undoubleVowelModificationOther.foundModification === true ) {
-			stemmedWord = undoubleVowelModificationOther.stemmedWord;
-			return stemmedWord;
+
+	if ( ! typeSuffix.includes( "der" ) ) {
+		const triedToUndoubleVowel = modifyStem( stemmedWord, morphologyDataStemModifications.vowelUndoubling );
+		if ( triedToUndoubleVowel ) {
+			return triedToUndoubleVowel;
 		}
 	}
-	const undoubleVowelModificationComp = modifyStem( stemmedWord, morphologyDataNL.addSuffixes.stemModifications.vowelUndoublingComparative );
-	if ( undoubleVowelModificationComp.foundModification === true ) {
-		stemmedWord = undoubleVowelModificationComp.stemmedWord;
-		return stemmedWord;
-	}
 	return stemmedWord;
-};
+}
 
 
 /**
  * Adds partitive suffix to the stem.
  *
  * @param {object} morphologyDataAdjectives The Dutch morphology data for adjectives.
- * @param {string} stemmedWord The stemmed word for which to get suffixes.
+ * @param {string} stemmedWord 				The stemmed word for which to get suffixes.
  *
  * @returns {string} The suffixed adjective form.
  */
@@ -150,15 +112,16 @@ export function addPartitiveSuffix( morphologyDataAdjectives, stemmedWord ) {
 /**
  * Adds the inflected suffix to the stem. Before adding the suffixes, the stem is modified if needed.
  *
- * @param {Object}      morphologyDataNL    The Dutch morphology data for adjectives.
- * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
+ * @param {Object}      morphologyDataAdjectives   		 The Dutch morphology data for adjectives.
+ * @param {Object}		morphologyDataStemModifications	 The Dutch stem modifications data.
+ * @param {string}      stemmedWord        				 The stemmed word for which to get suffixes.
  *
  * @returns {string} The suffixed adjective form.
  */
-export function addInflectedSuffix( morphologyDataNL, stemmedWord ) {
-	const inflectedSuffix = getSuffixesInflected( morphologyDataNL.adjectives, stemmedWord );
+export function addInflectedSuffix( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord ) {
+	const inflectedSuffix = getSuffixesInflected( morphologyDataAdjectives, stemmedWord );
 
-	stemmedWord = findAndApplyModifications( stemmedWord, inflectedSuffix, morphologyDataNL );
+	stemmedWord = findAndApplyModifications( stemmedWord, inflectedSuffix, morphologyDataStemModifications );
 
 	return stemmedWord.concat( inflectedSuffix );
 }
@@ -166,15 +129,16 @@ export function addInflectedSuffix( morphologyDataNL, stemmedWord ) {
 /**
  * Adds the comparative suffixes to the stem. Before adding the suffixes, the stem is modified if needed.
  *
- * @param {Object}      morphologyDataNL    The Dutch morphology data for adjectives.
- * @param {string}      stemmedWord         The stemmed word for which to get suffixes.
+ * @param {Object}      morphologyDataAdjectives   		The Dutch morphology data for adjectives.
+ * @param {Object}		morphologyDataStemModifications	The Dutch stem modifications data.
+ * @param {string}      stemmedWord         			The stemmed word for which to get suffixes.
  *
  * @returns {string[]} The suffixed adjective forms.
  */
-export function addComparativeSuffixes( morphologyDataNL, stemmedWord ) {
-	const comparativeSuffixes = getSuffixesComparative( morphologyDataNL.adjectives, stemmedWord );
+export function addComparativeSuffixes( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord ) {
+	const comparativeSuffixes = getSuffixesComparative( morphologyDataAdjectives, stemmedWord );
 
-	stemmedWord = findAndApplyModifications( stemmedWord, comparativeSuffixes, morphologyDataNL );
+	stemmedWord = findAndApplyModifications( stemmedWord, comparativeSuffixes, morphologyDataStemModifications );
 
 	return comparativeSuffixes.map( suffix => stemmedWord.concat( suffix ) );
 }
@@ -196,15 +160,16 @@ export function addSuperlativeSuffixes( morphologyDataAdjectives, stemmedWord ) 
 /**
  * Adds all suffixes (partitive, inflected, comparative, superlative) to the stem.
  *
- * @param {Object}      morphologyDataNL    The Dutch morphology data for adjectives.
- * @param {string}      stemmedWord         The stemmed word for which to get suffixes.
+ * @param {Object}      morphologyDataAdjectives    	The Dutch morphology data for adjectives.
+ * @param {Object}		morphologyDataStemModifications	The Dutch stem modifications data.
+ * @param {string}      stemmedWord        				The stemmed word for which to get suffixes.
  *
  * @returns {string[]} The suffixed adjective forms.
  */
-export function addAllAdjectiveSuffixes( morphologyDataNL, stemmedWord ) {
-	const comparativeForms = addComparativeSuffixes( morphologyDataNL, stemmedWord );
-	const superlativeForms = addSuperlativeSuffixes( morphologyDataNL.adjectives, stemmedWord );
-	const inflectedForm = addInflectedSuffix( morphologyDataNL, stemmedWord );
+export function addAllAdjectiveSuffixes( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord ) {
+	const comparativeForms = addComparativeSuffixes( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord );
+	const superlativeForms = addSuperlativeSuffixes( morphologyDataAdjectives, stemmedWord );
+	const inflectedForm = addInflectedSuffix( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord );
 
 	const adjectiveForms = comparativeForms.concat( superlativeForms );
 	adjectiveForms.push( inflectedForm );
@@ -212,7 +177,7 @@ export function addAllAdjectiveSuffixes( morphologyDataNL, stemmedWord ) {
 	if ( stemmedWord.endsWith( "s" ) ) {
 		return adjectiveForms;
 	}
-	const partitiveForm = addPartitiveSuffix( morphologyDataNL.adjectives, stemmedWord );
+	const partitiveForm = addPartitiveSuffix( morphologyDataAdjectives, stemmedWord );
 	adjectiveForms.push( partitiveForm );
 
 	return adjectiveForms;

--- a/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
+++ b/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
@@ -74,7 +74,7 @@ const doubleFinalLetter = function( stemmedWord ) {
  * Modifies the stem if the stem ending matches one of the regexes from a given modification group.
  *
  * @param {string} stemmedWord The stem.
- * @param {array} modificationGroup The type of modification
+ * @param {string[]} modificationGroup The type of modification
  * @returns {{stemmedWord: string, foundModification: boolean}} The stem and information about whether a modification was
  * performed or not.
  */
@@ -167,7 +167,7 @@ export function addInflectedSuffix( morphologyDataNL, stemmedWord ) {
  * Adds the comparative suffixes to the stem. Before adding the suffixes, the stem is modified if needed.
  *
  * @param {Object}      morphologyDataNL    The Dutch morphology data for adjectives.
- * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
+ * @param {string}      stemmedWord         The stemmed word for which to get suffixes.
  *
  * @returns {string[]} The suffixed adjective forms.
  */
@@ -197,7 +197,7 @@ export function addSuperlativeSuffixes( morphologyDataAdjectives, stemmedWord ) 
  * Adds all suffixes (partitive, inflected, comparative, superlative) to the stem.
  *
  * @param {Object}      morphologyDataNL    The Dutch morphology data for adjectives.
- * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
+ * @param {string}      stemmedWord         The stemmed word for which to get suffixes.
  *
  * @returns {string[]} The suffixed adjective forms.
  */

--- a/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
+++ b/packages/yoastseo/src/morphology/dutch/addAdjectiveSuffixes.js
@@ -1,5 +1,3 @@
-import { uniq as unique } from "lodash-es";
-
 
 /**
  * Returns the inflected suffix depending on the ending of the stem.
@@ -12,37 +10,36 @@ import { uniq as unique } from "lodash-es";
 export function getSuffixesInflected( morphologyDataAdjectives, stemmedWord ) {
 	const takesUmlautEnding = morphologyDataAdjectives.takesUmlautEnding.slice();
 
-	if ( takesUmlautEnding.some( ending => stemmedWord.endsWith( ending ) ) ) {
-		return "ë";
+	if ( stemmedWord.search( new RegExp( takesUmlautEnding ) ) !== -1 ) {
+		return morphologyDataAdjectives.inflectedSuffixUmlautE;
 	}
 
-	return "e";
+	return morphologyDataAdjectives.inflectedSuffixE;
 }
 
 /**
  * Returns a set of comparative suffixes depending on the ending of the stem.
  *
- * @param {Object}  morphologyDataAdjectives    The Dutch morphology data for adjectives.
+ * @param {Object}  morphologyDataAdjectives    The Dutch morphology data.
  * @param {string}  stemmedWord                 The stemmed word for which to get suffixes.
  *
  * @returns {string[]} The correct comparative suffixes for the given stem.
  */
 export function getSuffixesComparative( morphologyDataAdjectives, stemmedWord ) {
-	const takesREnding = morphologyDataAdjectives.takesComparativeREnding.slice();
 	const takesDerEnding = morphologyDataAdjectives.takesComparativeDerEnding.slice();
+	const takesREnding = morphologyDataAdjectives.takesComparativeREnding.slice();
 	const takesUmlautEnding = morphologyDataAdjectives.takesUmlautEnding.slice();
 
-	if ( takesREnding.some( ending => stemmedWord.endsWith( ending ) ) ) {
-		return morphologyDataAdjectives.comparativeSuffixesR;
-	} else if ( takesDerEnding.some( ending => stemmedWord.endsWith( ending ) ) ) {
+	if ( stemmedWord.endsWith( takesDerEnding ) ) {
 		return morphologyDataAdjectives.comparativeSuffixesDer;
-	} else if ( takesUmlautEnding.some( ending => stemmedWord.endsWith( ending ) ) ) {
+	} else if ( stemmedWord.search( new RegExp( takesREnding ) ) !== -1 ) {
+		return morphologyDataAdjectives.comparativeSuffixesR;
+	} else if ( stemmedWord.search( new RegExp( takesUmlautEnding ) ) !== -1 ) {
 		return morphologyDataAdjectives.comparativeSuffixesUmlaut;
 	}
 
 	return morphologyDataAdjectives.comparativeSuffixesEr;
 }
-
 /**
  * Returns a set of superlative suffixes depending on the ending of the stem.
  *
@@ -52,120 +49,116 @@ export function getSuffixesComparative( morphologyDataAdjectives, stemmedWord ) 
  * @returns {string[]} The correct superlative suffixes for the given stem.
  */
 export function getSuffixesSuperlative( morphologyDataAdjectives, stemmedWord ) {
-	const takesTEnding = morphologyDataAdjectives.takesSuperlativeEstTEnding.slice();
+	const takesTEnding = morphologyDataAdjectives.takesSuperlativeTEnding.slice();
 
-	if ( takesTEnding.some( ending => stemmedWord.endsWith( ending ) ) ) {
+	if ( stemmedWord.endsWith( takesTEnding ) ) {
 		return morphologyDataAdjectives.superlativeSuffixesT;
 	}
 
-	return morphologyDataAdjectives.superlativeSuffixesT;
+	return morphologyDataAdjectives.superlativeSuffixesSt;
 }
 
 /**
- * Undoubles vowel in the last syllable of the stem before adding the inflected suffix.
- * @param {string} stemmedWord The stemmed word that should have the vowel undoubled.
- * @returns {string} The stem with the undoubled vowel.
+ * Doubles the final letter of the word.
+ *
+ * @param {string} stemmedWord The stemmed word that should have its final consonant doubled.
+ * @returns {string} The stem with the final letter of the word doubled.
  */
-const undoubleVowelInflected = function( stemmedWord ) {
-	stemmedWord = stemmedWord.replace( /(aa)([^i])$/, "a$2" );
-	stemmedWord = stemmedWord.replace( /(oo)([^i])$/, "o$2" );
-	stemmedWord = stemmedWord.replace( /(uu)([^i])$/, "u$2" );
-	stemmedWord = stemmedWord.replace( /(ee)([^i])$/, "e$2" );
+const doubleFinalLetter = function( stemmedWord ) {
+	const finalLetter = stemmedWord.slice( -1 );
 
-	return stemmedWord;
+	return stemmedWord.concat( finalLetter );
 };
 
 /**
- * Undoubles vowel in the last syllable of the stem before adding comparative suffixes.
- * @param {string} stemmedWord The stemmed word that should have the vowel undoubled.
- * @returns {string} The stem with the undoubled vowel.
+ * Modifies the stem if the stem ending matches one of the regexes from a given modification group.
+ *
+ * @param {string} stemmedWord The stem.
+ * @param {array} modificationGroup The type of modification
+ * @returns {{stemmedWord: string, foundModification: boolean}} The stem and information about whether a modification was
+ * performed or not.
  */
-const undoubleVowelComparative = function( stemmedWord ) {
-	stemmedWord = stemmedWord.replace( /(aa)([^ir])$/, "a$2" );
-	stemmedWord = stemmedWord.replace( /(oo)([^ir])$/, "o$2" );
-	stemmedWord = stemmedWord.replace( /(uu)([^ir])$/, "u$2" );
-	stemmedWord = stemmedWord.replace( /(ee)([^ir])$/, "e$2" );
+const modifyStem = function( stemmedWord, modificationGroup ) {
+	const neededReplacement = modificationGroup.find( replacement => stemmedWord.search( new RegExp( replacement[ 0 ] ) ) !== -1 );
+	let foundModification = false;
 
-	return stemmedWord;
-};
+	if ( typeof neededReplacement !== "undefined" ) {
+		stemmedWord = stemmedWord.replace( new RegExp( neededReplacement[ 0 ] ), neededReplacement[ 1 ] );
+		foundModification = true;
 
-/**
- * Doubles the consonant at the end of the stem.
- * @param {string} stemmedWord The stemmed word that should have the consonant doubled.
- * @returns {string} The stem with the doubled consonant.
- */
-const doubleConsonant = function( stemmedWord ) {
-	const finalConsonant = stemmedWord.slice( -1 );
-
-	return stemmedWord.concat( finalConsonant );
-};
-
-/**
- * Changes word-final f to v, and s to z.
- * @param {string} stemmedWord The stemmed word that should have the consonant replaced.
- * @returns {string} The stem with the replaced consonant.
- */
-const voiceConsonant = function( stemmedWord ) {
-	stemmedWord = stemmedWord.replace( /f$/, "v" );
-	stemmedWord = stemmedWord.repace( /s$/, "z" );
-
-	return stemmedWord;
+		return { stemmedWord, foundModification };
+	}
+	return { stemmedWord, foundModification };
 };
 
 /**
  * Creates the second stem of words that have two possible stems (this includes stem ending in -ieel or -iël;
- * stem with double or single vowel; double or single consonant; s/f or z/v).
+ * stem with double or single vowel; ending in double or single consonant; ending in s/f or z/v). The inflected and comparative
+ * suffixes are then added to the modified stem.
  *
  * @param {string} stemmedWord The stem
  * @param {string} typeSuffix The type of suffix that should be added to the inputted stem.
- * @returns {string} The modified stem, or the original stem if no modifications had to be made.
+ * @param {object} morphologyDataNL The Dutch morphology data file
+ * @returns {string} The modified stem, or the original stem if no modifications were made.
  */
-const modifyStem = function( stemmedWord, typeSuffix ) {
-	if ( stemmedWord.endsWith( "ieel" ) ) {
-		stemmedWord = stemmedWord.replace( "ieel", "iël" );
-	} else if ( stemmedWord.search( /([aeoiuyèäüëïöáéíóú]?)([^aeoiuyèäüëïöáéíóú])([aeoiuáéíóú])([bdfgklmnpst])$/ ) ) {
-		stemmedWord = doubleConsonant( stemmedWord );
-	} else if ( stemmedWord.search( /(aa|oo|uu|ee)(^i)$/ ) ) {
-		if ( typeSuffix === "e" ) {
-			stemmedWord = undoubleVowelInflected( stemmedWord );
-		}   stemmedWord = undoubleVowelComparative( stemmedWord );
-
-		if ( stemmedWord.endsWith( "f" ) || stemmedWord.endsWith( "s" ) ) {
-			stemmedWord = voiceConsonant( stemmedWord );
+const findAndApplyModifications = function( stemmedWord, typeSuffix, morphologyDataNL ) {
+	const ieelToIelModification = modifyStem( stemmedWord, morphologyDataNL.addSuffixes.stemModifications.ieelToIel );
+	if ( ieelToIelModification.foundModification === true ) {
+		stemmedWord = ieelToIelModification.stemmedWord;
+		return stemmedWord;
+	}
+	const doubleConsonantModification = modifyStem( stemmedWord, morphologyDataNL.addSuffixes.stemModifications.doublingConsonant );
+	if ( doubleConsonantModification.foundModification === true ) {
+		stemmedWord = doubleFinalLetter( stemmedWord );
+		return stemmedWord;
+	}
+	const voiceConsonantModification = modifyStem( stemmedWord, morphologyDataNL.addSuffixes.stemModifications.consonantVoicing );
+	if ( voiceConsonantModification.foundModification === true ) {
+		stemmedWord = voiceConsonantModification.stemmedWord;
+		return stemmedWord;
+	}
+	if ( typeSuffix === "e" ) {
+		const undoubleVowelModificationOther = modifyStem( stemmedWord, morphologyDataNL.addSuffixes.stemModifications.vowelUndoublingOther );
+		if ( undoubleVowelModificationOther.foundModification === true ) {
+			stemmedWord = undoubleVowelModificationOther.stemmedWord;
+			return stemmedWord;
 		}
-	} else if ( stemmedWord.search( /(ie|eu|ij|oe)([fs])/ ) ) {
-		stemmedWord = voiceConsonant( stemmedWord );
+	}
+	const undoubleVowelModificationComp = modifyStem( stemmedWord, morphologyDataNL.addSuffixes.stemModifications.vowelUndoublingComparative );
+	if ( undoubleVowelModificationComp.foundModification === true ) {
+		stemmedWord = undoubleVowelModificationComp.stemmedWord;
+		return stemmedWord;
 	}
 	return stemmedWord;
 };
 
+
 /**
  * Adds partitive suffix to the stem.
  *
- * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
+ * @param {object} morphologyDataAdjectives The Dutch morphology data for adjectives.
+ * @param {string} stemmedWord The stemmed word for which to get suffixes.
  *
  * @returns {string} The suffixed adjective form.
  */
-export function addPartitiveSuffix( stemmedWord ) {
-	if ( stemmedWord.endsWith( "s" ) ) {
-		return stemmedWord;
-	}
-	const partitiveSuffix = "s";
+export function addPartitiveSuffix( morphologyDataAdjectives, stemmedWord ) {
+	const partitiveSuffix = morphologyDataAdjectives.partitiveSuffix;
+
 	return stemmedWord.concat( partitiveSuffix );
 }
 
 /**
- * Adds the inflected suffix to the stem.
+ * Adds the inflected suffix to the stem. Before adding the suffixes, the stem is modified if needed.
  *
- * @param {Object}      morphologyDataAdjectives    The Dutch morphology data for adjectives.
+ * @param {Object}      morphologyDataNL    The Dutch morphology data for adjectives.
  * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
  *
  * @returns {string} The suffixed adjective form.
  */
-export function addInflectedSuffix( morphologyDataAdjectives, stemmedWord ) {
-	const inflectedSuffix = getSuffixesInflected( morphologyDataAdjectives, stemmedWord );
+export function addInflectedSuffix( morphologyDataNL, stemmedWord ) {
+	const inflectedSuffix = getSuffixesInflected( morphologyDataNL.adjectives, stemmedWord );
 
-	stemmedWord = modifyStem( stemmedWord, inflectedSuffix );
+	stemmedWord = findAndApplyModifications( stemmedWord, inflectedSuffix, morphologyDataNL );
 
 	return stemmedWord.concat( inflectedSuffix );
 }
@@ -173,21 +166,21 @@ export function addInflectedSuffix( morphologyDataAdjectives, stemmedWord ) {
 /**
  * Adds the comparative suffixes to the stem. Before adding the suffixes, the stem is modified if needed.
  *
- * @param {Object}      morphologyDataAdjectives    The Dutch morphology data for adjectives.
+ * @param {Object}      morphologyDataNL    The Dutch morphology data for adjectives.
  * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
  *
  * @returns {string[]} The suffixed adjective forms.
  */
-export function addComparativeSuffixes( morphologyDataAdjectives, stemmedWord ) {
-	const comparativeSuffixes = getSuffixesComparative( morphologyDataAdjectives, stemmedWord );
+export function addComparativeSuffixes( morphologyDataNL, stemmedWord ) {
+	const comparativeSuffixes = getSuffixesComparative( morphologyDataNL.adjectives, stemmedWord );
 
-	stemmedWord = modifyStem( stemmedWord, comparativeSuffixes );
+	stemmedWord = findAndApplyModifications( stemmedWord, comparativeSuffixes, morphologyDataNL );
 
-	return unique( comparativeSuffixes.map( suffix => stemmedWord.concat( suffix ) ) );
+	return comparativeSuffixes.map( suffix => stemmedWord.concat( suffix ) );
 }
 
 /**
- * Adds the superlative suffixes to the stem. Before adding the suffixes, the stem is modified if needed.
+ * Adds the superlative suffixes to the stem.
  *
  * @param {Object}      morphologyDataAdjectives    The Dutch morphology data for adjectives.
  * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
@@ -197,22 +190,30 @@ export function addComparativeSuffixes( morphologyDataAdjectives, stemmedWord ) 
 export function addSuperlativeSuffixes( morphologyDataAdjectives, stemmedWord ) {
 	const superlativeSuffixes = getSuffixesSuperlative( morphologyDataAdjectives, stemmedWord );
 
-	return unique( superlativeSuffixes.map( suffix => stemmedWord.concat( suffix ) ) );
+	return superlativeSuffixes.map( suffix => stemmedWord.concat( suffix ) );
 }
 
 /**
  * Adds all suffixes (partitive, inflected, comparative, superlative) to the stem.
  *
- * @param {Object}      morphologyDataAdjectives    The German morphology data for adjectives.
+ * @param {Object}      morphologyDataNL    The Dutch morphology data for adjectives.
  * @param {string}      stemmedWord                 The stemmed word for which to get suffixes.
  *
  * @returns {string[]} The suffixed adjective forms.
  */
-export function addAllAdjectiveSuffixes( morphologyDataAdjectives, stemmedWord ) {
-	const partitiveForm = addPartitiveSuffix( stemmedWord );
-	const inflectedForm = addInflectedSuffix( morphologyDataAdjectives, stemmedWord );
-	const comparativeForms = addComparativeSuffixes( morphologyDataAdjectives, stemmedWord );
-	const superlativeForms = addSuperlativeSuffixes( morphologyDataAdjectives, stemmedWord );
+export function addAllAdjectiveSuffixes( morphologyDataNL, stemmedWord ) {
+	const comparativeForms = addComparativeSuffixes( morphologyDataNL, stemmedWord );
+	const superlativeForms = addSuperlativeSuffixes( morphologyDataNL.adjectives, stemmedWord );
+	const inflectedForm = addInflectedSuffix( morphologyDataNL, stemmedWord );
 
-	return unique( partitiveForm.concat( inflectedForm, comparativeForms, superlativeForms ) );
+	const adjectiveForms = comparativeForms.concat( superlativeForms );
+	adjectiveForms.push( inflectedForm );
+
+	if ( stemmedWord.endsWith( "s" ) ) {
+		return adjectiveForms;
+	}
+	const partitiveForm = addPartitiveSuffix( morphologyDataNL.adjectives, stemmedWord );
+	adjectiveForms.push( partitiveForm );
+
+	return adjectiveForms;
 }

--- a/packages/yoastseo/src/morphology/morphoHelpers/suffixHelpers.js
+++ b/packages/yoastseo/src/morphology/morphoHelpers/suffixHelpers.js
@@ -1,4 +1,19 @@
 /**
+ * Modifies the stem if the stem ending matches one of the regexes from a given modification group.
+ *
+ * @param {string} stemmedWord The stem.
+ * @param {array} modificationGroup The type of modification.
+ * @returns {string} The modified stem.
+ */
+export function modifyStem( stemmedWord, modificationGroup ) {
+	const neededReplacement = modificationGroup.find( replacement => stemmedWord.search( new RegExp( replacement[ 0 ] ) ) !== -1 );
+
+	if ( typeof neededReplacement !== "undefined" ) {
+		return stemmedWord.replace( new RegExp( neededReplacement[ 0 ] ), neededReplacement[ 1 ] );
+	}
+}
+
+/**
  * Creates word forms from a list of given suffixes and a stem.
  *
  * @param {string}      stem                The stem on which to apply the suffixes.


### PR DESCRIPTION
## Summary

Adds adjective suffixes to regular Dutch adjectives.

## Test instructions

This PR can be tested by following these steps:

* Add more word stems to the spec, together with all of the expected word forms (excluding the stem). Make sure all the expected forms are created.
  * To get stems, run some adjectives to the stemmer to get stems first. E.g., from the input word `korte` you should get the stem `kort`.
  * Use the stem you got in the adjective spec. You should then get forms such as `korte`, `korter`, `kortst` etc., plus also some nonsense forms. (In principle, obtaining nonsense forms is expected behavior. But if you obtain lots of nonsense forms that are ambiguous with other words, this might lead to too many false positives. So also keep an eye on the nonsense forms.)

### Note: 
Please change the package.json premium data specification to `feature/Dutch-morphology` after merging this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #323
