### PR TITLE
Adds a minimum height to every linking suggestion.

### DIFF
--- a/packages/yoast-components/composites/LinkSuggestions/LinkSuggestion.js
+++ b/packages/yoast-components/composites/LinkSuggestions/LinkSuggestion.js
@@ -9,6 +9,7 @@ import { makeOutboundLink } from "@yoast/helpers";
 const LinkSuggestionWrapper = styled.div`
 	width: 100%;
 	display: block;
+	min-height: 40px;
 	margin-bottom: 5px;
 `;
 


### PR DESCRIPTION
This solves a bug where each suggestions was not aligned to the left and on a new line, but indented instead.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoast-components] Fixes a bug where internal linking suggestions were not aligned correctly, but were indented instead.
* [wordpress-seo-premium] Fixes a bug where internal linking suggestions were not aligned correctly, but were indented instead.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### The bug in Safari

#### Reproducing the bug
* Checkout the `develop` branch.
* Checkout the `trunk` branch of `wordpress-seo-premium`.
* Make sure that the JavaScript monorepo is linked to Premium.
* Open Safari.
* Make sure that you have posts that have been indexed for use in internal linking suggestions.
  * The best way to make sure is to run a site-wide analysis first (Yoast SEO > Tools > analyze your site).
* Go to a post.
* Make sure that the internal linking metabox is below the Premium metabox.
  * If it is not, you can drag it from the Gutenberg sidebar and drop it below the Premium metabox.
* Wait a few seconds before linking suggestions are shown.
* The suggested links should look something like this:
![](https://user-images.githubusercontent.com/36954173/63747341-36714f80-c8a7-11e9-9176-880a8ab92a62.png) 

#### Checking if the bug has been fixed
* Checkout the `333-fix-alignment-internal-linking-suggestions` branch.
* For the rest, follow the same steps as in 'reproducing the bug'.
* This time, the suggested links should look something like this:
<img width="460" alt="Screenshot 2019-09-25 at 11 28 52" src="https://user-images.githubusercontent.com/10195175/65594998-14491b00-df94-11e9-8b1b-59242677ac23.png">

### The bug in the Gutenberg sidebar

#### Reproducing the bug
* Checkout the `develop` branch.
* Checkout the `trunk` branch of `wordpress-seo-premium`.
* Make sure that the JavaScript monorepo is linked to Premium.
* Open Chrome.
* Make sure that you have posts that have been indexed for use in internal linking suggestions.
  * The best way to make sure is to run a site-wide analysis first (Yoast SEO > Tools > analyze your site).
* Go to a post.
* Wait a few seconds before linking suggestions are shown.
* In the Gutenberg sidebar, the suggested links should look something like this:
<img width="272" alt="Screenshot 2019-09-25 at 13 03 42" src="https://user-images.githubusercontent.com/36954173/62518506-01cf2280-b82a-11e9-8cb6-a062308a123c.png">

#### Checking if the bug has been fixed
* Checkout the `333-fix-alignment-internal-linking-suggestions` branch.
* For the rest, follow the same steps as in 'reproducing the bug'.
* This time, the suggested links should look something like this:
<img width="272" alt="Screenshot 2019-09-25 at 13 03 42" src="https://user-images.githubusercontent.com/10195175/65595362-efa17300-df94-11e9-81fd-709a9effdec4.png">


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * 

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #333 
