### PR TITLE
add  Dutch adjective exceptions

### DIFF
--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -116,6 +116,6 @@
     }
   },
   "yoast": {
-    "premiumConfiguration": "feature/Dutch-morphology"
+    "premiumConfiguration": ""
   }
 }

--- a/packages/yoastseo/spec/morphology/dutch/generateAdjectiveExceptionFormsSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/generateAdjectiveExceptionFormsSpec.js
@@ -4,11 +4,6 @@ import getMorphologyData from "../../specHelpers/getMorphologyData";
 const morphologyDataNL = getMorphologyData( "nl" ).nl;
 
 describe( "Test for checking adjective exceptions in Dutch", () => {
-	it( "creates forms for indeclinable exception words", () => {
-		expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, "acajou" ) ).toEqual(
-			"acajou"
-		);
-	} );
 	it( "creates forms for adjectives which only take partitive suffix -s", () => {
 		expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, "halal" ) ).toEqual(
 			[ "halals" ]

--- a/packages/yoastseo/spec/morphology/dutch/generateAdjectiveExceptionFormsSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/generateAdjectiveExceptionFormsSpec.js
@@ -4,29 +4,29 @@ import getMorphologyData from "../../specHelpers/getMorphologyData";
 const morphologyDataNL = getMorphologyData( "nl" ).nl;
 
 describe( "Test for checking adjective exceptions in Dutch", () => {
-    it( "creates forms for indeclinable exception words", () => {
-        expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, "acajou" ) ).toEqual(
-            "acajou"
-         );
-    } );
-    it( "creates forms for adjectives which only take partitive suffix -s", () => {
-        expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, "halal" ) ).toEqual(
-            [ "halals" ]
-        );
-    } );
-    it( "creates forms for adjectives ending in -en which take all adjective suffixes", () => {
-        expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "feminien" ) ).toEqual(
-            [ "feminiener", "feminieners", "feminienere", "feminieneres", "feminienst", "feminienste", "feminiene", "feminiens" ]
-        );
-    } );
-    it( "creates forms for adjectives ending in -en which take 5 adjective suffixes (s, er, ers, st, ste)", () => {
-        expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "even" ) ).toEqual(
-            [ "evens", "evener", "eveners", "evenst", "evenste" ]
-        )
-    } );
-    it("created forms for adjectives ending in -en which only take partitive and inflected suffixes", () => {
-        expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "neopreen" ) ).toEqual(
-            [ "neopreens", "neoprene" ]
-        )
-    } )
+	it( "creates forms for indeclinable exception words", () => {
+		expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, "acajou" ) ).toEqual(
+			"acajou"
+		);
+	} );
+	it( "creates forms for adjectives which only take partitive suffix -s", () => {
+		expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, "halal" ) ).toEqual(
+			[ "halals" ]
+		);
+	} );
+	it( "creates forms for adjectives ending in -en which take all adjective suffixes", () => {
+		expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "feminien" ) ).toEqual(
+			[ "feminiener", "feminieners", "feminienere", "feminieneres", "feminienst", "feminienste", "feminiene", "feminiens" ]
+		);
+	} );
+	it( "creates forms for adjectives ending in -en which take 5 adjective suffixes (s, er, ers, st, ste)", () => {
+		expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "even" ) ).toEqual(
+			[ "evens", "evener", "eveners", "evenst", "evenste" ]
+		);
+	} );
+	it( "created forms for adjectives ending in -en which only take partitive and inflected suffixes", () => {
+		expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "neopreen" ) ).toEqual(
+			[ "neopreens", "neoprene" ]
+		);
+	} );
 } );

--- a/packages/yoastseo/spec/morphology/dutch/generateAdjectiveExceptionFormsSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/generateAdjectiveExceptionFormsSpec.js
@@ -1,0 +1,32 @@
+import { generateAdjectiveExceptionForms } from "../../../src/morphology/dutch/generateAdjectiveExceptionForms";
+import getMorphologyData from "../../specHelpers/getMorphologyData";
+
+const morphologyDataNL = getMorphologyData( "nl" ).nl;
+
+describe( "Test for checking adjective exceptions in Dutch", () => {
+    it( "creates forms for indeclinable exception words", () => {
+        expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, "acajou" ) ).toEqual(
+            "acajou"
+         );
+    } );
+    it( "creates forms for adjectives which only take partitive suffix -s", () => {
+        expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, "halal" ) ).toEqual(
+            [ "halals" ]
+        );
+    } );
+    it( "creates forms for adjectives ending in -en which take all adjective suffixes", () => {
+        expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "feminien" ) ).toEqual(
+            [ "feminiener", "feminieners", "feminienere", "feminieneres", "feminienst", "feminienste", "feminiene", "feminiens" ]
+        );
+    } );
+    it( "creates forms for adjectives ending in -en which take 5 adjective suffixes (s, er, ers, st, ste)", () => {
+        expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "even" ) ).toEqual(
+            [ "evens", "evener", "eveners", "evenst", "evenste" ]
+        )
+    } );
+    it("created forms for adjectives ending in -en which only take partitive and inflected suffixes", () => {
+        expect( generateAdjectiveExceptionForms( morphologyDataNL.adjectives, morphologyDataNL.addSuffixes.stemModifications, "neopreen" ) ).toEqual(
+            [ "neopreens", "neoprene" ]
+        )
+    } )
+} );

