### PR TITLE
Sentence beginnings assessment for Portuguese

### DIFF
--- a/packages/yoastseo/spec/researches/getSentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/researches/getSentenceBeginningsSpec.js
@@ -143,6 +143,34 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
 	} );
 
+	it( "returns an object with sentence beginnings and counts for two sentences in Portuguese starting with different words.", function() {
+		changePaper( { text: "Quem sou? Para onde vou?", locale: "pt_PT" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "quem" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings()[ 1 ].word ).toBe( "para" );
+		expect( getSentenceBeginnings()[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Portuguese starting with the same word.", function() {
+		changePaper( { text: "Dora pensa sobre o quanto ela ama sua floresta. Dora ama explorar a floresta, saltando de ramo para ramo entre as árvores altas.", locale: "es_ES" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "dora" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Portuguese all starting with one of the exception words.", function() {
+		changePaper( { text: "O mês estava frio. O mês foi difícil. O final disso os fez felizes.", locale: "pt_PT" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "o mês" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 2 );
+		expect( getSentenceBeginnings()[ 1 ].word ).toBe( "o final" );
+		expect( getSentenceBeginnings()[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for sentences in Portuguese that start with a character with a diacritic.", function() {
+		changePaper( { text: "Não viajo faz muito tempo. Não vi montanhas em anos. Não vi o mar desde que eu era pequeno.", locale: "es_ES" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "não" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
+	} );
+
 	it( "returns an object with sentence beginnings and counts for two sentences in Dutch starting with different words.", function() {
 		changePaper( { text: "Hallo wereld. Hoe gaat het? ", locale: "nl_NL" } );
 		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "hallo" );

--- a/packages/yoastseo/src/assessments/readability/sentenceBeginningsAssessment.js
+++ b/packages/yoastseo/src/assessments/readability/sentenceBeginningsAssessment.js
@@ -9,7 +9,7 @@ import Mark from "../../values/Mark";
 const maximumConsecutiveDuplicates = 2;
 
 import getLanguageAvailability from "../../helpers/getLanguageAvailability.js";
-const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru", "pl", "sv" ];
+const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru", "pl", "sv", "pt" ];
 
 /**
  * Counts and groups the number too often used sentence beginnings and determines the lowest count within that group.

--- a/packages/yoastseo/src/config/content/combinedConfig.js
+++ b/packages/yoastseo/src/config/content/combinedConfig.js
@@ -6,6 +6,7 @@ import ru from "./ru";
 import pl from "./pl";
 import es from "./es";
 import ca from "./ca";
+import pt from "./pt";
 
 const configurations = {
 	it: it,
@@ -13,6 +14,7 @@ const configurations = {
 	pl: pl,
 	es: es,
 	ca: ca,
+	pt: pt,
 };
 
 /**

--- a/packages/yoastseo/src/config/content/pt.js
+++ b/packages/yoastseo/src/config/content/pt.js
@@ -1,0 +1,11 @@
+/**
+ * Portuguese sentences tend to be longer than English ones (for which the recommended word limit is 20 words).
+ * This is why the sentence length limit was increased to 25 for Portuguese. For more detailed explanation, see:
+ * https://github.com/Yoast/research/wiki/Sentence-length-in-Portuguese
+ */
+
+export default {
+	sentenceLength: {
+		recommendedWordCount: 25,
+	},
+};

--- a/packages/yoastseo/src/helpers/getFirstWordExceptions.js
+++ b/packages/yoastseo/src/helpers/getFirstWordExceptions.js
@@ -7,7 +7,7 @@ import firstWordExceptionsItalian from "../researches/italian/firstWordException
 import firstWordExceptionsRussian from "../researches/russian/firstWordExceptions.js";
 import firstWordExceptionsPolish from "../researches/polish/firstWordExceptions.js";
 import firstWordExceptionsSwedish from "../researches/swedish/firstWordExceptions.js";
-import firstWordExceptionsPortuguese from "../researches/Portuguese/firstWordExceptions.js";
+import firstWordExceptionsPortuguese from "../researches/portuguese/firstWordExceptions.js";
 import getLanguage from "./getLanguage.js";
 
 /**

--- a/packages/yoastseo/src/helpers/getFirstWordExceptions.js
+++ b/packages/yoastseo/src/helpers/getFirstWordExceptions.js
@@ -18,27 +18,24 @@ import getLanguage from "./getLanguage.js";
  * @returns {Function} A function that will return the first word exceptions.
  */
 export default function( locale ) {
-	switch ( getLanguage( locale ) ) {
-		case "de":
-			return firstWordExceptionsGerman;
-		case "fr":
-			return firstWordExceptionsFrench;
-		case "es":
-			return firstWordExceptionsSpanish;
-		case "nl":
-			return firstWordExceptionsDutch;
-		case "it":
-			return firstWordExceptionsItalian;
-		case "ru":
-		    return firstWordExceptionsRussian;
-		case "pl":
-			return firstWordExceptionsPolish;
-		case "sv":
-			return firstWordExceptionsSwedish;
-		case "pt":
-			return firstWordExceptionsPortuguese;
-		default:
-		case "en":
-			return firstWordExceptionsEnglish;
+	const firstWordExceptions = {
+		en: firstWordExceptionsEnglish,
+		de: firstWordExceptionsGerman,
+		fr: firstWordExceptionsFrench,
+		es: firstWordExceptionsSpanish,
+		nl: firstWordExceptionsDutch,
+		it: firstWordExceptionsItalian,
+		ru: firstWordExceptionsRussian,
+		pl: firstWordExceptionsPolish,
+		sv: firstWordExceptionsSwedish,
+		pt: firstWordExceptionsPortuguese,
+	};
+
+	// If available, return the language-specific first word exceptions.
+	if ( Object.keys( firstWordExceptions ).includes( getLanguage( locale ) ) ) {
+		return firstWordExceptions[ getLanguage( locale ) ];
 	}
+
+	// Return the English first word exceptions as a default.
+	return firstWordExceptionsEnglish;
 }

--- a/packages/yoastseo/src/helpers/getFirstWordExceptions.js
+++ b/packages/yoastseo/src/helpers/getFirstWordExceptions.js
@@ -7,6 +7,7 @@ import firstWordExceptionsItalian from "../researches/italian/firstWordException
 import firstWordExceptionsRussian from "../researches/russian/firstWordExceptions.js";
 import firstWordExceptionsPolish from "../researches/polish/firstWordExceptions.js";
 import firstWordExceptionsSwedish from "../researches/swedish/firstWordExceptions.js";
+import firstWordExceptionsPortuguese from "../researches/Portuguese/firstWordExceptions.js";
 import getLanguage from "./getLanguage.js";
 
 /**
@@ -34,6 +35,8 @@ export default function( locale ) {
 			return firstWordExceptionsPolish;
 		case "sv":
 			return firstWordExceptionsSwedish;
+		case "pt":
+			return firstWordExceptionsPortuguese;
 		default:
 		case "en":
 			return firstWordExceptionsEnglish;

--- a/packages/yoastseo/src/researches/portuguese/firstWordExceptions.js
+++ b/packages/yoastseo/src/researches/portuguese/firstWordExceptions.js
@@ -1,0 +1,16 @@
+/**
+ * Returns an array with exceptions for the sentence beginning researcher.
+ * @returns {Array} The array filled with exceptions.
+ */
+export default function() {
+	return [
+		// Definite articles:
+		"o", "a", "os", "as",
+		// Indefinite articles:
+		"um", "uma", "uns", "umas",
+		// Numbers 1-10:
+		"um", "dois", "três", "quatro", "cinco", "seis", "sete", "oito", "nove", "dez",
+		// Demonstrative pronouns:
+		"este", "estes", "esta", "estas", "esse", "esses", "essa", "essas", "aquele",
+		"aqueles", "aquela", "aquelas", "isto", "isso", "aquilo" ];
+}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Implements the assessment that checks if multiple sentences begin with the same word for Portuguese.

## Test instructions

This PR can be tested by following these steps:

* In your WordPress testing environment, set the language to Portuguese.
* Open a new post or page.
* Write three or more Portuguese sentences...
    * that all begin with the same written-out number, like `um` (one), `dois` (two) or `oito` (eight).
       * E.g. `Três gatos estão em casa. Três ratos estão no telhado. Três cavalos estão no estábulo. Três pessoas estão dançando no salão de baile.`
    * that all begin with the same demonstrative pronoun, like `este` or `isto` (forms of 'this').
       * E.g. `Esta pessoa vem na nossa direcção. Esta casa é grande. Esta faca também é grande. Esta casa é grande.`
    * that all begin with the same definite article, like `o` or `as` (forms of 'the').
* In all of the above cases, the sentence beginning readability assessment should read: `Consecutive sentences: There is enough variety in your sentences. That's great!`
* Write three or more Portuguese sentences that begin with the same word.
  * E.g. `Olá, como estás? Olá, estou bem. Olá mundo! Olá!`
* The sentence beginning readability assessment should read: `Consecutive sentences: The text contains 4 consecutive sentences starting with the same word. Try to mix things up!`


Fixes #338 

