### PR TITLE
Dutch stemming exceptions

### DIFF
--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -116,6 +116,6 @@
     }
   },
   "yoast": {
-    "premiumConfiguration": "feature/Dutch-morphology"
+    "premiumConfiguration": ""
   }
 }

--- a/packages/yoastseo/spec/morphology/dutch/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/stemSpec.js
@@ -116,6 +116,8 @@ const wordsNotToStem = [
 	 "zo",
 	// A word with a single vowel. Only stems which had one of the specified suffixes should have the vowel doubled.
 	 "man",
+	// A word on the exception list of words not to stem.
+	"kerst",
 ];
 
 describe( "Test for stemming Dutch words", () => {

--- a/packages/yoastseo/spec/morphology/dutch/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/stemSpec.js
@@ -93,6 +93,10 @@ const wordsToStem = [
 	[ "wisselen", "wissel" ],
 	// A word that should not have the vowel doubled because it is on an exception list.
 	[ "motoren", "motor" ],
+	// A word that should not have the vowel doubled because the preceding syllable contains a diphthong.
+	[ "duivelen", "duivel" ],
+	// A word that should have the vowel doubled, even though the vowel is preceded by two same consonants.
+	[ "nivelleren", "nivelleer" ],
 	// A word that should have the consonant undoubled.
 	[ "mannen", "man" ],
 	// An adjective with stem ending in -iël.

--- a/packages/yoastseo/spec/morphology/dutch/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/stemSpec.js
@@ -101,10 +101,12 @@ const wordsToStem = [
 	[ "mannen", "man" ],
 	// An adjective with stem ending in -iël.
 	[ "officiële", "officieel" ],
-	// An adjective with the superlative stem ending in -ïed
+	// An adjective with the superlative stem ending in -ïed.
 	[ "paranoïedste", "paranoïd" ],
-	// An adjective with the comparative partitive suffix -ers
+	// An adjective with the comparative partitive suffix -ers.
 	[ "ronders", "rond" ],
+	// An adjective with stem ending in -rd.
+	[ "absurder", "absurd" ],
 ];
 
 // These words should not be stemmed (same form should be returned).

--- a/packages/yoastseo/spec/morphology/dutch/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/stemSpec.js
@@ -89,8 +89,10 @@ const wordsToStem = [
 	[ "beloven", "beloof" ],
 	// Vowel doubling + Z at the end of a stem gets replaced by s.
 	[ "lezen", "lees" ],
-	// A word that should not have the vowel doubled
+	// A word that should not have the vowel doubled because the vowel is preceded by two same consonants.
 	[ "wisselen", "wissel" ],
+	// A word that should not have the vowel doubled because it is on an exception list.
+	[ "motoren", "motor" ],
 	// A word that should have the consonant undoubled.
 	[ "mannen", "man" ],
 	// An adjective with stem ending in -iël.

--- a/packages/yoastseo/spec/morphology/dutch/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/stemSpec.js
@@ -106,7 +106,7 @@ const wordsToStem = [
 	// An adjective with the comparative partitive suffix -ers.
 	[ "ronders", "rond" ],
 	// An adjective with stem ending in -rd.
-	[ "absurder", "absurd" ],
+	[ "absurder", "absurd" ] ];
 
 // These words should not be stemmed (same form should be returned).
 

--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -119,7 +119,11 @@ const secondExceptionCheckVowelDoubling = function( word, wordsWithVowelDoubling
 	if ( wordsWithVowelDoubling.includes( word ) )  {
 		return true;
 	}
+	const fourthToLastLetter = word.charAt( word.length - 4 );
+	const thirdToLastLetter = word.charAt( word.length - 3 );
+	return fourthToLastLetter !== thirdToLastLetter;
 };
+
 
 /**
  * Checks whether the vowel matches a regex. If it does, it means that its vowel should not be doubled.
@@ -141,10 +145,13 @@ const thirdExceptionCheckVowelDoubling = function( word, noVowelDoublingRegex ) 
  */
 const isVowelDoublingAllowed = function( word, morphologyDataNLStemmingExceptions ) {
 	const firstCheck = firstExceptionCheckVowelDoubling( word, morphologyDataNLStemmingExceptions.noVowelDoubling.words );
+	console.log("firstcheck", firstCheck)
 
 	const secondCheck = secondExceptionCheckVowelDoubling( word, morphologyDataNLStemmingExceptions.getVowelDoubling );
+	console.log("secondcheck", secondCheck)
 
 	const thirdCheck = thirdExceptionCheckVowelDoubling(  word, morphologyDataNLStemmingExceptions.noVowelDoubling.rule );
+	console.log("thirdcheck", thirdCheck)
 
 	if ( ! firstCheck && secondCheck && thirdCheck  ) {
 		return true;

--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -119,6 +119,7 @@ const secondExceptionCheckVowelDoubling = function( word, wordsWithVowelDoubling
 	if ( wordsWithVowelDoubling.includes( word ) )  {
 		return true;
 	}
+};
 
 /**
  * Checks whether the vowel matches a regex. If it does, it means that its vowel should not be doubled.

--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -145,13 +145,8 @@ const thirdExceptionCheckVowelDoubling = function( word, noVowelDoublingRegex ) 
  */
 const isVowelDoublingAllowed = function( word, morphologyDataNLStemmingExceptions ) {
 	const firstCheck = firstExceptionCheckVowelDoubling( word, morphologyDataNLStemmingExceptions.noVowelDoubling.words );
-	console.log("firstcheck", firstCheck)
-
 	const secondCheck = secondExceptionCheckVowelDoubling( word, morphologyDataNLStemmingExceptions.getVowelDoubling );
-	console.log("secondcheck", secondCheck)
-
 	const thirdCheck = thirdExceptionCheckVowelDoubling(  word, morphologyDataNLStemmingExceptions.noVowelDoubling.rule );
-	console.log("thirdcheck", thirdCheck)
 
 	if ( ! firstCheck && secondCheck && thirdCheck  ) {
 		return true;

--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -94,6 +94,20 @@ const modifyStem = function( word, modificationGroup ) {
 	} return word;
 };
 
+const exceptionCheckVowelDoubling = function( word, morphologyDataNLNoVowelDoubling ) {
+	for (const exceptionWord of morphologyDataNLNoVowelDoubling) {
+		if (word === exceptionWord) {
+			return true
+		}
+	}
+};
+
+const ruleCheckVowelDoubling = function( word ) {
+	const fourthToLastLetter = word.charAt( word.length - 4 );
+	const thirdToLastLetter = word.charAt( word.length - 3 );
+	return fourthToLastLetter !== thirdToLastLetter;
+};
+
 /**
  * Checks whether the third to last and fourth to last characters are different. If they are, then the doubling vowel
  * modification should be performed. If these characters are the same, no doubling should be performed.
@@ -101,12 +115,18 @@ const modifyStem = function( word, modificationGroup ) {
  * performed (it would not become 'lutteel').
  *
  * @param {string} word The stemmed word that the check should be executed on.
+ * @param {Object} morphologyDataNLNoVowelDoubling Exception list of words that should not have the vowel doubled.
  * @returns {boolean} Whether the third and fourth to last characters are different.
  */
 const isVowelDoublingAllowed = function( word, morphologyDataNLNoVowelDoubling ) {
-	const fourthToLastLetter = word.charAt( word.length - 4 );
-	const thirdToLastLetter = word.charAt( word.length - 3 );
-	return fourthToLastLetter !== thirdToLastLetter;
+
+	const isOnExceptionList = exceptionCheckVowelDoubling( word, morphologyDataNLNoVowelDoubling );
+
+	const vowelIsPrecededByTwoSameLetters = ruleCheckVowelDoubling( word );
+
+	if( !isOnExceptionList && vowelIsPrecededByTwoSameLetters ) {
+		return true
+	}
 };
 
 /**
@@ -128,12 +148,11 @@ const deleteSuffixAndModifyStem = function( word, suffixStep, suffixIndex, stemM
 		return modifyStem( word, morphologyDataNL.stemming.stemModifications.iedToId );
 	} else if ( stemModification === "changeInktoIng" && word.endsWith( "ink" ) ) {
 		return modifyStem( word, morphologyDataNL.stemming.stemModifications.inkToIng );
-	} else if ( stemModification === "vowelDoubling" && isVowelDoublingAllowed( word ) ) {
+	} else if ( stemModification === "vowelDoubling" && isVowelDoublingAllowed( word, morphologyDataNL.stemming.stemExceptions.noVowelDoubling ) ) {
 		return modifyStem( word, morphologyDataNL.stemming.stemModifications.doubleVowel );
 	}
 	return word;
 };
-
 
 /**
  * Finds and deletes the suffix found in a particular step, and modifies the stem.

--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -8,6 +8,22 @@
  *
  * Redistribution and use in source and binary forms, with or without modification, is covered by the standard BSD license.
  */
+
+/**
+ * Checks whether the word ends with what looks like a suffix but is actually part of the stem, and therefore should not be stemmed.
+ *
+ * @param {string} word The word to check.
+ * @param {Object} morphologyDataNLWordsNotToStem The exception list of words that should not be stemmed.
+ * @returns {boolean} Whether or not the word should be stemmed
+ */
+const shouldNotBeStemmed = function( word, morphologyDataNLWordsNotToStem ) {
+	for ( const wordNotToStem of morphologyDataNLWordsNotToStem ) {
+		if ( word === wordNotToStem ) {
+			return true
+		}
+	}
+};
+
 /**
  * Determines the start index of the R1 region.
  * R1 is the region after the first non-vowel following a vowel. It should include at least 3 letters.
@@ -15,6 +31,7 @@
  * @param {string} word The word for which to determine the R1 region.
  * @returns {number} The start index of the R1 region.
  */
+
 const determineR1 = function( word ) {
 	// Start with matching the first cluster that consists of a vowel and a non-vowel.
 	let r1Index = word.search( /[aeiouyèäüëïöáéíóú][^aeiouyèäüëïöáéíóú]/ );
@@ -86,7 +103,7 @@ const modifyStem = function( word, modificationGroup ) {
  * @param {string} word The stemmed word that the check should be executed on.
  * @returns {boolean} Whether the third and fourth to last characters are different.
  */
-const isVowelDoublingAllowed = function( word ) {
+const isVowelDoublingAllowed = function( word, morphologyDataNLNoVowelDoubling ) {
 	const fourthToLastLetter = word.charAt( word.length - 4 );
 	const thirdToLastLetter = word.charAt( word.length - 3 );
 	return fourthToLastLetter !== thirdToLastLetter;
@@ -166,6 +183,12 @@ const findAndDeleteSuffixes = function( word, suffixSteps, r1Index, morphologyDa
  * @returns {string} The stemmed word.
  */
 export default function stem( word, morphologyDataNL ) {
+
+	// Return the word if it should not be stemmed.
+	if ( shouldNotBeStemmed( word, morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions ) ) {
+		return word
+	}
+
 	/**
 	 * Put i and y in between vowels, initial y, and y after a vowel into upper case. This is because they should
 	 * be treated as consonants so we want to differentiate them from other i's and y's when matching regexes.


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds exception checks to the Dutch stemmer (vowel doubling exceptions, words that should not be stemmed, adjectives ending in -rd which would have the -d incorrectly stemmed).

## Test instructions

This PR can be tested by following these steps:

Add more words that constitute a stemming exception to the specs. This includes:
- Words that should not be stemmed. The list of those can be found in the morphology data file under wordsNotToBeStemmedExceptions.
- Adjectives with stem ending in -rd. Those can be found in the data file under adjectivesEndInRD
- Words that should not have the vowel doubled. The list and regex for those can be found in the data file under noVowelDoubling. Also words for which have the same third and fourth to last character (followed by consonant - vowel - consonant) should not have the vowel doubled. This [corpus](http://anw.inl.nl/search?type=feature) can be used to find some examples of such words.
- Words that should have the vowel doubled. The list can be found in the data file under getVowelDoubling.

Fixes #364 
