### PR TITLE
Change desktop font size to match google

### DIFF
--- a/apps/components/SnippetEditorExample.js
+++ b/apps/components/SnippetEditorExample.js
@@ -65,8 +65,8 @@ export default class SnippetEditorExample extends Component {
 			title: "Welcome to the Gutenberg Editor - Local WordPress Dev. Snippet Title Snippet" +
 			" Snippet: %%snippet%% Title: %%title%% Manual: %%snippet_manual%% Type: %%post_type%%" +
 			" %%these%% %%are%% %%not%% %%tags%% and throw in some % here %%%%%%% and %%there too%%",
-			url: "https://local.wordpress.test/welcome-to-the-gutenberg-editor-2/",
-			slug: "welcome-to-the-gutenberg-editor-2",
+			url: "https://local.wordpress.test/welcome-to-the-gutenberg-editor/",
+			slug: "welcome-to-the-gutenberg-editor",
 			description: "Merci, merçi, Of Mountains & Printing Presses The goal of this new editor is to make" +
 			" adding rich content to WordPress simple and enjoyable. This whole post is composed" +
 			" of. Of Mountains & Printing Presses The goal of this new editor is to make adding" +

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -32,8 +32,10 @@ const colorTitleDesktop         = "#1e0fbe";
 const colorTitleMobile          = "#1967d2";
 const colorUrlDesktop           = "#006621";
 const colorUrlMobile            = "#3c4043";
-const fontSizeUrlDesktop        = "14px";
+const fontSizeUrlDesktop        = "16px";
 const fontSizeUrlMobile         = "12px";
+const fontSizeTitleDesktop      = "20px";
+const fontSizeTitleMobile       = "28px";
 const colorDescriptionDesktop   = "#545454";
 const colorDescriptionMobile    = "#3c4043";
 const colorGeneratedDescription = "#777";
@@ -93,7 +95,7 @@ function addCaretStyle( WithoutCaret, color, mode ) {
 const Title = styled.div`
 	color: ${ props => props.screenMode === MODE_DESKTOP ? colorTitleDesktop : colorTitleMobile };
 	text-decoration: none;
-	font-size: 18px;
+	font-size: ${ props => props.screenMode === MODE_DESKTOP ? fontSizeTitleDesktop : fontSizeTitleMobile };
 	line-height: 1.2;
 	font-weight: normal;
 	margin: 0;
@@ -155,7 +157,7 @@ const DesktopDescription = styled.div`
 	cursor: pointer;
 	position: relative;
 	max-width: ${ MAX_WIDTH }px;
-	font-size: 13px;
+	font-size: 14px;
 `;
 
 const MobileDescription = styled.div`

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -28,18 +28,26 @@ import { angleLeft, angleRight } from "../shared";
  * These colors should not be abstracted. They are chosen because Google renders
  * the snippet like this.
  */
-const colorTitleDesktop         = "#1e0fbe";
+const colorTitleDesktop         = "#1a0dab"; // was #1e0fbe
 const colorTitleMobile          = "#1967d2";
 const colorUrlDesktop           = "#006621";
 const colorUrlMobile            = "#3c4043";
-const fontSizeUrlDesktop        = "16px";
-const fontSizeUrlMobile         = "12px";
-const fontSizeTitleDesktop      = "20px";
-const fontSizeTitleMobile       = "28px";
 const colorDescriptionDesktop   = "#545454";
 const colorDescriptionMobile    = "#3c4043";
-const colorGeneratedDescription = "#777";
-const colorDate                 = "#70757f";
+const colorGeneratedDescription = "#767676"; // 4.5:1 contrast
+const colorDateDesktop          = "#777";
+const colorDateMobile           = "#70757a"; // was #70757f for both desktop and mobile
+
+// Font sizes and line-heights.
+const fontSizeTitleMobile    = "16px";
+const lineHeightTitleMobile  = "20px";
+
+const fontSizeTitleDesktop   = "20px";
+const lineHeightTitleDesktop = "1.3";
+
+const fontSizeUrlMobile      = "12px";
+const fontSizeUrlDesktop     = "16px";
+
 
 const MAX_WIDTH         = 600;
 const MAX_WIDTH_MOBILE  = 400;
@@ -47,7 +55,7 @@ const WIDTH_PADDING     = 20;
 const DESCRIPTION_LIMIT = 156;
 
 const DesktopContainer = styled( FixedWidthContainer )`
-	background-color: white;
+	background-color: #fff;
 	font-family: arial, sans-serif;
 	box-sizing: border-box;
 `;
@@ -81,12 +89,14 @@ function addCaretStyle( WithoutCaret, color, mode ) {
 		&::before {
 			display: block;
 			position: absolute;
-			top: -3px;
+			top: 0;
 			${ getDirectionalStyle( "left", "right" ) }: ${ () => mode === MODE_DESKTOP ? "-22px" : "-40px" };
-			width: 24px;
-			height: 24px;
+			width: 22px;
+			height: 22px;
 			background-image: url( ${ getDirectionalStyle( angleRight( color ), angleLeft( color ) ) } );
-			background-size: 25px;
+			background-size: 24px;
+			background-repeat: no-repeat;
+			background-position: center;
 			content: "";
 		}
 	`;
@@ -96,7 +106,7 @@ const Title = styled.div`
 	color: ${ props => props.screenMode === MODE_DESKTOP ? colorTitleDesktop : colorTitleMobile };
 	text-decoration: none;
 	font-size: ${ props => props.screenMode === MODE_DESKTOP ? fontSizeTitleDesktop : fontSizeTitleMobile };
-	line-height: 1.2;
+	line-height: ${ props => props.screenMode === MODE_DESKTOP ? lineHeightTitleDesktop : lineHeightTitleMobile };
 	font-weight: normal;
 	margin: 0;
 	display: inline-block;
@@ -118,9 +128,8 @@ const TitleUnboundedDesktop = styled.span`
 
 const TitleUnboundedMobile = styled.span`
 	display: inline-block;
-	font-size: 16px;
-	line-height: 20px;
 	max-height: 40px; // max two lines of text
+	padding-top: 1px;
 	vertical-align: top;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -133,6 +142,7 @@ const BaseUrl = styled.div`
 	max-width: 90%;
 	white-space: nowrap;
 	font-size: 14px;
+	vertical-align: top;
 `;
 
 const BaseUrlOverflowContainer = styled( BaseUrl )`
@@ -140,8 +150,8 @@ const BaseUrlOverflowContainer = styled( BaseUrl )`
 	text-overflow: ellipsis;
 	max-width: 100%;
 	margin-bottom: ${ props => props.screenMode === MODE_DESKTOP ? "0" : "12px" };
-	padding-top: ${ props => props.screenMode === MODE_DESKTOP ? "0" : "1px" };
-	line-height: ${ props => props.screenMode === MODE_DESKTOP ? "inherit" : "20px" };
+	padding-top: 1px;
+	line-height: ${ props => props.screenMode === MODE_DESKTOP ? "1.5" : "20px" };
 	vertical-align: ${ props => props.screenMode === MODE_DESKTOP ? "baseline" : "top" };
 `;
 
@@ -157,7 +167,9 @@ const DesktopDescription = styled.div`
 	cursor: pointer;
 	position: relative;
 	max-width: ${ MAX_WIDTH }px;
+	padding-top: ${ props => props.screenMode === MODE_DESKTOP ? "0" : "1px" };
 	font-size: 14px;
+	line-height: 1.57;
 `;
 
 const MobileDescription = styled.div`
@@ -204,7 +216,7 @@ const DesktopPartContainer = styled.div`
 
 const UrlDownArrow = styled.div`
 	display: inline-block;
-	margin-top: 6px;
+	margin-top: 9px;
 	margin-left: 6px;
 	border-top: 5px solid #006621;
 	border-right: 4px solid transparent;
@@ -213,7 +225,7 @@ const UrlDownArrow = styled.div`
 `;
 
 const DatePreview = styled.span`
-	color: ${ colorDate };
+	color: ${ props => props.screenMode === MODE_DESKTOP ? colorDateDesktop : colorDateMobile };
 `;
 
 const globeFaviconSrc = "data:image/png;base64," +
@@ -472,9 +484,8 @@ export default class SnippetPreview extends PureComponent {
 		// The u22C5 is the unicode character "dot operator" equivalent to `&sdot;`.
 		const separator = this.props.mode === MODE_DESKTOP ? "-" : "\u22C5";
 
-		return this.props.date === ""
-			? null
-			: <DatePreview>{ this.props.date } { separator } </DatePreview>;
+		return this.props.date &&
+			<DatePreview screenMode={ this.props.mode }>{ this.props.date } { separator } </DatePreview>;
 	}
 
 	/**

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -28,15 +28,18 @@ import { angleLeft, angleRight } from "../shared";
  * These colors should not be abstracted. They are chosen because Google renders
  * the snippet like this.
  */
-const colorTitleDesktop         = "#1a0dab"; // was #1e0fbe
+// Was #1e0fbe
+const colorTitleDesktop         = "#1a0dab";
 const colorTitleMobile          = "#1967d2";
 const colorUrlDesktop           = "#006621";
 const colorUrlMobile            = "#3c4043";
 const colorDescriptionDesktop   = "#545454";
 const colorDescriptionMobile    = "#3c4043";
-const colorGeneratedDescription = "#767676"; // 4.5:1 contrast
+// Changed to have 4.5:1 contrast.
+const colorGeneratedDescription = "#767676";
+// Was #70757f for both desktop and mobile
 const colorDateDesktop          = "#777";
-const colorDateMobile           = "#70757a"; // was #70757f for both desktop and mobile
+const colorDateMobile           = "#70757a";
 
 // Font sizes and line-heights.
 const fontSizeTitleMobile    = "16px";

--- a/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -20,7 +20,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -891,7 +891,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -1822,7 +1822,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -5166,7 +5168,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -6097,7 +6099,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -9441,7 +9445,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -10372,7 +10376,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -13716,7 +13722,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -14647,7 +14653,9 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -17818,7 +17826,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -18542,7 +18550,9 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -20241,7 +20251,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -21172,7 +21182,9 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -24516,7 +24528,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -25447,7 +25459,9 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -28618,7 +28632,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -29208,7 +29222,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -29971,7 +29985,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -30929,7 +30943,9 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -34282,7 +34298,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -35240,7 +35256,9 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -38593,7 +38611,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -39524,7 +39542,9 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -42868,7 +42888,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -43810,7 +43830,9 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -47036,7 +47058,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -47919,7 +47941,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -48850,7 +48872,9 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                       "rules": Array [
                                         "color:",
                                         [Function],
-                                        ";text-decoration:none;font-size:18px;line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";text-decoration:none;font-size:",
+                                        [Function],
+                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -52029,7 +52053,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -52073,7 +52097,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -52082,7 +52106,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {
@@ -52769,7 +52793,7 @@ exports[`SnippetEditor renders the snippet editor without a close button when sh
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -53501,7 +53525,7 @@ exports[`SnippetEditor shows the editor 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;

--- a/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -20,8 +20,8 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -36,9 +36,8 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -51,6 +50,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -60,6 +60,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -485,6 +486,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
             className="c9"
           >
             
+            
             Totally different description
           </div>
         </div>
@@ -891,8 +893,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -907,9 +909,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -922,6 +923,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -931,6 +933,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -1614,7 +1617,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -1648,12 +1651,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -1824,7 +1825,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -1861,7 +1864,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -5168,8 +5171,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -5184,9 +5187,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -5199,6 +5201,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -5208,6 +5211,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -5891,7 +5895,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -5925,12 +5929,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -6101,7 +6103,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -6138,7 +6142,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -9445,8 +9449,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -9461,9 +9465,8 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -9476,6 +9479,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -9485,6 +9489,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -10168,7 +10173,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -10202,12 +10207,10 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -10378,7 +10381,9 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -10415,7 +10420,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -13722,8 +13727,8 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -13738,9 +13743,8 @@ exports[`SnippetEditor closes when calling close() 1`] = `
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -13753,6 +13757,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -13762,6 +13767,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -14445,7 +14451,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -14479,12 +14485,10 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -14655,7 +14659,9 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -14692,7 +14698,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -17826,8 +17832,8 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -17842,9 +17848,8 @@ exports[`SnippetEditor closes when calling close() 2`] = `
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -17857,6 +17862,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -17866,6 +17872,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -18342,7 +18349,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -18376,12 +18383,10 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -18552,7 +18557,9 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -18589,7 +18596,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -20251,8 +20258,8 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -20267,9 +20274,8 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -20282,6 +20288,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -20291,6 +20298,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -20974,7 +20982,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -21008,12 +21016,10 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -21184,7 +21190,9 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -21221,7 +21229,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -24528,8 +24536,8 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -24544,9 +24552,8 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -24559,6 +24566,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -24568,6 +24576,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -25251,7 +25260,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -25285,12 +25294,10 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -25461,7 +25468,9 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -25498,7 +25507,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -28632,8 +28641,8 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -28648,9 +28657,8 @@ exports[`SnippetEditor highlights a focused field 1`] = `
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -28663,6 +28671,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -28672,6 +28681,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -29097,6 +29107,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
             className="c9"
           >
             
+            
             Test description, %%replacement_variable%%
           </div>
         </div>
@@ -29222,8 +29233,8 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -29238,9 +29249,8 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -29253,6 +29263,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -29262,6 +29273,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -29686,6 +29698,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
           <div
             className="c9"
           >
+            
             
             Test description, %%replacement_variable%%
           </div>
@@ -29985,8 +29998,8 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -30001,9 +30014,8 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -30016,6 +30028,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -30025,6 +30038,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -30532,12 +30546,14 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
 .c9::before {
   display: block;
   position: absolute;
-  top: -3px;
+  top: 0;
   left: -40px;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23555%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  background-size: 25px;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
   content: "";
 }
 
@@ -30735,7 +30751,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -30769,12 +30785,10 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -30945,7 +30959,9 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -30982,7 +30998,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -31095,13 +31111,13 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                                   ";font-size:14px;line-height:20px;cursor:pointer;position:relative;max-width:",
                                   "600",
                                   "px;&:after{display:table;content:\\"\\";clear:both;}",
-                                  "&::before{display:block;position:absolute;top:-3px;",
+                                  "&::before{display:block;position:absolute;top:0;",
                                   [Function],
                                   ":",
                                   [Function],
-                                  ";width:24px;height:24px;background-image:url( ",
+                                  ";width:22px;height:22px;background-image:url( ",
                                   [Function],
-                                  " );background-size:25px;content:\\"\\";}",
+                                  " );background-size:24px;background-repeat:no-repeat;background-position:center;content:\\"\\";}",
                                 ],
                               },
                               "displayName": "SnippetPreview",
@@ -34298,8 +34314,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -34314,9 +34330,8 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -34329,6 +34344,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -34338,6 +34354,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -34845,12 +34862,14 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
 .c9::before {
   display: block;
   position: absolute;
-  top: -3px;
+  top: 0;
   left: -40px;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  background-size: 25px;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
   content: "";
 }
 
@@ -35048,7 +35067,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -35082,12 +35101,10 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -35258,7 +35275,9 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -35295,7 +35314,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -35408,13 +35427,13 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                                   ";font-size:14px;line-height:20px;cursor:pointer;position:relative;max-width:",
                                   "600",
                                   "px;&:after{display:table;content:\\"\\";clear:both;}",
-                                  "&::before{display:block;position:absolute;top:-3px;",
+                                  "&::before{display:block;position:absolute;top:0;",
                                   [Function],
                                   ":",
                                   [Function],
-                                  ";width:24px;height:24px;background-image:url( ",
+                                  ";width:22px;height:22px;background-image:url( ",
                                   [Function],
-                                  " );background-size:25px;content:\\"\\";}",
+                                  " );background-size:24px;background-repeat:no-repeat;background-position:center;content:\\"\\";}",
                                 ],
                               },
                               "displayName": "SnippetPreview",
@@ -38611,8 +38630,8 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -38627,9 +38646,8 @@ exports[`SnippetEditor opens when calling open() 1`] = `
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -38642,6 +38660,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -38651,6 +38670,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -39334,7 +39354,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -39368,12 +39388,10 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -39544,7 +39562,9 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -39581,7 +39601,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -42888,8 +42908,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -42904,9 +42924,8 @@ exports[`SnippetEditor passes replacement variables to the title and description
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -42919,6 +42938,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -42928,6 +42948,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -43622,7 +43643,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -43656,12 +43677,10 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -43832,7 +43851,9 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -43869,7 +43890,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -47058,8 +47079,8 @@ exports[`SnippetEditor passes the date prop 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -47074,9 +47095,8 @@ exports[`SnippetEditor passes the date prop 1`] = `
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -47089,6 +47109,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -47098,6 +47119,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -47136,7 +47158,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
 }
 
 .c10 {
-  color: #70757f;
+  color: #70757a;
 }
 
 .c4 {
@@ -47941,8 +47963,8 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -47957,9 +47979,8 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -47972,6 +47993,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -47981,6 +48003,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -48664,7 +48687,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                 "isStatic": true,
                                 "lastClassName": "c2",
                                 "rules": Array [
-                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                  "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                 ],
                               },
                               "displayName": "SnippetPreview__BaseUrl",
@@ -48698,12 +48721,10 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                       "isStatic": false,
                                       "lastClassName": "c3",
                                       "rules": Array [
-                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;",
+                                        "display:inline-block;cursor:pointer;position:relative;max-width:90%;white-space:nowrap;font-size:14px;vertical-align:top;",
                                         "overflow:hidden;text-overflow:ellipsis;max-width:100%;margin-bottom:",
                                         [Function],
-                                        ";padding-top:",
-                                        [Function],
-                                        ";line-height:",
+                                        ";padding-top:1px;line-height:",
                                         [Function],
                                         ";vertical-align:",
                                         [Function],
@@ -48874,7 +48895,9 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                         [Function],
                                         ";text-decoration:none;font-size:",
                                         [Function],
-                                        ";line-height:1.2;font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
+                                        ";line-height:",
+                                        [Function],
+                                        ";font-weight:normal;margin:0;display:inline-block;overflow:hidden;max-width:",
                                         "600",
                                         "px;vertical-align:top;text-overflow:ellipsis;",
                                         "max-width:",
@@ -48911,7 +48934,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                                             "isStatic": true,
                                             "lastClassName": "c8",
                                             "rules": Array [
-                                              "display:inline-block;font-size:16px;line-height:20px;max-height:40px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
+                                              "display:inline-block;max-height:40px;padding-top:1px;vertical-align:top;overflow:hidden;text-overflow:ellipsis;",
                                             ],
                                           },
                                           "displayName": "SnippetPreview__TitleUnboundedMobile",
@@ -52039,7 +52062,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -52050,11 +52073,11 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -52078,6 +52101,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -52087,12 +52111,13 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -52106,12 +52131,14 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -52495,6 +52522,7 @@ exports[`SnippetEditor renders in desktop mode 1`] = `
             onMouseLeave={[Function]}
             onMouseUp={[Function]}
           >
+            
             Test description, %%replacement_variable%%
           </div>
         </div>
@@ -52793,8 +52821,8 @@ exports[`SnippetEditor renders the snippet editor without a close button when sh
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -52809,9 +52837,8 @@ exports[`SnippetEditor renders the snippet editor without a close button when sh
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -52824,6 +52851,7 @@ exports[`SnippetEditor renders the snippet editor without a close button when sh
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -52833,6 +52861,7 @@ exports[`SnippetEditor renders the snippet editor without a close button when sh
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -53305,6 +53334,7 @@ exports[`SnippetEditor renders the snippet editor without a close button when sh
             className="c9"
           >
             
+            
             Test description, %%replacement_variable%%
           </div>
         </div>
@@ -53525,8 +53555,8 @@ exports[`SnippetEditor shows the editor 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -53541,9 +53571,8 @@ exports[`SnippetEditor shows the editor 1`] = `
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -53556,6 +53585,7 @@ exports[`SnippetEditor shows the editor 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -53565,6 +53595,7 @@ exports[`SnippetEditor shows the editor 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -53989,6 +54020,7 @@ exports[`SnippetEditor shows the editor 1`] = `
           <div
             className="c9"
           >
+            
             
             Test description, %%replacement_variable%%
           </div>

--- a/packages/search-metadata-previews/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/packages/search-metadata-previews/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -14,7 +14,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -25,11 +25,11 @@ exports[`SnippetPreview changes the colors of the description if it was generate
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -53,6 +53,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -62,12 +63,13 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -81,12 +83,14 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -191,6 +195,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           Description
         </div>
       </div>
@@ -213,7 +218,7 @@ exports[`SnippetPreview highlights a keyword in different morphological forms 1`
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -224,11 +229,11 @@ exports[`SnippetPreview highlights a keyword in different morphological forms 1`
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -252,6 +257,7 @@ exports[`SnippetPreview highlights a keyword in different morphological forms 1`
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -261,12 +267,13 @@ exports[`SnippetPreview highlights a keyword in different morphological forms 1`
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -280,12 +287,14 @@ exports[`SnippetPreview highlights a keyword in different morphological forms 1`
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -390,6 +399,7 @@ exports[`SnippetPreview highlights a keyword in different morphological forms 1`
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           She
           <strong>
              runs
@@ -424,7 +434,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -435,11 +445,11 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -463,6 +473,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -472,12 +483,13 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -491,12 +503,14 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -601,6 +615,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           Something with a transliterated
           <strong>
              kaayword
@@ -626,7 +641,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -637,11 +652,11 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -665,6 +680,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -674,12 +690,13 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -693,12 +710,14 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -803,6 +822,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           Something with a
           <strong>
              keyword
@@ -828,7 +848,7 @@ exports[`SnippetPreview highlights separate words from the keyphrase 1`] = `
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -839,11 +859,11 @@ exports[`SnippetPreview highlights separate words from the keyphrase 1`] = `
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -867,6 +887,7 @@ exports[`SnippetPreview highlights separate words from the keyphrase 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -876,12 +897,13 @@ exports[`SnippetPreview highlights separate words from the keyphrase 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -895,12 +917,14 @@ exports[`SnippetPreview highlights separate words from the keyphrase 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -1005,6 +1029,7 @@ exports[`SnippetPreview highlights separate words from the keyphrase 1`] = `
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           She
           <strong>
              runs
@@ -1051,8 +1076,8 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -1067,9 +1092,8 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1082,6 +1106,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -1091,6 +1116,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -1251,6 +1277,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
           className="c10"
         >
           
+          
           Description
         </div>
       </div>
@@ -1279,8 +1306,8 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -1295,9 +1322,8 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1310,6 +1336,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -1319,6 +1346,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -1464,6 +1492,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
         <div
           className="c9"
         >
+          
           
           Description
         </div>
@@ -1493,8 +1522,8 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 28px;
-  line-height: 1.2;
+  font-size: 16px;
+  line-height: 20px;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -1509,9 +1538,8 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
 
 .c8 {
   display: inline-block;
-  font-size: 16px;
-  line-height: 20px;
   max-height: 40px;
+  padding-top: 1px;
   vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1524,6 +1552,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c3 {
@@ -1533,6 +1562,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
@@ -1679,6 +1709,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
           className="c9"
         >
           
+          
           Description
         </div>
       </div>
@@ -1701,7 +1732,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -1712,11 +1743,11 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -1740,6 +1771,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -1749,12 +1781,13 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -1768,12 +1801,14 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -1878,6 +1913,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           Description
         </div>
       </div>
@@ -1900,17 +1936,17 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -1934,6 +1970,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -1943,12 +1980,13 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -1962,12 +2000,14 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -1983,12 +2023,14 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
 .c3::before {
   display: block;
   position: absolute;
-  top: -3px;
+  top: 0;
   left: -22px;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23555%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  background-size: 25px;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
   content: "";
 }
 
@@ -2089,6 +2131,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           Description
         </div>
       </div>
@@ -2111,7 +2154,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -2122,11 +2165,11 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -2150,6 +2193,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -2159,12 +2203,13 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -2175,7 +2220,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -2188,18 +2233,22 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c10::before {
   display: block;
   position: absolute;
-  top: -3px;
+  top: 0;
   left: -22px;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23555%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  background-size: 25px;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
   content: "";
 }
 
@@ -2300,6 +2349,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           Description
         </div>
       </div>
@@ -2322,7 +2372,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -2333,11 +2383,11 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -2361,12 +2411,13 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -2380,12 +2431,14 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -2400,17 +2453,20 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c6::before {
   display: block;
   position: absolute;
-  top: -3px;
+  top: 0;
   left: -22px;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23555%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  background-size: 25px;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
   content: "";
 }
 
@@ -2511,6 +2567,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           Description
         </div>
       </div>
@@ -2533,17 +2590,17 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -2567,6 +2624,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -2576,12 +2634,13 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -2595,12 +2654,14 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -2616,12 +2677,14 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
 .c3::before {
   display: block;
   position: absolute;
-  top: -3px;
+  top: 0;
   left: -22px;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  background-size: 25px;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
   content: "";
 }
 
@@ -2722,6 +2785,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           Description
         </div>
       </div>
@@ -2744,7 +2808,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -2755,11 +2819,11 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -2783,6 +2847,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -2792,12 +2857,13 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -2808,7 +2874,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -2821,18 +2887,22 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c10::before {
   display: block;
   position: absolute;
-  top: -3px;
+  top: 0;
   left: -22px;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  background-size: 25px;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
   content: "";
 }
 
@@ -2933,6 +3003,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           Description
         </div>
       </div>
@@ -2955,7 +3026,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -2966,11 +3037,11 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -2994,12 +3065,13 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -3013,12 +3085,14 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -3033,17 +3107,20 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c6::before {
   display: block;
   position: absolute;
-  top: -3px;
+  top: 0;
   left: -22px;
-  width: 24px;
-  height: 24px;
+  width: 22px;
+  height: 22px;
   background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  background-size: 25px;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
   content: "";
 }
 
@@ -3144,6 +3221,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
           onMouseLeave={[Function]}
           onMouseUp={[Function]}
         >
+          
           Description
         </div>
       </div>
@@ -3166,7 +3244,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
 }
 
 .c0 {
-  background-color: white;
+  background-color: #fff;
   font-family: arial,sans-serif;
   box-sizing: border-box;
 }
@@ -3177,11 +3255,11 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
 }
 
 .c4 {
-  color: #1e0fbe;
+  color: #1a0dab;
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 20px;
-  line-height: 1.2;
+  line-height: 1.3;
   font-weight: normal;
   margin: 0;
   display: inline-block;
@@ -3205,6 +3283,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
 }
 
 .c7 {
@@ -3214,12 +3293,13 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   max-width: 90%;
   white-space: nowrap;
   font-size: 14px;
+  vertical-align: top;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 100%;
   margin-bottom: 0;
-  padding-top: 0;
-  line-height: inherit;
+  padding-top: 1px;
+  line-height: 1.5;
   vertical-align: baseline;
 }
 
@@ -3233,12 +3313,14 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
+  padding-top: 1px;
   font-size: 14px;
+  line-height: 1.57;
 }
 
 .c9 {
   display: inline-block;
-  margin-top: 6px;
+  margin-top: 9px;
   margin-left: 6px;
   border-top: 5px solid #006621;
   border-right: 4px solid transparent;
@@ -3247,7 +3329,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
 }
 
 .c11 {
-  color: #70757f;
+  color: #777;
 }
 
 <section>

--- a/packages/search-metadata-previews/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/packages/search-metadata-previews/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -28,7 +28,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -72,7 +72,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -81,7 +81,7 @@ exports[`SnippetPreview changes the colors of the description if it was generate
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {
@@ -227,7 +227,7 @@ exports[`SnippetPreview highlights a keyword in different morphological forms 1`
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -271,7 +271,7 @@ exports[`SnippetPreview highlights a keyword in different morphological forms 1`
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -280,7 +280,7 @@ exports[`SnippetPreview highlights a keyword in different morphological forms 1`
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {
@@ -438,7 +438,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -482,7 +482,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -491,7 +491,7 @@ exports[`SnippetPreview highlights keywords even if they are transliterated 1`] 
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {
@@ -640,7 +640,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -684,7 +684,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -693,7 +693,7 @@ exports[`SnippetPreview highlights keywords inside the description and url 1`] =
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {
@@ -842,7 +842,7 @@ exports[`SnippetPreview highlights separate words from the keyphrase 1`] = `
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -886,7 +886,7 @@ exports[`SnippetPreview highlights separate words from the keyphrase 1`] = `
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -895,7 +895,7 @@ exports[`SnippetPreview highlights separate words from the keyphrase 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {
@@ -1051,7 +1051,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -1279,7 +1279,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -1493,7 +1493,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
   color: #1967d2;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 28px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -1715,7 +1715,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -1759,7 +1759,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -1768,7 +1768,7 @@ exports[`SnippetPreview renders a SnippetPreview that looks like Google 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {
@@ -1909,7 +1909,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -1953,7 +1953,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -1962,7 +1962,7 @@ exports[`SnippetPreview renders a caret on activation 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {
@@ -2125,7 +2125,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -2169,7 +2169,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -2188,7 +2188,7 @@ exports[`SnippetPreview renders a caret on activation 2`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c10::before {
@@ -2336,7 +2336,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -2371,7 +2371,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -2380,7 +2380,7 @@ exports[`SnippetPreview renders a caret on activation 3`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {
@@ -2542,7 +2542,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -2586,7 +2586,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -2595,7 +2595,7 @@ exports[`SnippetPreview renders a caret on hover 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {
@@ -2758,7 +2758,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -2802,7 +2802,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -2821,7 +2821,7 @@ exports[`SnippetPreview renders a caret on hover 2`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c10::before {
@@ -2969,7 +2969,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -3004,7 +3004,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -3013,7 +3013,7 @@ exports[`SnippetPreview renders a caret on hover 3`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {
@@ -3180,7 +3180,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   color: #1e0fbe;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 18px;
+  font-size: 20px;
   line-height: 1.2;
   font-weight: normal;
   margin: 0;
@@ -3224,7 +3224,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
 }
 
 .c8 {
-  font-size: 14px;
+  font-size: 16px;
   color: #006621;
 }
 
@@ -3233,7 +3233,7 @@ exports[`SnippetPreview shows the date if a date is passed 1`] = `
   cursor: pointer;
   position: relative;
   max-width: 600px;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 .c9 {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Changes desktop snippet preview to match Google's new font sizes.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Inspect the snippet preview. Make sure the mobile snippet preview fot sizes haven't changed, and the desktop snippet preview font sizes are the following:
Title: 20px
URL: 16px
Meta description: 14px

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Snippet preview

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes Yoast/wordpress-seo#13421