--- a/packages/yoastseo/src/morphology/dutch/generateAdjectiveExceptionForms.js
+++ b/packages/yoastseo/src/morphology/dutch/generateAdjectiveExceptionForms.js
@@ -1,0 +1,134 @@
+import {
+	addAllAdjectiveSuffixes,
+	addSuperlativeSuffixes,
+	addPartitiveSuffix,
+	addInflectedSuffix,
+} from "./addAdjectiveSuffixes";
+import {
+	applySuffixesToStem,
+} from "../../../src/morphology/morphoHelpers/suffixHelpers";
+
+/**
+ *  Returns form of the indeclinable adjectives. These adjectives should not get any suffixes.
+ *
+ * @param {Object}  morphologyDataAdjectives    The Dutch morphology data for adjectives.
+ * @param {string}  stemmedWord                 The stemmed word for which to get suffixes.
+ *
+ * @returns {string[]}  The original form. The form returned should be the same with the input.
+ *
+ */
+
+
+export function indeclinable( morphologyDataAdjectives, stemmedWord ) {
+	const exceptionStems = morphologyDataAdjectives.exceptions.indeclinable;
+	if ( exceptionStems.includes( stemmedWord ) ) {
+		return stemmedWord;
+	}
+	return [];
+}
+
+/**
+ * Returns form of the adjectives which only take partitive suffix -s.
+ *
+ * @param {Object} morphologyDataAdjectives		The Dutch morphology data for adjectives.
+ * @param {string} stemmedWord					The stemmed word for which to get suffixes.
+ *
+ * @returns {string[]} The created adjective form.
+ */
+export function stemSuffixS( morphologyDataAdjectives, stemmedWord ) {
+	const exceptionStems = morphologyDataAdjectives.exceptions.stemSuffixS;
+	if ( exceptionStems.includes( stemmedWord ) ) {
+		return [ addPartitiveSuffix( morphologyDataAdjectives, stemmedWord ) ];
+	}
+	return [];
+}
+
+/**
+ * Returns forms of the adjectives ending in -en which get all adjective suffixes.
+ *
+ * @param {Object} morphologyDataAdjectives			The Dutch morphology data for adjectives.
+ * @param {Object} morphologyDataStemModifications	The Dutch stem modifications data.
+ * @param {string} stemmedWord						The stemmed word for which to get suffixes.
+ *
+ * @returns {string[]}	The created adjective forms.
+ */
+export function enGetAllSuffixes( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord ) {
+	const exceptionStems = morphologyDataAdjectives.exceptions.enGetAllSuffixes;
+	if ( exceptionStems.includes( stemmedWord ) ) {
+		return addAllAdjectiveSuffixes( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord );
+	}
+	return [];
+}
+
+/**
+ * Returns forms of the adjectives ending in -en which get 5 adjective suffixes ("s", "er", "ers", "st", "ste").
+ *
+ * @param {Object} morphologyDataAdjectives			The Dutch morphology data for adjectives.
+ * @param {Object} morphologyDataStemModifications	The Dutch stem modifications data.
+ * @param {string} stemmedWord						The stemmed word for which to get suffixes.
+ *
+ * @returns {string[]}	The created Adjective forms.
+ */
+
+export function enGet5Suffixes( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord ) {
+	const exceptionStems = morphologyDataAdjectives.exceptions.enGet5Suffixes;
+	const comparativeSuffixes = morphologyDataAdjectives.comparativeSuffixesEr.slice( 0, 2 );
+	if ( exceptionStems.includes( stemmedWord ) ) {
+		return [
+			addPartitiveSuffix( morphologyDataAdjectives, stemmedWord ),
+			...applySuffixesToStem( stemmedWord, comparativeSuffixes ),
+			...addSuperlativeSuffixes( morphologyDataAdjectives, stemmedWord ),
+		];
+	}
+	return [];
+}
+
+/**
+ * Returns forms of the adjectives ending in -en which only get partitive and inflected suffix.
+ *
+ * @param {Object} morphologyDataAdjectives			The Dutch morphology data for adjectives.
+ * @param {Object} morphologyDataStemModifications	The Dutch stem modifications data.
+ * @param {string} stemmedWord						The stemmed word for which to get suffixes.
+ *
+ * @returns {string[]}	The created Adjective forms.
+ */
+export function enGet2Suffixes( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord ) {
+	const exceptionStems = morphologyDataAdjectives.exceptions.enGet2Suffixes;
+	if ( exceptionStems.includes( stemmedWord ) ) {
+		return [
+			addPartitiveSuffix( morphologyDataAdjectives, stemmedWord ),
+			addInflectedSuffix( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord ),
+		];
+	}
+	return [];
+}
+
+
+/**
+ * Checks whether a given stem falls into any of the adjective exception categories and creates the
+ * correct forms if that is the case.
+ *
+ * @param {Object} morphologyDataAdjectives			The Dutch morphology data for adjectives.
+ * @param {Object} morphologyDataStemModifications	The Dutch stem modifications data.
+ * @param {string} stemmedWord						The stemmed word for which to get suffixes.
+ *
+ * @returns {string[]}	The created adjective forms.
+ */
+export function generateAdjectiveExceptionForms( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord ) {
+	const exceptionChecks = [
+		indeclinable,
+		stemSuffixS,
+		enGetAllSuffixes,
+		enGet5Suffixes,
+		enGet2Suffixes,
+	];
+
+	for ( let i = 0; i < exceptionChecks.length; i++ ) {
+		const exceptions = exceptionChecks[ i ]( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord );
+		if ( exceptions.length > 0 ) {
+			return exceptions;
+		}
+	}
+
+	return [];
+}

