### PR TITLE
Adjust custom form controls styling for WP 5.3.

### DIFF
--- a/packages/components/src/input/InputField.js
+++ b/packages/components/src/input/InputField.js
@@ -6,7 +6,8 @@ import { colors, rgba } from "@yoast/style-guide";
 
 export const InputField = styled.input`
 	&&& {
-		padding: 8px;
+		padding: 0 8px;
+		min-height: 34px;
 		font-size: 1em;
 		box-shadow: inset 0 1px 2px ${ rgba( colors.$color_black, 0.07 ) };
 		border: 1px solid ${ colors.$color_input_border };

--- a/packages/yoast-components/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
@@ -56,7 +56,8 @@ exports[`KeywordInput matches the snapshot by default 1`] = `
 }
 
 .c5.c5.c5 {
-  padding: 8px;
+  padding: 0 8px;
+  min-height: 34px;
   font-size: 1em;
   box-shadow: inset 0 1px 2px rgba( 0,0,0,0.07 );
   border: 1px solid #ddd;


### PR DESCRIPTION
## Summary

This tiny PR is needed for the related wordpress-seo PR, please see instructions there.

This PR can be summarized in the following changelog entry:

- [components] Improves the `InputField` styling for consistency with the new WordPress 5.3 admin styles
- [yoast-components] Improves the `KeywordInput` and `SynonymsInput` styling for consistency with the new WordPress 5.3 admin styles

## Relevant technical choices:

*

## Test instructions
This tiny PR is needed for the related wordpress-seo PR, please see instructions there.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/642
