### PR TITLE
Add Hungarian transition word list

### DIFF
--- a/packages/yoastseo/spec/helpers/getTransitionWordsSpec.js
+++ b/packages/yoastseo/spec/helpers/getTransitionWordsSpec.js
@@ -52,6 +52,11 @@ describe( "gets transition words, based on language", function() {
 		expect( Object.keys( transitionWords ) ).toEqual( properties );
 	} );
 
+	it( "checks if all properties are set for Hungarian", function() {
+		const transitionWords = getTransitionWords( "hu_HU" );
+		expect( Object.keys( transitionWords ) ).toEqual( properties );
+	} );
+
 	it( "checks if all properties are set if no locale is given", function() {
 		const transitionWords = getTransitionWords( "" );
 		expect( Object.keys( transitionWords ) ).toEqual( properties );

--- a/packages/yoastseo/spec/researches/findTransitionWordsSpec.js
+++ b/packages/yoastseo/spec/researches/findTransitionWordsSpec.js
@@ -400,6 +400,27 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.transitionWordSentences ).toBe( 0 );
 	} );
 
+	it( "returns 1 when a transition word is found in a sentence (Hungarian)", function() {
+		// Transition word: Mikor
+		mockPaper = new Paper( "Mikor kezdődik a film?", { locale: "hu_HU" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
+	it( "returns 1 when a two-part transition word is found in a sentence (Hungarian)", function() {
+		// Transition word: addig...amíg
+		mockPaper = new Paper( "Én sem tudom addig, amíg rá nem jövök, hogy az élet komoly-e vagy sem", { locale: "hu_HU" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
+	it( "returns 0 when no transition words are present in a sentence (Hungarian)", function() {
+		mockPaper = new Paper( "Nem beszélek magyarul", { locale: "hu_HU" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 0 );
+	} );
+
 	it( "defaults to English in case of a bogus locale", function() {
 		// Transition word: because.
 		mockPaper = new Paper( "Because of a bogus locale.", { locale: "xx_YY" } );

--- a/packages/yoastseo/spec/researches/findTransitionWordsSpec.js
+++ b/packages/yoastseo/spec/researches/findTransitionWordsSpec.js
@@ -408,14 +408,14 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.transitionWordSentences ).toBe( 1 );
 	} );
 	it( "returns 1 when a two-part transition word is found in a sentence (Hungarian)", function() {
-		// Transition word: addig...amíg
-		mockPaper = new Paper( "Én sem tudom addig, amíg rá nem jövök, hogy az élet komoly-e vagy sem", { locale: "hu_HU" } );
+		// Transition word: ahogy, akkor
+		mockPaper = new Paper( "Csak később, ahogy felnőttem, akkor kezdődött a sok baj.", { locale: "hu_HU" } );
 		result = transitionWordsResearch( mockPaper );
 		expect( result.totalSentences ).toBe( 1 );
 		expect( result.transitionWordSentences ).toBe( 1 );
 	} );
 	it( "returns 0 when no transition words are present in a sentence (Hungarian)", function() {
-		mockPaper = new Paper( "Nem beszélek magyarul", { locale: "hu_HU" } );
+		mockPaper = new Paper( "Nem beszélek magyarul.", { locale: "hu_HU" } );
 		result = transitionWordsResearch( mockPaper );
 		expect( result.totalSentences ).toBe( 1 );
 		expect( result.transitionWordSentences ).toBe( 0 );

--- a/packages/yoastseo/src/assessments/readability/transitionWordsAssessment.js
+++ b/packages/yoastseo/src/assessments/readability/transitionWordsAssessment.js
@@ -8,7 +8,7 @@ import AssessmentResult from "../../values/AssessmentResult";
 import Mark from "../../values/Mark.js";
 import marker from "../../markers/addMark.js";
 import getLanguageAvailability from "../../helpers/getLanguageAvailability.js";
-const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "pt", "ru", "ca", "pl", "sv" ];
+const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "pt", "ru", "ca", "pl", "sv", "hu" ];
 
 /**
  * Calculates the actual percentage of transition words in the sentences.

--- a/packages/yoastseo/src/helpers/getTransitionWords.js
+++ b/packages/yoastseo/src/helpers/getTransitionWords.js
@@ -43,6 +43,8 @@ import twoPartTransitionWordsSwedish from "../researches/swedish/twoPartTransiti
 
 import transitionWordsHungarianFactory from "../researches/hungarian/transitionWords.js";
 const transitionWordsHungarian = transitionWordsHungarianFactory().allWords;
+import twoPartTransitionWordsHungarian from "../researches/hungarian/twoPartTransitionWords.js";
+
 import getLanguage from "./getLanguage.js";
 
 
@@ -108,7 +110,7 @@ export default function( locale ) {
 		case "hu":
 			return {
 				transitionWords: transitionWordsHungarian,
-				twoPartTransitionWords: function() { return []; },
+				twoPartTransitionWords: twoPartTransitionWordsHungarian,
 			};
 		default:
 		case "en":

--- a/packages/yoastseo/src/helpers/getTransitionWords.js
+++ b/packages/yoastseo/src/helpers/getTransitionWords.js
@@ -40,7 +40,11 @@ import twoPartTransitionWordsPolish from "../researches/polish/twoPartTransition
 import transitionWordsSwedishFactory from "../researches/swedish/transitionWords.js";
 const transitionWordsSwedish = transitionWordsSwedishFactory().allWords;
 import twoPartTransitionWordsSwedish from "../researches/swedish/twoPartTransitionWords.js";
+
+import transitionWordsHungarianFactory from "../researches/hungarian/transitionWords.js";
+const transitionWordsHungarian = transitionWordsHungarianFactory().allWords;
 import getLanguage from "./getLanguage.js";
+
 
 /**
  * Returns transition words for a specific locale.
@@ -100,6 +104,11 @@ export default function( locale ) {
 			return {
 				transitionWords: transitionWordsSwedish,
 				twoPartTransitionWords: twoPartTransitionWordsSwedish,
+			};
+		case "hu":
+			return {
+				transitionWords: transitionWordsHungarian,
+				twoPartTransitionWords: function() { return []; },
 			};
 		default:
 		case "en":

--- a/packages/yoastseo/src/researches/findTransitionWords.js
+++ b/packages/yoastseo/src/researches/findTransitionWords.js
@@ -61,15 +61,19 @@ const checkSentencesForTransitionWords = function( sentences, transitionWords ) 
 	const results = [];
 
 	sentences.forEach( sentence => {
-		const twoPartMatches = matchTwoPartTransitionWords( sentence, transitionWords.twoPartTransitionWords() );
 
-		if ( twoPartMatches !== null ) {
-			results.push( {
-				sentence: sentence,
-				transitionWords: twoPartMatches,
-			} );
+		// Some languages don't have two-part transition words.
+		if( transitionWords.twoPartTransitionWords().length ) {
+			const twoPartMatches = matchTwoPartTransitionWords( sentence, transitionWords.twoPartTransitionWords() );
 
-			return;
+			if ( twoPartMatches !== null ) {
+				results.push( {
+					sentence: sentence,
+					transitionWords: twoPartMatches,
+				} );
+
+				return;
+			}
 		}
 
 		const transitionWordMatches = matchTransitionWords( sentence, transitionWords.transitionWords );

--- a/packages/yoastseo/src/researches/findTransitionWords.js
+++ b/packages/yoastseo/src/researches/findTransitionWords.js
@@ -61,19 +61,15 @@ const checkSentencesForTransitionWords = function( sentences, transitionWords ) 
 	const results = [];
 
 	sentences.forEach( sentence => {
+		const twoPartMatches = matchTwoPartTransitionWords( sentence, transitionWords.twoPartTransitionWords() );
 
-		// Some languages don't have two-part transition words.
-		if( transitionWords.twoPartTransitionWords().length ) {
-			const twoPartMatches = matchTwoPartTransitionWords( sentence, transitionWords.twoPartTransitionWords() );
+		if ( twoPartMatches !== null ) {
+			results.push( {
+				sentence: sentence,
+				transitionWords: twoPartMatches,
+			} );
 
-			if ( twoPartMatches !== null ) {
-				results.push( {
-					sentence: sentence,
-					transitionWords: twoPartMatches,
-				} );
-
-				return;
-			}
+			return;
 		}
 
 		const transitionWordMatches = matchTransitionWords( sentence, transitionWords.transitionWords );

--- a/packages/yoastseo/src/researches/hungarian/transitionWords.js
+++ b/packages/yoastseo/src/researches/hungarian/transitionWords.js
@@ -1,0 +1,17 @@
+/** @module config/transitionWords */
+
+const singleWords = [ "ahányszor", "ahelyett", "ahelyt", "ahogy", "ahol", "ahonnan", "ahová", "akár", "akárcsak", "akkor", "alapvetően", "alighogy", "ám", "ámbár", "ámde", "ameddig", "amennyiben", "amennyire", "amennyiszer", "amíg", "amikor", "amikorra", "aminthogy", "amióta", "amire", "annálfogva", "annyira", "avagy", "azaz", "azazhogy", "azért", "azonban", "azután", "bár", "bizony", "csakhogy", "de", "dehát", "dehogy", "egybehangzóan", "egyöntetűen", "egyöntetűleg", "ekképpen", "ellenben", "előzőleg", "elsősorban", "ennélfogva", "eredményeképp", "eredményeképpen", "és", "eszerint", "ezért", "feltétlenül", "főként", "főleg", "ha", "habár", "hanem", "hányszor", "harmadjára", "hasonlóképpen", "hát", "hirtelen", "hirtelenjében", "hiszen", "hogy", "hogyha", "hol", "holott", "honnan", "hová", "így", "illetőleg", "illetve", "immár", "is", "jóllehet", "kár", "kétségtelenül", "kiváltképp", "következésképpen", "maga", "máskülönben", "másodsorban", "meg", "mégis", "megkérdőjelezhetetlenül", "megkérdőjelezhetően", "mégpedig", "mégsem", "mennél", "mennyiszer", "merre", "mert", "merthogy", "midőn", "mielőtt", "míg", "mihelyt", "miként", "miképp", "mikor", "mikorra", "mindamellett", "mindazáltal", "mindazonáltal", "minél", "mint", "mintha", "minthogy", "mióta", "mire", "miután", "mivel", "mivelhogy", "nahát", "nehogy", "noha", "nos", "óh", "összehasonlításképp", "összehasonlításképpen", "pedig", "plusz", "s", "sajna", "satöbbi", "se", "sem", "sőt", "szintén", "tehát", "továbbá", "tudniillik", "úgy", "ugyan", "ugyanis", "úgyhogy", "vagy", "vagyis", "valamennyi", "valamint", "valóban", "végezetül", "végül", "végülis", "viszont" ];
+
+const multipleWords =  [ "abba hogy", "abban hogy", "abból hogy", "addig amíg", "addig hogy", "addig míg", "afelé hogy", "ahelyett hogy", "ahhoz hogy", "akként hogy", "akkorra hogy", "amaitt hogy", "amellett hogy", "amint csak", "anélkül hogy", "annak okáért", "annyi hogy", "annyi mint", "annyira hogy", "annyira mint", "arra hogy", "arról hogy", "attól fogva hogy", "attól hogy", "avégett hogy", "avégre hogy", "az ellen hogy", "az iránt hogy", "azelőtt hogy", "azért hogy", "azok után", "azon hogy", "azonkívül hogy", "azóta hogy", "aztán pedig", "azután hogy", "azzal hogy", "ennek folytán", "ha csak", "ha egyébként", "ha egyszer", "ha egyszer", "ha is", "ha különben", "ha ugyan", "hogy sem", "hogy sem mint", "hol hol", "holott pedig", "igaz hogy", "így tehát", "még akkor is", "még ha", "mert különben", "mert tény hogy", "mind mind", "mindenek előtt", "mindezek után", "mint sem", "mint sem hogy", "nem úgy mint", "oda hogy", "oly módon hogy", "sem hogy", "tény hogy", "úgy hogy", "úgy mint" ];
+
+/**
+ * Returns an list with transition words to be used by the assessments.
+ * @returns {Object} The list filled with transition word lists.
+ */
+module.exports = function() {
+    return {
+        singleWords: singleWords,
+        multipleWords: multipleWords,
+        allWords: singleWords.concat( multipleWords ),
+    };
+};

--- a/packages/yoastseo/src/researches/hungarian/transitionWords.js
+++ b/packages/yoastseo/src/researches/hungarian/transitionWords.js
@@ -1,17 +1,38 @@
 /** @module config/transitionWords */
 
-const singleWords = [ "ahányszor", "ahelyett", "ahelyt", "ahogy", "ahol", "ahonnan", "ahová", "akár", "akárcsak", "akkor", "alapvetően", "alighogy", "ám", "ámbár", "ámde", "ameddig", "amennyiben", "amennyire", "amennyiszer", "amíg", "amikor", "amikorra", "aminthogy", "amióta", "amire", "annálfogva", "annyira", "avagy", "azaz", "azazhogy", "azért", "azonban", "azután", "bár", "bizony", "csakhogy", "de", "dehát", "dehogy", "egybehangzóan", "egyöntetűen", "egyöntetűleg", "ekképpen", "ellenben", "előzőleg", "elsősorban", "ennélfogva", "eredményeképp", "eredményeképpen", "és", "eszerint", "ezért", "feltétlenül", "főként", "főleg", "ha", "habár", "hanem", "hányszor", "harmadjára", "hasonlóképpen", "hát", "hirtelen", "hirtelenjében", "hiszen", "hogy", "hogyha", "hol", "holott", "honnan", "hová", "így", "illetőleg", "illetve", "immár", "is", "jóllehet", "kár", "kétségtelenül", "kiváltképp", "következésképpen", "maga", "máskülönben", "másodsorban", "meg", "mégis", "megkérdőjelezhetetlenül", "megkérdőjelezhetően", "mégpedig", "mégsem", "mennél", "mennyiszer", "merre", "mert", "merthogy", "midőn", "mielőtt", "míg", "mihelyt", "miként", "miképp", "mikor", "mikorra", "mindamellett", "mindazáltal", "mindazonáltal", "minél", "mint", "mintha", "minthogy", "mióta", "mire", "miután", "mivel", "mivelhogy", "nahát", "nehogy", "noha", "nos", "óh", "összehasonlításképp", "összehasonlításképpen", "pedig", "plusz", "s", "sajna", "satöbbi", "se", "sem", "sőt", "szintén", "tehát", "továbbá", "tudniillik", "úgy", "ugyan", "ugyanis", "úgyhogy", "vagy", "vagyis", "valamennyi", "valamint", "valóban", "végezetül", "végül", "végülis", "viszont" ];
+const singleWords = [ "ahányszor", "ahelyett", "ahelyt", "ahogy", "ahol", "ahonnan", "ahová", "akár", "akárcsak",
+	"akkor", "alapvetően", "alighogy", "ám", "ámbár", "ámde", "ameddig", "amennyiben", "amennyire", "amennyiszer",
+	"amíg", "amikor", "amikorra", "aminthogy", "amióta", "amire", "annálfogva", "annyira", "avagy", "azaz", "azazhogy",
+	"azért", "azonban", "azután", "bár", "bizony", "csakhogy", "de", "dehát", "dehogy", "egybehangzóan", "egyöntetűen",
+	"egyöntetűleg", "ekképpen", "ellenben", "előzőleg", "elsősorban", "ennélfogva", "eredményeképp", "eredményeképpen",
+	"és", "eszerint", "ezért", "feltétlenül", "főként", "főleg", "ha", "habár", "hanem", "hányszor", "harmadjára",
+	"hasonlóképpen", "hát", "hirtelen", "hirtelenjében", "hiszen", "hogy", "hogyha", "hol", "holott", "honnan",
+	"hová", "így", "illetőleg", "illetve", "immár", "is", "jóllehet", "kár", "kétségtelenül", "kiváltképp",
+	"következésképpen", "maga", "máskülönben", "másodsorban", "meg", "mégis", "megkérdőjelezhetetlenül",
+	"megkérdőjelezhetően", "mégpedig", "mégsem", "mennél", "mennyiszer", "merre", "mert", "merthogy", "midőn",
+	"mielőtt", "míg", "mihelyt", "miként", "miképp", "mikor", "mikorra", "mindamellett", "mindazáltal", "mindazonáltal",
+	"minél", "mint", "mintha", "minthogy", "mióta", "mire", "miután", "mivel", "mivelhogy", "nahát", "nehogy", "noha",
+	"nos", "óh", "összehasonlításképp", "összehasonlításképpen", "pedig", "plusz", "s", "sajna", "satöbbi", "se", "sem",
+	"sőt", "szintén", "tehát", "továbbá", "tudniillik", "úgy", "ugyan", "ugyanis", "úgyhogy", "vagy", "vagyis",
+	"valamennyi", "valamint", "valóban", "végezetül", "végül", "végülis", "viszont" ];
 
-const multipleWords =  [ "abba hogy", "abban hogy", "abból hogy", "addig amíg", "addig hogy", "addig míg", "afelé hogy", "ahelyett hogy", "ahhoz hogy", "akként hogy", "akkorra hogy", "amaitt hogy", "amellett hogy", "amint csak", "anélkül hogy", "annak okáért", "annyi hogy", "annyi mint", "annyira hogy", "annyira mint", "arra hogy", "arról hogy", "attól fogva hogy", "attól hogy", "avégett hogy", "avégre hogy", "az ellen hogy", "az iránt hogy", "azelőtt hogy", "azért hogy", "azok után", "azon hogy", "azonkívül hogy", "azóta hogy", "aztán pedig", "azután hogy", "azzal hogy", "ennek folytán", "ha csak", "ha egyébként", "ha egyszer", "ha egyszer", "ha is", "ha különben", "ha ugyan", "hogy sem", "hogy sem mint", "hol hol", "holott pedig", "igaz hogy", "így tehát", "még akkor is", "még ha", "mert különben", "mert tény hogy", "mind mind", "mindenek előtt", "mindezek után", "mint sem", "mint sem hogy", "nem úgy mint", "oda hogy", "oly módon hogy", "sem hogy", "tény hogy", "úgy hogy", "úgy mint" ];
+const multipleWords =  [ "abba hogy", "abban hogy", "abból hogy", "addig amíg", "addig hogy", "addig míg", "afelé hogy",
+	"ahelyett hogy", "ahhoz hogy", "akként hogy", "akkorra hogy", "amaitt hogy", "amellett hogy", "amint csak",
+	"anélkül hogy", "annak okáért", "annyi hogy", "annyi mint", "annyira hogy", "annyira mint", "arra hogy",
+	"arról hogy", "attól fogva hogy", "attól hogy", "avégett hogy", "avégre hogy", "az ellen hogy", "az iránt hogy",
+	"azelőtt hogy", "azért hogy", "azok után", "azon hogy", "azonkívül hogy", "azóta hogy", "aztán pedig", "azután hogy",
+	"ha ugyan", "hogy sem", "hogy sem mint", "hol hol", "holott pedig", "igaz hogy", "így tehát", "még akkor is",
+	"még ha", "mert különben", "mert tény hogy", "mind mind", "mindenek előtt", "mindezek után", "mint sem",
+	"mint sem hogy", "nem úgy mint", "oda hogy", "oly módon hogy", "sem hogy", "tény hogy", "úgy hogy", "úgy mint" ];
 
 /**
  * Returns an list with transition words to be used by the assessments.
  * @returns {Object} The list filled with transition word lists.
  */
 module.exports = function() {
-    return {
-        singleWords: singleWords,
-        multipleWords: multipleWords,
-        allWords: singleWords.concat( multipleWords ),
-    };
+	return {
+		singleWords: singleWords,
+		multipleWords: multipleWords,
+		allWords: singleWords.concat( multipleWords ),
+	};
 };

--- a/packages/yoastseo/src/researches/hungarian/transitionWords.js
+++ b/packages/yoastseo/src/researches/hungarian/transitionWords.js
@@ -17,13 +17,15 @@ const singleWords = [ "ahányszor", "ahelyett", "ahelyt", "ahogy", "ahol", "ahon
 	"valamennyi", "valamint", "valóban", "végezetül", "végül", "végülis", "viszont" ];
 
 const multipleWords =  [ "abba hogy", "abban hogy", "abból hogy", "addig amíg", "addig hogy", "addig míg", "afelé hogy",
-	"ahelyett hogy", "ahhoz hogy", "akként hogy", "akkorra hogy", "amaitt hogy", "amellett hogy", "amint csak",
+	"ahelyett hogy", "ahhoz hogy", "akként hogy", "akkorra hogy", "amiatt hogy", "amellett hogy", "amint csak",
 	"anélkül hogy", "annak okáért", "annyi hogy", "annyi mint", "annyira hogy", "annyira mint", "arra hogy",
-	"arról hogy", "attól fogva hogy", "attól hogy", "avégett hogy", "avégre hogy", "az ellen hogy", "az iránt hogy",
-	"azelőtt hogy", "azért hogy", "azok után", "azon hogy", "azonkívül hogy", "azóta hogy", "aztán pedig", "azután hogy",
-	"ha ugyan", "hogy sem", "hogy sem mint", "hol hol", "holott pedig", "igaz hogy", "így tehát", "még akkor is",
-	"még ha", "mert különben", "mert tény hogy", "mind mind", "mindenek előtt", "mindezek után", "mint sem",
-	"mint sem hogy", "nem úgy mint", "oda hogy", "oly módon hogy", "sem hogy", "tény hogy", "úgy hogy", "úgy mint" ];
+	"arra hogy", "arról hogy", "attól fogva hogy", "attól hogy", "avégett hogy", "avégre hogy", "az ellen hogy",
+	"az iránt hogy", "azelőtt hogy", "azért hogy", "azért hogy", "azok után", "azon hogy", "azonkívül hogy",
+	"azóta hogy", "aztán pedig", "azután hogy", "azzal hogy", "ennek folytán", "ha csak", "ha egyébként", "ha egyszer",
+	"ha egyszer", "ha is", "ha különben", "ha ugyan", "hogy sem", "hogy sem mint", "hol hol", "holott pedig",
+	"igaz hogy", "így tehát", "még akkor is", "még ha", "mert különben", "mert tény hogy", "mind mind", "mindenek előtt",
+	"mindezek után", "mint sem", "mint sem hogy", "nem úgy mint", "oda hogy", "oly módon hogy", "sem hogy", "tény hogy",
+	"úgy hogy", "úgy mint" ];
 
 /**
  * Returns an list with transition words to be used by the assessments.

--- a/packages/yoastseo/src/researches/hungarian/twoPartTransitionWords.js
+++ b/packages/yoastseo/src/researches/hungarian/twoPartTransitionWords.js
@@ -1,0 +1,23 @@
+/** @module config/twoPartTransitionWords */
+
+/**
+ * Returns an array with two-part transition words to be used by the assessments.
+ * @returns {Array} The array filled with two-part transition words.
+ */
+export default function() {
+	return	[ [ "addig", "hogy" ], [ "ahogy", "akkor" ], [ "ahogy", "azonnal" ], [ "ahogy", "azonnal" ],
+		[ "ahogy", "azután" ], [ "ahogy", "máris" ], [ "ahogy", "máris" ], [ "ahogy", "nyomban" ], [ "ahogy", "nyomban" ],
+		[ "ahogy", "tüstént" ], [ "ahogy", "tüstént" ], [ "akkor", "amikor" ], [ "akkor", "ha" ], [ "akkor", "hogy" ],
+		[ "akkor", "hogyha" ], [ "akkor", "mikor" ], [ "akkorra", "amikorra" ], [ "akkorra", "amire" ],
+		[ "akkorra", "mikorra" ], [ "akkorra", "mire" ], [ "akkortól", "amikor" ], [ "akkortól", "mikor" ],
+		[ "alighogy", "máris" ], [ "alighogy", "máris" ], [ "alighogy", "nyomban" ], [ "alighogy", "tüstént" ],
+		[ "ameddig", "addig" ], [ "amíg", "addig" ], [ "amíg", "addig" ], [ "amíg", "addigra" ], [ "amikor", "akkor" ],
+		[ "amikor", "aközben" ], [ "amikor", "azalatt" ], [ "amikorra", "addigra" ], [ "amikorra", "akkorra" ],
+		[ "amint", "akkor" ], [ "amint", "azonnal" ], [ "amint", "máris" ], [ "amint", "nyomban" ], [ "amint", "tüstént" ],
+		[ "amióta", "attól kezdve" ], [ "amióta", "azóta" ], [ "amire", "addig" ], [ "amire", "addigra" ],
+		[ "azóta", "hogy" ], [ "ha", "akkor" ], [ "hogyha", "akkor" ], [ "mialatt", "azalatt" ], [ "mielőtt", "azelőtt" ],
+		[ "mihelyt", "azonnal" ], [ "mihelyt", "máris" ], [ "mihelyt", "nyomban" ], [ "mihelyt", "tüstént" ],
+		[ "mikor", "akkor" ], [ "mikor", "aközben" ], [ "mikor", "azalatt" ], [ "mikor", "azután" ], [ "mikorra", "addigra" ],
+		[ "mikorra", "addigra" ], [ "mikorra", "akkorra" ], [ "mikorra", "akkorra" ], [ "miközben", "azalatt" ],
+		[ "mióta", "attól kezdve" ], [ "mióta", "azóta" ], [ "mire", "addig" ], [ "mire", "addigra" ], [ "miután", "azután" ] ];
+}

--- a/packages/yoastseo/src/researches/hungarian/twoPartTransitionWords.js
+++ b/packages/yoastseo/src/researches/hungarian/twoPartTransitionWords.js
@@ -5,19 +5,20 @@
  * @returns {Array} The array filled with two-part transition words.
  */
 export default function() {
-	return	[ [ "addig", "hogy" ], [ "ahogy", "akkor" ], [ "ahogy", "azonnal" ], [ "ahogy", "azonnal" ],
-		[ "ahogy", "azután" ], [ "ahogy", "máris" ], [ "ahogy", "máris" ], [ "ahogy", "nyomban" ], [ "ahogy", "nyomban" ],
-		[ "ahogy", "tüstént" ], [ "ahogy", "tüstént" ], [ "akkor", "amikor" ], [ "akkor", "ha" ], [ "akkor", "hogy" ],
-		[ "akkor", "hogyha" ], [ "akkor", "mikor" ], [ "akkorra", "amikorra" ], [ "akkorra", "amire" ],
+	return	[ [ "ahogy", "akkor" ], [ "ahogy", "azonnal" ], [ "ahogy", "azután" ],
+		[ "ahogy", "máris" ], [ "ahogy", "nyomban" ], [ "ahogy", "tüstént" ], [ "akkor", "amikor" ], [ "akkor", "ha" ],
+		[ "akkor", "hogy" ], [ "akkor", "hogyha" ], [ "akkor", "mikor" ], [ "akkorra", "amikorra" ],
 		[ "akkorra", "mikorra" ], [ "akkorra", "mire" ], [ "akkortól", "amikor" ], [ "akkortól", "mikor" ],
-		[ "alighogy", "máris" ], [ "alighogy", "máris" ], [ "alighogy", "nyomban" ], [ "alighogy", "tüstént" ],
-		[ "ameddig", "addig" ], [ "amíg", "addig" ], [ "amíg", "addig" ], [ "amíg", "addigra" ], [ "amikor", "akkor" ],
-		[ "amikor", "aközben" ], [ "amikor", "azalatt" ], [ "amikorra", "addigra" ], [ "amikorra", "akkorra" ],
-		[ "amint", "akkor" ], [ "amint", "azonnal" ], [ "amint", "máris" ], [ "amint", "nyomban" ], [ "amint", "tüstént" ],
+		[ "alighogy", "máris" ], [ "alighogy", "nyomban" ], [ "alighogy", "tüstént" ], [ "ameddig", "addig" ],
+		[ "amíg", "addig" ], [ "amíg", "addigra" ], [ "amikor", "akkor" ], [ "amikor", "aközben" ],
+		[ "amikor", "azalatt" ], [ "amikorra", "addigra" ], [ "amikorra", "akkorra" ], [ "amint", "akkor" ],
+		[ "amint", "azonnal" ], [ "amint", "máris" ], [ "amint", "nyomban" ], [ "amint", "tüstént" ],
 		[ "amióta", "attól kezdve" ], [ "amióta", "azóta" ], [ "amire", "addig" ], [ "amire", "addigra" ],
-		[ "azóta", "hogy" ], [ "ha", "akkor" ], [ "hogyha", "akkor" ], [ "mialatt", "azalatt" ], [ "mielőtt", "azelőtt" ],
-		[ "mihelyt", "azonnal" ], [ "mihelyt", "máris" ], [ "mihelyt", "nyomban" ], [ "mihelyt", "tüstént" ],
-		[ "mikor", "akkor" ], [ "mikor", "aközben" ], [ "mikor", "azalatt" ], [ "mikor", "azután" ], [ "mikorra", "addigra" ],
-		[ "mikorra", "addigra" ], [ "mikorra", "akkorra" ], [ "mikorra", "akkorra" ], [ "miközben", "azalatt" ],
-		[ "mióta", "attól kezdve" ], [ "mióta", "azóta" ], [ "mire", "addig" ], [ "mire", "addigra" ], [ "miután", "azután" ] ];
+		[ "azóta", "hogy" ], [ "ha", "akkor" ], [ "hogyha", "akkor" ], [ "mialatt", "azalatt" ],
+		[ "mielőtt", "azelőtt" ], [ "mihelyt", "azonnal" ], [ "mihelyt", "máris" ], [ "mihelyt", "nyomban" ],
+		[ "mihelyt", "tüstént" ], [ "mikor", "akkor" ], [ "mikor", "aközben" ], [ "mikor", "azalatt" ],
+		[ "mikor", "azután" ], [ "mikorra", "addigra" ], [ "mikorra", "akkorra" ], [ "miközben", "azalatt" ],
+		[ "mióta", "attól kezdve" ], [ "mióta", "azóta" ], [ "mire", "addig" ], [ "mire", "addigra" ],
+		[ "miután", "azután" ], [ "nemcsak", "hanem" ], [ "sem", "sem" ] ];
 }
+


### PR DESCRIPTION
**Summary**
This PR can be summarized in the following changelog entry:

- Adds the transition word assessment for Hungarian, props to [9abor](https://github.com/9abor).

**Test instructions**
This PR can be tested by following these steps:

- Check out this branch
- Open the content analysis app or link the monorepo to `trunk` on wordpress-seo on your local development environment
- Set locale to hu_HU
- Write a Hungarian sentence containing a one or two-part transition word (see list of transition words in the code files)
- Hit the mark transition word sentences button to check if the sentences are correctly marked.


Fixes #357 
