### PR TITLE
Make sure the snippet preview image CSS size cannot be altered.

### DIFF
--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -201,10 +201,12 @@ const MobileDescriptionImageContainer = styled.div`
 `;
 
 const MobileDescriptionImage = styled.img`
-	display: block;
-	/* The !important is used to make sure inherited CSS rules don't alter the image ratio. */
-	width: 104px !important;
-	height: 104px !important;
+	/* Higher specificity is necessary to make sure inherited CSS rules don't alter the image ratio. */
+	&&& {
+		display: block;
+		width: 104px;
+		height: 104px;
+	}
 `;
 
 const MobilePartContainer = styled.div`

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -202,8 +202,9 @@ const MobileDescriptionImageContainer = styled.div`
 
 const MobileDescriptionImage = styled.img`
 	display: block;
-	width: 104px;
-	height: 104px;
+	/* The !important is used to make sure inherited CSS rules don't alter the image ratio. */
+	width: 104px !important;
+	height: 104px !important;
 `;
 
 const MobilePartContainer = styled.div`


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [search-metadata-previews] Increases the specificity of the width and height CSS of the MobileDescriptionImage.

~This quick PR adds `!important` to the snippet preview image width and height CSS values to make sure the image size isn't altered by other CSS rules.~

For more details please see https://github.com/Yoast/wordpress-seo/pull/13458#issuecomment-537416643

~Yes: `!important` is a bad CSS practice but in this case we really don't want the 104 by 104 pixels size to be altered.~

Fixes https://github.com/Yoast/wordpress-seo/issues/13058