### PR TITLE
Allow the internal linking suggestion components to render customized messages based on the metadata

### DIFF
--- a/packages/yoast-components/composites/LinkSuggestions/LinkSuggestions.js
+++ b/packages/yoast-components/composites/LinkSuggestions/LinkSuggestions.js
@@ -92,7 +92,7 @@ class LinkSuggestions extends React.Component {
 
 	/**
 	 * Renders the component for when there are no link suggestions. If there is not enough text to calculate Prominent Words
-	 * of if no Prominent Words could be found, an "Add a bit more copy" message is returned. Otherwise we return a message
+	 * or if no Prominent Words could be found, an "Add a bit more copy" message is returned. Otherwise we return a message
 	 * that no relevant posts are found.
 	 *
 	 * @returns {React.Element} The rendered empty list

--- a/packages/yoast-components/composites/LinkSuggestions/LinkSuggestions.js
+++ b/packages/yoast-components/composites/LinkSuggestions/LinkSuggestions.js
@@ -7,7 +7,6 @@ import Clipboard from "clipboard";
 import interpolateComponents from "interpolate-components";
 import { speak } from "@wordpress/a11y";
 import styled from "styled-components";
-import { isEqual } from "lodash-es";
 
 /* Internal dependencies */
 import { makeOutboundLink } from "@yoast/helpers";
@@ -21,9 +20,17 @@ const LinkSuggestionsWrapper = styled.div`
 const noRelevantPostsMessage = __(
 	"We could not find any relevant articles on your website that you could link to from your post.", "yoast-components" );
 
-const moreCopyMessage = __(
-	"Once you add a bit more copy, we'll give you a list of related " +
-	"content here to which you could link in your post.", "yoast-components" );
+const listIntroMessage = __( "This is a list of related content to which you could link in your post.", "yoast-components" );
+
+// Translators: Text between {{a}} and {{/a}} will be a link to an article about site structure.
+const articleLinkString = __(
+	"{{a}}Read our article about site structure{{/a}} " +
+	"to learn more about how internal linking can help improve your SEO.", "yoast-components" );
+
+// Translators: Text between {{a}} and {{/a}} will be a link to an article about cornerstone content.
+const cornerstoneLinkString = __( "Consider linking to these {{a}}cornerstone articles:{{/a}}", "yoast-components" );
+
+const nonCornerstoneLinkString = __( "Consider linking to these articles:", "yoast-components" );
 
 /**
  * Represents the Suggestions component.
@@ -84,34 +91,21 @@ class LinkSuggestions extends React.Component {
 	}
 
 	/**
-	 * Renders the component for when there are no link suggestions.
+	 * Renders the component for when there are no link suggestions. If there is not enough text to calculate Prominent Words
+	 * of if no Prominent Words could be found, an "Add a bit more copy" message is returned. Otherwise we return a message
+	 * that no relevant posts are found.
 	 *
 	 * @returns {React.Element} The rendered empty list
 	 */
 	renderEmptyList() {
-		// Translators: Text between {{a}} and {{/a}} will be a link to an article about site structure.
-		const articleLinkString = __(
-			"Read {{a}}our article about site structure{{/a}} " +
-			"to learn more about how internal linking can help improve your SEO.", "yoast-components" );
-
-		const articleLink = interpolateComponents( {
-			mixedString: articleLinkString,
-			components: {
-				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				a: <HelpTextLink href="https://yoa.st/site-structure-metabox" />,
-			},
-		} );
-
-		/*
-		If there is not enough text to calculate Prominent Words an "Add a bit more copy" message is returned.
-		Otherwise we return a message that no relevant posts are found.
-		*/
-		const renderMessage = isEqual( this.props.prominentWords, [] ) ? moreCopyMessage : noRelevantPostsMessage;
+		let lengthMessage = this.props.customMessages.lengthMessage;
+		lengthMessage = lengthMessage === "" ? noRelevantPostsMessage : lengthMessage;
 
 		return (
 			<div>
-				<p>{ renderMessage }</p>
-				<p>{ articleLink }</p>
+				<p>{ lengthMessage }</p>
+				<p>{ this.props.customMessages.metaMessage }</p>
+				<p>{ this.getArticleLink() }</p>
 			</div>
 		);
 	}
@@ -125,20 +119,6 @@ class LinkSuggestions extends React.Component {
 		const suggestions = this.props.suggestions;
 		const maximumSuggestions = this.props.maxSuggestions;
 
-		// Translators: Text between {{a}} and {{/a}} will be a link to an article about site structure.
-		const articleLinkString = __(
-			"This is a list of related content to which you could link in your post. " +
-			"{{a}}Read our article about site structure{{/a}} " +
-			"to learn more about how internal linking can help improve your SEO.", "yoast-components" );
-
-		const articleLink = interpolateComponents( {
-			mixedString: articleLinkString,
-			components: {
-				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				a: <HelpTextLink href="https://yoa.st/site-structure-metabox" />,
-			},
-		} );
-
 		if ( suggestions.length === 0 ) {
 			return this.renderEmptyList();
 		}
@@ -151,7 +131,9 @@ class LinkSuggestions extends React.Component {
 
 		return (
 			<LinkSuggestionsWrapper>
-				<p>{ articleLink }</p>
+				<p>{ listIntroMessage }</p>
+				<p>{ this.props.customMessages.metaMessage }</p>
+				<p>{ this.getArticleLink() }</p>
 				{ cornerStoneSuggestions }
 				{ defaultSuggestions }
 			</LinkSuggestionsWrapper>
@@ -170,17 +152,15 @@ class LinkSuggestions extends React.Component {
 			return null;
 		}
 
-		// Translators: Text between {{a}} and {{/a}} will be a link to an article about cornerstone content.
-		const articleLinkString = __( "Consider linking to these {{a}}cornerstone articles:{{/a}}", "yoast-components" );
-		const articleLink = interpolateComponents( {
-			mixedString: articleLinkString,
+		const cornerstoneLink = interpolateComponents( {
+			mixedString: cornerstoneLinkString,
 			components: {
 				// eslint-disable-next-line jsx-a11y/anchor-has-content
 				a: <HelpTextLink href="https://yoa.st/metabox-ls-help-cornerstone" />,
 			},
 		} );
 
-		return this.getSuggestionsList( articleLink, suggestions );
+		return this.getSuggestionsList( cornerstoneLink, suggestions );
 	}
 
 	/**
@@ -195,7 +175,22 @@ class LinkSuggestions extends React.Component {
 			return null;
 		}
 
-		return this.getSuggestionsList( __( "Consider linking to these articles:", "yoast-components" ), suggestions );
+		return this.getSuggestionsList( nonCornerstoneLinkString, suggestions );
+	}
+
+	/**
+	 * Returns the message with a link to the Internal Linking article on yoast.com.
+	 *
+	 * @returns {React.Element} The values to use.
+	 */
+	getArticleLink() {
+		return interpolateComponents( {
+			mixedString: articleLinkString,
+			components: {
+				// eslint-disable-next-line jsx-a11y/anchor-has-content
+				a: <HelpTextLink href="https://yoa.st/site-structure-metabox" />,
+			},
+		} );
 	}
 
 	/**
@@ -233,12 +228,16 @@ class LinkSuggestions extends React.Component {
 
 LinkSuggestions.propTypes = {
 	suggestions: PropTypes.array.isRequired,
-	prominentWords: PropTypes.array.isRequired,
 	maxSuggestions: PropTypes.number,
+	customMessages: PropTypes.object,
 };
 
 LinkSuggestions.defaultProps = {
 	maxSuggestions: 10,
+	customMessages: {
+		lengthMessage: "",
+		metaMessage: "",
+	},
 };
 
 export default LinkSuggestions;

--- a/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
+++ b/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
@@ -8,15 +8,34 @@ import getMorphologyData from "../specHelpers/getMorphologyData";
 const morphologyData = getMorphologyData( "en" );
 
 describe( "relevantWords research", function() {
-	it( "does not break if no morphology support is added for the language", function() {
-		const paper = new Paper( "texte et texte et texte et texte", { locale: "fr_FR" } );
+	it( "returns no prominent words for texts under 300 words", function() {
+		const paper = new Paper( "texte et texte et texte et texte" );
 
 		const researcher = new Researcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
 
-		const expected = [
-			new ProminentWord( "texte", "texte", 4 ),
-		];
+		const expected = {
+			prominentWords: [],
+			metadescriptionAvailable: false,
+			titleAvailable: false,
+		};
+
+		const words = prominentWordsResearch( paper, researcher );
+
+		expect( words ).toEqual( expected );
+	} );
+
+	it( "does not break if no morphology support is added for the language", function() {
+		const paper = new Paper( "texte " + " et texte".repeat( 399 ), { locale: "fr_FR" } );
+
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		const expected = {
+			prominentWords: [ new ProminentWord( "texte", "texte", 400 ) ],
+			metadescriptionAvailable: false,
+			titleAvailable: false,
+		};
 
 		const words = prominentWordsResearch( paper, researcher );
 
@@ -24,17 +43,22 @@ describe( "relevantWords research", function() {
 	} );
 
 	it( "returns relevant words from the text alone if no attributes are available", function() {
-		const paper = new Paper( "Here are a ton of syllables. Syllables are very important. I think the syllable " +
+		const paper = new Paper( ( "Here are a ton of syllables. Syllables are very important. I think the syllable " +
 			"combinations are even more important. Syllable combinations for the win! Combinations are awesome. " +
-			"So many combinations!" );
+			"So many combinations! " ).repeat( 15 ) );
 
 		const researcher = new Researcher( paper );
 		researcher.addResearchData( "morphology", morphologyData );
 
-		const expected = [
-			new ProminentWord( "combinations", "combination", 4 ),
-			new ProminentWord( "syllable", "syllable", 4 ),
-		];
+		const expected = {
+			prominentWords: [
+				new ProminentWord( "combinations", "combination", 60 ),
+				new ProminentWord( "syllable", "syllable", 60 ),
+				new ProminentWord( "win", "win", 15 ),
+			],
+			metadescriptionAvailable: false,
+			titleAvailable: false,
+		};
 
 		const words = prominentWordsResearch( paper, researcher );
 
@@ -42,13 +66,13 @@ describe( "relevantWords research", function() {
 	} );
 
 	it( "combines data from the text and from the paper attributes", function() {
-		const paper = new Paper( "As we announced at YoastCon, we’re working together with Bing and Google to allow live indexing for " +
+		const paper = new Paper( ( "As we announced at YoastCon, we’re working together with Bing and Google to allow live indexing for " +
 			"everyone who uses Yoast SEO — free and premium. " +
 			"<h2>Subheading!</h2>" +
 			"In an update currently planned for the end of March, we’ll " +
 			"allow users to connect their sites to MyYoast, our customer portal. After that we’ll roll out live indexing, " +
 			"which means every time you publish, update, or delete a post, that will be reflected almost instantly into " +
-			"Bing and Google’s indices. How does this work? When you connect your site to MyYoast...", {
+			"Bing and Google’s indices. How does this work? When you connect your site to MyYoast... " ).repeat( 6 ), {
 			keyword: "live indexing Yoast SEO",
 			synonyms: "live index",
 			title: "Amazing title",
@@ -64,18 +88,46 @@ describe( "relevantWords research", function() {
 		 *  from the text of the paper. Therefore, the final number of occurrences can be calculated as
 		 *  number_of_occurrences_in_text + 3 * number_of_occurrences_in_paper_attributes.
 		 */
-		const expected = [
-			/*
-			 *  The stem "index" occurs 3 times in the text ("indexing", "indexing" and "indices") and 2 times in the
-			 *  attributes ("indexing" and "index"): 3 + 2 * 3 = 9
-			 */
-			new ProminentWord( "index", "index", 9 ),
-			// The stem "live" occurs 2 times in the text and 2 times in the attributes: 2 + 2 * 3 = 8
-			new ProminentWord( "live", "live", 8 ),
-			// The stems "seo" and "yoast" occur once in the text and once in the attributes: 1 + 1 * 3 = 4
-			new ProminentWord( "SEO", "seo", 4 ),
-			new ProminentWord( "yoast", "yoast", 4 ),
-		];
+		const expected = {
+			prominentWords: [
+				/*
+				*  The stem "index" occurs 18 times in the text ("indexing", "indexing" and "indices") and 2 times in the
+				*  attributes ("indexing" and "index"): 18 + 2 * 3 = 24
+				*/
+				new ProminentWord( "index", "index", 24 ),
+				new ProminentWord( "live", "live", 18 ),
+				new ProminentWord( "subheading", "subhead", 18 ),
+				new ProminentWord( "allow", "allow", 12 ),
+				new ProminentWord( "bing", "bing", 12 ),
+				new ProminentWord( "connect", "connect", 12 ),
+				new ProminentWord( "google", "google", 12 ),
+				new ProminentWord( "myyoast", "myyoast", 12 ),
+				new ProminentWord( "site", "site", 12 ),
+				new ProminentWord( "update", "update", 12 ),
+				new ProminentWord( "work", "work", 12 ),
+				new ProminentWord( "SEO", "seo", 9 ),
+				new ProminentWord( "yoast", "yoast", 9 ),
+				new ProminentWord( "customer", "custome", 6 ),
+				new ProminentWord( "delete", "delete", 6 ),
+				new ProminentWord( "end", "end", 6 ),
+				new ProminentWord( "free", "free", 6 ),
+				new ProminentWord( "march", "march", 6 ),
+				new ProminentWord( "planned", "plan", 6 ),
+				new ProminentWord( "portal", "portal", 6 ),
+				new ProminentWord( "post", "post", 6 ),
+				new ProminentWord( "premium", "premium", 6 ),
+				new ProminentWord( "publish", "publish", 6 ),
+				new ProminentWord( "reflected", "reflect", 6 ),
+				new ProminentWord( "roll", "roll", 6 ),
+				new ProminentWord( "time", "time", 6 ),
+				new ProminentWord( "together", "together", 6 ),
+				new ProminentWord( "uses", "use", 6 ),
+				new ProminentWord( "users", "user", 6 ),
+				new ProminentWord( "yoastcon", "yoastcon", 6 ),
+			],
+			metadescriptionAvailable: true,
+			titleAvailable: true,
+		};
 
 		const words = prominentWordsResearch( paper, researcher );
 

--- a/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
+++ b/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
@@ -25,6 +25,43 @@ describe( "relevantWords research", function() {
 		expect( words ).toEqual( expected );
 	} );
 
+	it( "returns no prominent words for texts between 300 and 400 words without title and metadescription", function() {
+		const paper = new Paper( "texte" + " et texte".repeat( 180 ) );
+
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		const expected = {
+			prominentWords: [],
+			metadescriptionAvailable: false,
+			titleAvailable: false,
+		};
+
+		const words = prominentWordsResearch( paper, researcher );
+
+		expect( words ).toEqual( expected );
+	} );
+
+	it( "does return prominent words for texts between 300 and 400 words with a title", function() {
+		const paper = new Paper( "texte" + " et texte".repeat( 180 ), { title: "Title" } );
+
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		const expected = {
+			prominentWords: [
+				new ProminentWord( "texte", "texte", 181 ),
+				new ProminentWord( "et", "et", 180 ),
+			],
+			metadescriptionAvailable: false,
+			titleAvailable: true,
+		};
+
+		const words = prominentWordsResearch( paper, researcher );
+
+		expect( words ).toEqual( expected );
+	} );
+
 	it( "does not break if no morphology support is added for the language", function() {
 		const paper = new Paper( "texte " + " et texte".repeat( 399 ), { locale: "fr_FR" } );
 

--- a/packages/yoastseo/spec/researches/relevantWordsSpec.js
+++ b/packages/yoastseo/spec/researches/relevantWordsSpec.js
@@ -7,21 +7,28 @@ const functionWords = functionWordsFactory().all;
 
 describe( "relevantWords research", function() {
 	it( "calls through to the string processing function", function() {
-		let input = "Here are a ton of syllables. Syllables are very important. I think the syllable combinations are even more important. Syllable combinations for the win!";
+		let input = ( "Here are a ton of syllables. Syllables are very important. I think the syllable combinations are " +
+			"even more important. Syllable combinations for the win!" ).repeat( 30 );
 		input = new Paper( input );
-		const expected = [
-			new WordCombination( [ "syllable", "combinations" ], 2, functionWords ),
-			new WordCombination( [ "syllables" ], 2, functionWords ),
-			new WordCombination( [ "syllable" ], 2, functionWords ),
-			new WordCombination( [ "combinations" ], 2, functionWords ),
-		];
+		const expected = {
+			prominentWords: [
+				new WordCombination( [ "syllable", "combinations", "for", "the", "win" ], 30, functionWords ),
+				new WordCombination( [ "syllable", "combinations" ], 60, functionWords ),
+				new WordCombination( [ "combinations", "for", "the", "win" ], 30, functionWords ),
+				new WordCombination( [ "syllables" ], 60, functionWords ),
+				new WordCombination( [ "syllable" ], 60, functionWords ),
+				new WordCombination( [ "combinations" ], 60, functionWords ),
+				new WordCombination( [ "win" ], 30, functionWords ),
+			],
+			metadescriptionAvailable: false,
+			titleAvailable: false,
+		};
 
 		// Make sure our words aren't filtered by density.
 		spyOn( WordCombination.prototype, "getDensity" ).and.returnValue( 0.01 );
 
 		const words = relevantWordsResearch( input );
-
-		words.forEach( function( word ) {
+		words.prominentWords.forEach( function( word ) {
 			delete( word._relevantWords );
 		} );
 

--- a/packages/yoastseo/spec/researches/relevantWordsSpec.js
+++ b/packages/yoastseo/spec/researches/relevantWordsSpec.js
@@ -6,6 +6,24 @@ import functionWordsFactory from "../../src/researches/english/functionWords.js"
 const functionWords = functionWordsFactory().all;
 
 describe( "relevantWords research", function() {
+	it( "returns no relevant words for short texts under 400 words", function() {
+		let input = "Here are a ton of syllables. Syllables are very important. I think the syllable combinations are even more important. Syllable combinations for the win!";
+		input = new Paper( input );
+
+		const expected = {
+			prominentWords: [],
+			metadescriptionAvailable: false,
+			titleAvailable: false,
+		};
+
+		// Make sure our words aren't filtered by density.
+		spyOn( WordCombination.prototype, "getDensity" ).and.returnValue( 0.01 );
+
+		const words = relevantWordsResearch( input );
+
+		expect( words ).toEqual( expected );
+	} );
+
 	it( "calls through to the string processing function", function() {
 		let input = ( "Here are a ton of syllables. Syllables are very important. I think the syllable combinations are " +
 			"even more important. Syllable combinations for the win!" ).repeat( 30 );

--- a/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
+++ b/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
@@ -1,5 +1,6 @@
 import { get, take } from "lodash-es";
 import getLanguage from "../helpers/getLanguage";
+import countWords from "../stringProcessing/countWords";
 import {
 	collapseProminentWordsOnStem,
 	filterProminentWords,
@@ -13,13 +14,37 @@ import { getSubheadingsTopLevel, removeSubheadingsTopLevel } from "../stringProc
 /**
  * Retrieves the prominent words from the given paper.
  *
- * @param {Paper} paper The paper to determine the prominent words of.
- * @param {Researcher} researcher The researcher to use for analysis.
+ * @param {Paper}       paper       The paper to determine the prominent words of.
+ * @param {Researcher}  researcher  The researcher to use for analysis.
  *
- * @returns {WordCombination[]} Prominent words for this paper, filtered and sorted.
+ * @returns {Object}          result                          A compound result object.
+ * @returns {ProminentWord[]} result.prominentWords           Prominent words for this paper, filtered and sorted.
+ * @returns {boolean}         result.metadescriptionAvailable Whether the metadescription is available in the input paper.
+ * @returns {boolean}         result.titleAvailable           Whether the title is available in the input paper.
  */
 function getProminentWordsForInternalLinking( paper, researcher ) {
 	const text = paper.getText();
+	const metadescription = paper.getDescription();
+	const title = paper.getTitle();
+
+	const result = {};
+	result.metadescriptionAvailable = metadescription !== "";
+	result.titleAvailable = title !== "";
+	result.prominentWords = [];
+
+	/**
+	 * We only want to return suggestions (and spend time calculating prominent words) if the text is at least 300 words
+	 * and has a title or a metadescription of if the text is at least 400 words if it has neither.
+ 	 */
+	const textLength = countWords( text );
+	if ( textLength < 300 ) {
+		return result;
+	}
+
+	if ( textLength < 400 && ( ! result.titleAvailable ) && ( ! result.metadescriptionAvailable ) ) {
+		return result;
+	}
+
 	const language = getLanguage( paper.getLocale() );
 	const morphologyData = get( researcher.getData( "morphology" ), language, false );
 
@@ -27,8 +52,8 @@ function getProminentWordsForInternalLinking( paper, researcher ) {
 	const attributes = [
 		paper.getKeyword(),
 		paper.getSynonyms(),
-		paper.getTitle(),
-		paper.getDescription(),
+		title,
+		metadescription,
 		subheadings.join( " " ),
 	];
 
@@ -51,10 +76,12 @@ function getProminentWordsForInternalLinking( paper, researcher ) {
 	 * Return the 100 top items from the collapsed and sorted list. The number is picked deliberately to prevent larger
 	 * articles from getting too long of lists.
 	 *
-	 * Minimum required occurrences set to 4 in order to avoid premature suggestions of words fro  the paper attributes.
+	 * Minimum required occurrences set to 4 in order to avoid premature suggestions of words from the paper attributes.
 	 * These get a times-3 boost and would therefore be prominent with just 1 occurrence.
 	 */
-	return take( filterProminentWords( collapsedWords, 4 ), 100 );
+	result.prominentWords = take( filterProminentWords( collapsedWords, 4 ), 100 );
+
+	return result;
 }
 
 

--- a/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
+++ b/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
@@ -34,7 +34,7 @@ function getProminentWordsForInternalLinking( paper, researcher ) {
 
 	/**
 	 * We only want to return suggestions (and spend time calculating prominent words) if the text is at least 300 words
-	 * and has a title or a metadescription of if the text is at least 400 words if it has neither.
+	 * and has a title or a metadescription or if the text is at least 400 words if it has neither.
  	 */
 	const textLength = countWords( text );
 	if ( textLength < 300 ) {

--- a/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
+++ b/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
@@ -37,11 +37,10 @@ function getProminentWordsForInternalLinking( paper, researcher ) {
 	 * and has a title or a metadescription or if the text is at least 400 words if it has neither.
  	 */
 	const textLength = countWords( text );
-	if ( textLength < 300 ) {
-		return result;
-	}
-
-	if ( textLength < 400 && ( ! result.titleAvailable ) && ( ! result.metadescriptionAvailable ) ) {
+	if (
+		( textLength < 300 ) ||
+		( textLength < 400 && ( ! result.titleAvailable ) && ( ! result.metadescriptionAvailable ) )
+	) {
 		return result;
 	}
 

--- a/packages/yoastseo/src/researches/relevantWords.js
+++ b/packages/yoastseo/src/researches/relevantWords.js
@@ -1,13 +1,36 @@
 import { getRelevantWords } from "../stringProcessing/relevantWords";
+import countWords from "../stringProcessing/countWords";
 
 /**
  * Retrieves the relevant words from the given paper.
  *
  * @param {Paper} paper The paper to determine the relevant words of.
- * @returns {WordCombination[]} Relevant words for this paper, filtered and sorted.
+ *
+ * @returns {Object}            result                          A compound result object.
+ * @returns {WordCombination[]} result.prominentWords           Relevant words for this paper, filtered and sorted.
+ * @returns {boolean}           result.metadescriptionAvailable Whether the metadescription is available in the input paper.
+ * @returns {boolean}           result.titleAvailable           Whether the title is available in the input paper.
  */
 function relevantWords( paper ) {
-	return getRelevantWords( paper.getText(), paper.getLocale() );
+	const text = paper.getText();
+	const metadescription = paper.getDescription();
+	const title = paper.getTitle();
+
+	const result = {};
+	result.metadescriptionAvailable = metadescription !== "";
+	result.titleAvailable = title !== "";
+	result.prominentWords = [];
+
+	/**
+	 * We only want to return suggestions (and spend time calculating prominent words) if the text is at least 300 words
+	 * and has a title or a metadescription of if the text is at least 400 words if it has neither.
+	 */
+	if ( countWords( text ) < 400 ) {
+		return result;
+	}
+
+	result.prominentWords = getRelevantWords( paper.getText(), paper.getLocale() );
+	return result;
 }
 
 


### PR DESCRIPTION
## Summary

<!--
Copy and fill in the following template as many times as there are individual changes.
-->
### yoastseo
  * Should the change be included in the package changelog?
    * [x] Yes
  * Should the change be included in one or more plugin changelogs?
    * [x] No
  * Package changelog item (if applicable): Changes the `getProminentWordsForInternalLinking` research so that it only runs for texts over 400 words or texts over 300 words with a title and/or a metadescription specified. Changes the output of the research so that it not only returns the list of prominent words but also information about the presence of metadescription and title, as well as the length of text. This information is later used to return a customized message to the user, within the internal linking suggestions container. 

### yoast-components
  * Should the change be included in the package changelog?
    * [ ] No
    * [x] Yes
  * Should the change be included in one or more plugin changelogs?
    * [x] No
    * [ ] Free
    * [ ] Premium
    * [ ] Other (please specify)
  * Package changelog item (if applicable): Changes the message the user receives in the internal linking suggestions container. The message now includes a notification to add a title and/or a metadescription (if those are missing) to improve the quality of internal linking suggestions.

## Relevant technical choices:

* This PR almost completely reverts https://github.com/Yoast/javascript/pull/320, because the logic of choosing a message to render is moved from `yoast-components` to `Premium`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* see https://github.com/Yoast/wordpress-seo-premium/pull/2496

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * internal linking suggestions
  * Insights

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #https://github.com/Yoast/wordpress-seo-premium/issues/2469
