### PR TITLE
Only show the button when there are elements in the array

### DIFF
--- a/packages/search-metadata-previews/src/snippet-editor/ReplacementVariableEditor.js
+++ b/packages/search-metadata-previews/src/snippet-editor/ReplacementVariableEditor.js
@@ -100,7 +100,7 @@ class ReplacementVariableEditor extends React.Component {
 				>
 					{ label }
 				</SimulatedLabel>
-				{ addVariableButton }
+				{ replacementVariables.length > 0 && addVariableButton }
 				<InputContainer
 					onClick={ onFocus }
 					isActive={ isActive }


### PR DESCRIPTION
## Summary
Makes the addVariable button only visible when there are actually replacement variables.

This PR can be summarized in the following changelog entry:

* Only show the `addVariable` button when replacement variables get passed to the element.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #26
