### PR TITLE
Provide singular and plural form for the Prominent Words occurrences string

### DIFF
--- a/apps/components/WordOccurrencesWrapper.js
+++ b/apps/components/WordOccurrencesWrapper.js
@@ -108,7 +108,7 @@ class WordOccurrencesWrapper extends React.Component {
 					nextState.relevantWords[ index ]._stem = input;
 					break;
 				case "_occurrences":
-					nextState.relevantWords[ index ].setOccurrences( input );
+					nextState.relevantWords[ index ].setOccurrences( parseInt( input, 10 ) );
 					break;
 			}
 			return nextState;

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -13,7 +13,7 @@
   "license": "GPL-3.0",
   "scripts": {
     "test": "jest",
-    "lint": "eslint . --max-warnings=96",
+    "lint": "eslint . --max-warnings=94",
     "prepublishOnly": "rm -rf dist && cp -R src dist && cp package.json dist/package.json && json -I -f dist/package.json -e \"this.main='index.js'\" && cp .babelrc dist/.babelrc"
   },
   "jest": {

--- a/packages/components/src/WordOccurrences.js
+++ b/packages/components/src/WordOccurrences.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
-import { __, sprintf } from "@wordpress/i18n";
+import { __, _n, sprintf } from "@wordpress/i18n";
 
 const ProminentWordOccurrence = styled.span`
 	display: inline-block;
@@ -54,7 +54,15 @@ const WordBar = ( { word, occurrence, width } ) => {
 			<ProminentWord>{ word }</ProminentWord>
 			<ProminentWordOccurrence>
 				<span aria-hidden={ true }>{ occurrence }</span>
-				<span className="screen-reader-text">{ sprintf( __( "%d occurrences", "yoast-components" ), occurrence ) }</span>
+				<span className="screen-reader-text">
+					{
+						sprintf(
+							/* translators: %d: Prominent words occurrences. */
+							_n( "%d occurrence", "%d occurrences", occurrence, "yoast-components" ),
+							occurrence
+						)
+					}
+				</span>
 			</ProminentWordOccurrence>
 		</WordBarContainer>
 	);


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [components] Improved Prominent Words occurrences strings translation.

## Relevant technical choices:
- uses `_n()` to provide singular and plural forms
- in the demo app, makes sure the value that comes from the occurrences number field is of type `number`: typically, browsers send values from input fields as `string` even if the input field is of type "number". This was causing an "invalid prop type" warning _and_ the string to not be updated even before this PR (see attached screenshot)
- reduces the ESLint max-warnings to 94

<img width="885" alt="Screenshot 2019-09-05 at 12 57 37" src="https://user-images.githubusercontent.com/1682452/64341114-f8330900-cfe7-11e9-8713-137b4891bc10.png">

## Test instructions
- go to the standalone demo app > WordOccurrences tab
- inspect the source of one of the words in the list, for example: "Linking"

<img width="703" alt="Screenshot 2019-09-05 at 14 19 40" src="https://user-images.githubusercontent.com/1682452/64341281-4cd68400-cfe8-11e9-8fa5-018f3f9053d5.png">

- see the visually hidden string is `2 occurrences`
- in the related input fields above the list, change the occurrences for this word to `1`
- see the visually hidden string changed to `1 occurrence` (singular)
- repeat on other words with different occurrences values and check there are no errors

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/javascript/issues/352