--- a/packages/yoastseo/src/morphology/dutch/generateAdjectiveExceptionForms.js
+++ b/packages/yoastseo/src/morphology/dutch/generateAdjectiveExceptionForms.js
@@ -17,8 +17,6 @@ import {
  * @returns {string[]}  The original form. The form returned should be the same with the input.
  *
  */
-
-
 export function indeclinable( morphologyDataAdjectives, stemmedWord ) {
 	const exceptionStems = morphologyDataAdjectives.exceptions.indeclinable;
 	if ( exceptionStems.includes( stemmedWord ) ) {
@@ -69,7 +67,6 @@ export function enGetAllSuffixes( morphologyDataAdjectives, morphologyDataStemMo
  *
  * @returns {string[]}	The created Adjective forms.
  */
-
 export function enGet5Suffixes( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord ) {
 	const exceptionStems = morphologyDataAdjectives.exceptions.enGet5Suffixes;
 	const comparativeSuffixes = morphologyDataAdjectives.comparativeSuffixesEr.slice( 0, 2 );

--- a/packages/yoastseo/src/morphology/dutch/generateAdjectiveExceptionForms.js
+++ b/packages/yoastseo/src/morphology/dutch/generateAdjectiveExceptionForms.js
@@ -7,24 +7,6 @@ import {
 import {
 	applySuffixesToStem,
 } from "../../../src/morphology/morphoHelpers/suffixHelpers";
-
-/**
- *  Returns form of the indeclinable adjectives. These adjectives should not get any suffixes.
- *
- * @param {Object}  morphologyDataAdjectives    The Dutch morphology data for adjectives.
- * @param {string}  stemmedWord                 The stemmed word for which to get suffixes.
- *
- * @returns {string[]}  The original form. The form returned should be the same with the input.
- *
- */
-export function indeclinable( morphologyDataAdjectives, stemmedWord ) {
-	const exceptionStems = morphologyDataAdjectives.exceptions.indeclinable;
-	if ( exceptionStems.includes( stemmedWord ) ) {
-		return stemmedWord;
-	}
-	return [];
-}
-
 /**
  * Returns form of the adjectives which only take partitive suffix -s.
  *
@@ -113,7 +95,6 @@ export function enGet2Suffixes( morphologyDataAdjectives, morphologyDataStemModi
  */
 export function generateAdjectiveExceptionForms( morphologyDataAdjectives, morphologyDataStemModifications, stemmedWord ) {
 	const exceptionChecks = [
-		indeclinable,
 		stemSuffixS,
 		enGetAllSuffixes,
 		enGet5Suffixes,


### PR DESCRIPTION
## Summary


This PR can be summarized in the following changelog entry:

* adding Dutch adjective exceptions

## Test instructions

This PR can be tested by following these steps:

* add more words from adjective exception lists in morphologyDataNL into spec. For example from stemSfuffixS, enGetAllSuffixes, enGet5Suffixes and enGet2Suffixes lists.


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #369 
