### PR TITLE
Rename messagedata variables

### DIFF
--- a/packages/yoast-components/index.js
+++ b/packages/yoast-components/index.js
@@ -63,7 +63,7 @@ export { SiteSEOReport as SeoAssessment } from "@yoast/analysis-report";
 export { default as VideoTutorial } from "./composites/HelpCenter/views/VideoTutorial";
 export { default as KeywordInput } from "./composites/Plugin/Shared/components/KeywordInput";
 export { insightsReducer } from "./redux/reducers/insights";
-export { setProminentWords } from "./redux/actions/insights";
+export { setWordsForInsights } from "./redux/actions/insights";
 export {
 	setReadabilityResults,
 	setSeoResultsForKeyword,

--- a/packages/yoast-components/redux/actions/insights.js
+++ b/packages/yoast-components/redux/actions/insights.js
@@ -1,24 +1,22 @@
 /*
  * Action types
  */
-const prefix = "INSIGHTS_";
-
-export const SET_PROMINENT_WORDS = `${ prefix }SET_PROMINENT_WORDS`;
+export const SET_WORDS_FOR_INSIGHTS = "SET_WORDS_FOR_INSIGHTS";
 
 /*
  * Action creators
  */
 
 /**
- * An action creator for setting the prominent words.
+ * An action creator for setting the prominent words for insights.
  *
- * @param {array} prominentWords The prominent words.
+ * @param {array} wordsForInsights The prominent words to be used for insights.
  *
- * @returns {Object} A set prominent words action.
+ * @returns {Object} A set words for insights action.
  */
-export function setProminentWords( prominentWords ) {
+export function setWordsForInsights( wordsForInsights ) {
 	return {
-		type: SET_PROMINENT_WORDS,
-		prominentWords: prominentWords,
+		type: SET_WORDS_FOR_INSIGHTS,
+		wordsForInsights: wordsForInsights,
 	};
 }

--- a/packages/yoast-components/redux/actions/tests/insightsTest.js
+++ b/packages/yoast-components/redux/actions/tests/insightsTest.js
@@ -1,15 +1,15 @@
-import { SET_PROMINENT_WORDS, setProminentWords } from "../insights";
+import { SET_WORDS_FOR_INSIGHTS, setWordsForInsights } from "../insights";
 
 describe( "setProminentWords action creator", function() {
 	it( "creates the setProminentWords action", function() {
-		const prominentWords = [ "prominent word 1", "prominent word 2", "prominent word 3",
+		const wordsForInsights = [ "prominent word 1", "prominent word 2", "prominent word 3",
 			"prominent word 4", "prominent word 5", "prominent word 6" ];
 
 		const expected = {
-			type: SET_PROMINENT_WORDS,
-			prominentWords: prominentWords,
+			type: SET_WORDS_FOR_INSIGHTS,
+			wordsForInsights: wordsForInsights,
 		};
-		const actual = setProminentWords( prominentWords );
+		const actual = setWordsForInsights( wordsForInsights );
 		expect( actual ).toEqual( expected );
 	} );
 } );

--- a/packages/yoast-components/redux/reducers/insights.js
+++ b/packages/yoast-components/redux/reducers/insights.js
@@ -1,6 +1,6 @@
 import { combineReducers } from "redux";
-import { prominentWordsReducer } from "./prominentWords";
+import { wordsForInsightsReducer } from "./prominentWords";
 
 export const insightsReducer = combineReducers( {
-	prominentWords: prominentWordsReducer,
+	prominentWords: wordsForInsightsReducer,
 } );

--- a/packages/yoast-components/redux/reducers/prominentWords.js
+++ b/packages/yoast-components/redux/reducers/prominentWords.js
@@ -1,4 +1,4 @@
-import { SET_PROMINENT_WORDS } from "../actions/insights";
+import { SET_WORDS_FOR_INSIGHTS } from "../actions/insights";
 
 /**
  * Initial state
@@ -13,10 +13,10 @@ const INITIAL_STATE = [];
  *
  * @returns {Object} The updated prominent words object.
  */
-export function prominentWordsReducer( state = INITIAL_STATE, action ) {
+export function wordsForInsightsReducer( state = INITIAL_STATE, action ) {
 	switch ( action.type ) {
-		case SET_PROMINENT_WORDS:
-			return action.prominentWords;
+		case SET_WORDS_FOR_INSIGHTS:
+			return action.wordsForInsights;
 		default:
 			return state;
 	}

--- a/packages/yoast-components/redux/reducers/tests/indexTest.js
+++ b/packages/yoast-components/redux/reducers/tests/indexTest.js
@@ -1,4 +1,4 @@
-import { SET_PROMINENT_WORDS } from "../../actions/insights";
+import { SET_WORDS_FOR_INSIGHTS } from "../../actions/insights";
 import rootReducer from "../index";
 
 jest.mock( "../insights", () => {
@@ -21,7 +21,7 @@ describe( "rootReducer with a SET_PROMINENT_WORDS action ", () => {
 	it( "returns the correct reducers", () => {
 		const state = {};
 		const action = {
-			type: SET_PROMINENT_WORDS,
+			type: SET_WORDS_FOR_INSIGHTS,
 		};
 		const expected = { insights: { name: "insightsReducer" }, linkSuggestions: { name: "linkSuggestionsReducer" } };
 

--- a/packages/yoast-components/redux/reducers/tests/insightsTest.js
+++ b/packages/yoast-components/redux/reducers/tests/insightsTest.js
@@ -1,21 +1,21 @@
-import { SET_PROMINENT_WORDS } from "../../actions/insights";
+import { SET_WORDS_FOR_INSIGHTS } from "../../actions/insights";
 import { insightsReducer } from "../insights";
 
 jest.mock( "../prominentWords", () => {
 	return {
-		prominentWordsReducer: jest.fn( () => {
-			return { name: "prominentWordsReducer" };
+		wordsForInsightsReducer: jest.fn( () => {
+			return { name: "wordsForInsightsReducer" };
 		} ),
 	};
 } );
 
-describe( "insightsReducer with a SET_PROMINENT_WORDS action ", () => {
+describe( "insightsReducer with a SET_WORDS_FOR_INSIGHTS action ", () => {
 	it( "returns the correct reducers", () => {
 		const state = {};
 		const action = {
-			type: SET_PROMINENT_WORDS,
+			type: SET_WORDS_FOR_INSIGHTS,
 		};
-		const expected = { prominentWords: { name: "prominentWordsReducer" } };
+		const expected = { prominentWords: { name: "wordsForInsightsReducer" } };
 
 		const actual = insightsReducer( state, action );
 		expect( actual ).toEqual( expected );

--- a/packages/yoast-components/redux/reducers/tests/prominentWordsTest.js
+++ b/packages/yoast-components/redux/reducers/tests/prominentWordsTest.js
@@ -1,16 +1,16 @@
-import { SET_PROMINENT_WORDS } from "../../actions/insights";
-import { prominentWordsReducer } from "../prominentWords";
+import { SET_WORDS_FOR_INSIGHTS } from "../../actions/insights";
+import { wordsForInsightsReducer } from "../prominentWords";
 
 describe( "prominentWordsReducer with the SET_PROMINENT_WORDS action", () => {
 	it( "sets the prominent words in an empty state", () => {
 		const state = [];
 		const action = {
-			type: SET_PROMINENT_WORDS,
-			prominentWords: [ "prominent word 1", "prominent word 2", "prominent word 3", "prominent word 4", "prominent word 5" ],
+			type: SET_WORDS_FOR_INSIGHTS,
+			wordsForInsights: [ "prominent word 1", "prominent word 2", "prominent word 3", "prominent word 4", "prominent word 5" ],
 		};
 		const expected = [ "prominent word 1", "prominent word 2", "prominent word 3", "prominent word 4", "prominent word 5" ];
 
-		const actual = prominentWordsReducer( state, action );
+		const actual = wordsForInsightsReducer( state, action );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -18,25 +18,25 @@ describe( "prominentWordsReducer with the SET_PROMINENT_WORDS action", () => {
 	it( "overwrites a non-empty state ", () => {
 		const state = [ "old prominent word 1", "old prominent word 2" ];
 		const action = {
-			type: SET_PROMINENT_WORDS,
-			prominentWords: [ "prominent word 1", "prominent word 2", "prominent word 3", "prominent word 4" ],
+			type: SET_WORDS_FOR_INSIGHTS,
+			wordsForInsights: [ "prominent word 1", "prominent word 2", "prominent word 3", "prominent word 4" ],
 		};
 		const expected = [ "prominent word 1", "prominent word 2", "prominent word 3", "prominent word 4" ];
 
-		const actual = prominentWordsReducer( state, action );
+		const actual = wordsForInsightsReducer( state, action );
 
 		expect( actual ).toEqual( expected );
 	} );
 
 	it( "uses the default state when an undefined state is passed", () => {
 		const action = {
-			type: SET_PROMINENT_WORDS,
-			prominentWords: [ "prominent word 1", "prominent word 2", "prominent word 3", "prominent word 4", "prominent word 5" ],
+			type: SET_WORDS_FOR_INSIGHTS,
+			wordsForInsights: [ "prominent word 1", "prominent word 2", "prominent word 3", "prominent word 4", "prominent word 5" ],
 		};
 		const expected = [ "prominent word 1", "prominent word 2", "prominent word 3", "prominent word 4", "prominent word 5" ];
 
 		// eslint-disable-next-line no-undefined
-		const actual = prominentWordsReducer( undefined, action );
+		const actual = wordsForInsightsReducer( undefined, action );
 
 		expect( actual ).toEqual( expected );
 	} );
@@ -50,7 +50,7 @@ describe( "prominentWordsReducer with a non-existing action ", () => {
 		};
 		const expected = state;
 
-		const actual = prominentWordsReducer( state, action );
+		const actual = wordsForInsightsReducer( state, action );
 
 		expect( actual ).toEqual( expected );
 	} );

--- a/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
+++ b/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
@@ -16,8 +16,8 @@ describe( "relevantWords research", function() {
 
 		const expected = {
 			prominentWords: [],
-			metadescriptionAvailable: false,
-			titleAvailable: false,
+			hasMetaDescription: false,
+			hasTitle: false,
 		};
 
 		const words = prominentWordsResearch( paper, researcher );
@@ -33,8 +33,8 @@ describe( "relevantWords research", function() {
 
 		const expected = {
 			prominentWords: [],
-			metadescriptionAvailable: false,
-			titleAvailable: false,
+			hasMetaDescription: false,
+			hasTitle: false,
 		};
 
 		const words = prominentWordsResearch( paper, researcher );
@@ -53,8 +53,8 @@ describe( "relevantWords research", function() {
 				new ProminentWord( "texte", "texte", 181 ),
 				new ProminentWord( "et", "et", 180 ),
 			],
-			metadescriptionAvailable: false,
-			titleAvailable: true,
+			hasMetaDescription: false,
+			hasTitle: true,
 		};
 
 		const words = prominentWordsResearch( paper, researcher );
@@ -70,8 +70,8 @@ describe( "relevantWords research", function() {
 
 		const expected = {
 			prominentWords: [ new ProminentWord( "texte", "texte", 400 ) ],
-			metadescriptionAvailable: false,
-			titleAvailable: false,
+			hasMetaDescription: false,
+			hasTitle: false,
 		};
 
 		const words = prominentWordsResearch( paper, researcher );
@@ -93,8 +93,8 @@ describe( "relevantWords research", function() {
 				new ProminentWord( "syllable", "syllable", 60 ),
 				new ProminentWord( "win", "win", 15 ),
 			],
-			metadescriptionAvailable: false,
-			titleAvailable: false,
+			hasMetaDescription: false,
+			hasTitle: false,
 		};
 
 		const words = prominentWordsResearch( paper, researcher );
@@ -162,8 +162,8 @@ describe( "relevantWords research", function() {
 				new ProminentWord( "users", "user", 6 ),
 				new ProminentWord( "yoastcon", "yoastcon", 6 ),
 			],
-			metadescriptionAvailable: true,
-			titleAvailable: true,
+			hasMetaDescription: true,
+			hasTitle: true,
 		};
 
 		const words = prominentWordsResearch( paper, researcher );

--- a/packages/yoastseo/spec/researches/relevantWordsSpec.js
+++ b/packages/yoastseo/spec/researches/relevantWordsSpec.js
@@ -12,8 +12,8 @@ describe( "relevantWords research", function() {
 
 		const expected = {
 			prominentWords: [],
-			metadescriptionAvailable: false,
-			titleAvailable: false,
+			hasMetaDescription: false,
+			hasTitle: false,
 		};
 
 		// Make sure our words aren't filtered by density.
@@ -38,8 +38,8 @@ describe( "relevantWords research", function() {
 				new WordCombination( [ "combinations" ], 60, functionWords ),
 				new WordCombination( [ "win" ], 30, functionWords ),
 			],
-			metadescriptionAvailable: false,
-			titleAvailable: false,
+			hasMetaDescription: false,
+			hasTitle: false,
 		};
 
 		// Make sure our words aren't filtered by density.

--- a/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
+++ b/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
@@ -17,10 +17,10 @@ import { getSubheadingsTopLevel, removeSubheadingsTopLevel } from "../stringProc
  * @param {Paper}       paper       The paper to determine the prominent words of.
  * @param {Researcher}  researcher  The researcher to use for analysis.
  *
- * @returns {Object}          result                          A compound result object.
- * @returns {ProminentWord[]} result.prominentWords           Prominent words for this paper, filtered and sorted.
- * @returns {boolean}         result.metadescriptionAvailable Whether the metadescription is available in the input paper.
- * @returns {boolean}         result.titleAvailable           Whether the title is available in the input paper.
+ * @returns {Object}          result                    A compound result object.
+ * @returns {ProminentWord[]} result.prominentWords     Prominent words for this paper, filtered and sorted.
+ * @returns {boolean}         result.hasMetaDescription Whether the metadescription is available in the input paper.
+ * @returns {boolean}         result.hasTitle           Whether the title is available in the input paper.
  */
 function getProminentWordsForInternalLinking( paper, researcher ) {
 	const text = paper.getText();
@@ -28,8 +28,8 @@ function getProminentWordsForInternalLinking( paper, researcher ) {
 	const title = paper.getTitle();
 
 	const result = {};
-	result.metadescriptionAvailable = metadescription !== "";
-	result.titleAvailable = title !== "";
+	result.hasMetaDescription = metadescription !== "";
+	result.hasTitle = title !== "";
 	result.prominentWords = [];
 
 	/**
@@ -39,7 +39,7 @@ function getProminentWordsForInternalLinking( paper, researcher ) {
 	const textLength = countWords( text );
 	if (
 		( textLength < 300 ) ||
-		( textLength < 400 && ( ! result.titleAvailable ) && ( ! result.metadescriptionAvailable ) )
+		( textLength < 400 && ( ! result.hasTitle ) && ( ! result.hasMetaDescription ) )
 	) {
 		return result;
 	}

--- a/packages/yoastseo/src/researches/relevantWords.js
+++ b/packages/yoastseo/src/researches/relevantWords.js
@@ -6,10 +6,10 @@ import countWords from "../stringProcessing/countWords";
  *
  * @param {Paper} paper The paper to determine the relevant words of.
  *
- * @returns {Object}            result                          A compound result object.
- * @returns {WordCombination[]} result.prominentWords           Relevant words for this paper, filtered and sorted.
- * @returns {boolean}           result.metadescriptionAvailable Whether the metadescription is available in the input paper.
- * @returns {boolean}           result.titleAvailable           Whether the title is available in the input paper.
+ * @returns {Object}            result                     A compound result object.
+ * @returns {WordCombination[]} result.prominentWords      Relevant words for this paper, filtered and sorted.
+ * @returns {boolean}           result.hasMetaDescription  Whether the metadescription is available in the input paper.
+ * @returns {boolean}           result.hasTitle            Whether the title is available in the input paper.
  */
 function relevantWords( paper ) {
 	const text = paper.getText();
@@ -17,8 +17,8 @@ function relevantWords( paper ) {
 	const title = paper.getTitle();
 
 	const result = {};
-	result.metadescriptionAvailable = metadescription !== "";
-	result.titleAvailable = title !== "";
+	result.hasMetaDescription = metadescription !== "";
+	result.hasTitle = title !== "";
 	result.prominentWords = [];
 
 	/**


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [yoastseo] Renames some Redux state variables.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

See https://github.com/Yoast/wordpress-seo-premium/pull/2552

* This PR affects the following parts of the plugin, which may require extra testing:
  * Linking suggestions in the metabox. No performance impact estimated.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2523
