### PR TITLE
Fix snippet preview elements order.

### DIFF
--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -584,21 +584,26 @@ export default class SnippetPreview extends PureComponent {
 		 * However this is not relevant in this case, because the url is not focusable.
 		 */
 		/* eslint-disable jsx-a11y/mouse-events-have-key-events */
-		return <Url>
-			<BaseUrlOverflowContainer
-				onMouseUp={ onMouseUp.bind( null, "url" ) }
-				onMouseEnter={ onMouseEnter.bind( null, "url" ) }
-				onMouseLeave={ onMouseLeave.bind( null ) }
-				screenMode={ mode }
-			>
-				{ isMobileMode && <Favicon src={ faviconSrc || globeFaviconSrc } alt="" /> }
-				<UrlContentContainer
+		return <React.Fragment>
+			<ScreenReaderText>
+				{ __( "Url preview", "yoast-components" ) + ":" }
+			</ScreenReaderText>
+			<Url>
+				<BaseUrlOverflowContainer
+					onMouseUp={ onMouseUp.bind( null, "url" ) }
+					onMouseEnter={ onMouseEnter.bind( null, "url" ) }
+					onMouseLeave={ onMouseLeave.bind( null ) }
 					screenMode={ mode }
 				>
-					{ urlContent }
-				</UrlContentContainer>
-			</BaseUrlOverflowContainer>
-		</Url>;
+					{ isMobileMode && <Favicon src={ faviconSrc || globeFaviconSrc } alt="" /> }
+					<UrlContentContainer
+						screenMode={ mode }
+					>
+						{ urlContent }
+					</UrlContentContainer>
+				</BaseUrlOverflowContainer>
+			</Url>
+		</React.Fragment>;
 		/* eslint-enable jsx-a11y/mouse-events-have-key-events */
 	}
 
@@ -759,10 +764,10 @@ export default class SnippetPreview extends PureComponent {
 					padding={ WIDTH_PADDING }
 				>
 					<PartContainer>
+						{ ! isDesktopMode && this.renderUrl() }
 						<ScreenReaderText>
 							{ __( "SEO title preview", "yoast-components" ) + ":" }
 						</ScreenReaderText>
-						{ ! isDesktopMode && this.renderUrl() }
 						<SnippetTitle
 							onMouseUp={ onMouseUp.bind( null, "title" ) }
 							onMouseEnter={ onMouseEnter.bind( null, "title" ) }
@@ -774,9 +779,6 @@ export default class SnippetPreview extends PureComponent {
 								</TitleUnbounded>
 							</TitleBounded>
 						</SnippetTitle>
-						<ScreenReaderText>
-							{ __( "Url preview", "yoast-components" ) + ":" }
-						</ScreenReaderText>
 						{ amp }
 						{ isDesktopMode && this.renderUrl() }
 						{ downArrow }

--- a/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -406,7 +406,7 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
             }
           }
         >
-          SEO title preview:
+          Url preview:
         </span>
         <div
           className="c2"
@@ -429,6 +429,20 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
             </span>
           </div>
         </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
         <div
           className="c6"
           onMouseEnter={[Function]}
@@ -445,20 +459,6 @@ exports[`SnippetEditor accepts a custom data mapping function 1`] = `
             </span>
           </div>
         </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
       </div>
       <div
         className="c1"
@@ -1607,7 +1607,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -1773,6 +1773,22 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -1896,22 +1912,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 1
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -6093,7 +6093,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -6259,6 +6259,22 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -6382,22 +6398,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 2
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -10579,7 +10579,7 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -10745,6 +10745,22 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -10868,22 +10884,6 @@ exports[`SnippetEditor calls callbacks when the editors are focused or changed 3
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -15065,7 +15065,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -15231,6 +15231,22 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -15354,22 +15370,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -19171,7 +19171,7 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -19337,6 +19337,22 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -19460,22 +19476,6 @@ exports[`SnippetEditor closes when calling close() 2`] = `
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -21930,7 +21930,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -22096,6 +22096,22 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -22219,22 +22235,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -26416,7 +26416,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -26582,6 +26582,22 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -26705,22 +26721,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -30402,7 +30402,7 @@ exports[`SnippetEditor highlights a focused field 1`] = `
             }
           }
         >
-          SEO title preview:
+          Url preview:
         </span>
         <div
           className="c2"
@@ -30425,6 +30425,20 @@ exports[`SnippetEditor highlights a focused field 1`] = `
             </span>
           </div>
         </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
         <div
           className="c6"
           onMouseEnter={[Function]}
@@ -30441,20 +30455,6 @@ exports[`SnippetEditor highlights a focused field 1`] = `
             </span>
           </div>
         </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
       </div>
       <div
         className="c1"
@@ -30995,7 +30995,7 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
             }
           }
         >
-          SEO title preview:
+          Url preview:
         </span>
         <div
           className="c2"
@@ -31018,6 +31018,20 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
             </span>
           </div>
         </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
         <div
           className="c6"
           onMouseEnter={[Function]}
@@ -31034,20 +31048,6 @@ exports[`SnippetEditor highlights a hovered field 1`] = `
             </span>
           </div>
         </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
       </div>
       <div
         className="c1"
@@ -32117,7 +32117,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -32283,6 +32283,22 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -32406,22 +32422,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -36641,7 +36641,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -36807,6 +36807,22 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -36930,22 +36946,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -41136,7 +41136,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -41302,6 +41302,22 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -41425,22 +41441,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -45633,7 +45633,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -45799,6 +45799,22 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -45922,22 +45938,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -49678,7 +49678,7 @@ exports[`SnippetEditor passes the date prop 1`] = `
             }
           }
         >
-          SEO title preview:
+          Url preview:
         </span>
         <div
           className="c2"
@@ -49701,6 +49701,20 @@ exports[`SnippetEditor passes the date prop 1`] = `
             </span>
           </div>
         </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
         <div
           className="c6"
           onMouseEnter={[Function]}
@@ -49717,20 +49731,6 @@ exports[`SnippetEditor passes the date prop 1`] = `
             </span>
           </div>
         </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
       </div>
       <div
         className="c1"
@@ -50886,7 +50886,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                             }
                           }
                         >
-                          SEO title preview:
+                          Url preview:
                         </span>
                       </ScreenReaderText>
                       <SnippetPreview__BaseUrl>
@@ -51052,6 +51052,22 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseUrl>
+                      <ScreenReaderText>
+                        <span
+                          className="screen-reader-text"
+                          style={
+                            Object {
+                              "clip": "rect(1px, 1px, 1px, 1px)",
+                              "height": "1px",
+                              "overflow": "hidden",
+                              "position": "absolute",
+                              "width": "1px",
+                            }
+                          }
+                        >
+                          SEO title preview:
+                        </span>
+                      </ScreenReaderText>
                       <SnippetPreview__BaseTitle
                         onMouseEnter={[Function]}
                         onMouseLeave={[Function]}
@@ -51175,22 +51191,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
                           </div>
                         </StyledComponent>
                       </SnippetPreview__BaseTitle>
-                      <ScreenReaderText>
-                        <span
-                          className="screen-reader-text"
-                          style={
-                            Object {
-                              "clip": "rect(1px, 1px, 1px, 1px)",
-                              "height": "1px",
-                              "overflow": "hidden",
-                              "position": "absolute",
-                              "width": "1px",
-                            }
-                          }
-                        >
-                          Url preview:
-                        </span>
-                      </ScreenReaderText>
                     </div>
                   </StyledComponent>
                 </SnippetPreview__MobilePartContainer>
@@ -55673,7 +55673,7 @@ exports[`SnippetEditor renders the snippet editor without a close button when sh
             }
           }
         >
-          SEO title preview:
+          Url preview:
         </span>
         <div
           className="c2"
@@ -55696,6 +55696,20 @@ exports[`SnippetEditor renders the snippet editor without a close button when sh
             </span>
           </div>
         </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
         <div
           className="c6"
           onMouseEnter={[Function]}
@@ -55712,20 +55726,6 @@ exports[`SnippetEditor renders the snippet editor without a close button when sh
             </span>
           </div>
         </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
       </div>
       <div
         className="c1"
@@ -56361,7 +56361,7 @@ exports[`SnippetEditor shows the editor 1`] = `
             }
           }
         >
-          SEO title preview:
+          Url preview:
         </span>
         <div
           className="c2"
@@ -56384,6 +56384,20 @@ exports[`SnippetEditor shows the editor 1`] = `
             </span>
           </div>
         </div>
+        <span
+          className="screen-reader-text"
+          style={
+            Object {
+              "clip": "rect(1px, 1px, 1px, 1px)",
+              "height": "1px",
+              "overflow": "hidden",
+              "position": "absolute",
+              "width": "1px",
+            }
+          }
+        >
+          SEO title preview:
+        </span>
         <div
           className="c6"
           onMouseEnter={[Function]}
@@ -56400,20 +56414,6 @@ exports[`SnippetEditor shows the editor 1`] = `
             </span>
           </div>
         </div>
-        <span
-          className="screen-reader-text"
-          style={
-            Object {
-              "clip": "rect(1px, 1px, 1px, 1px)",
-              "height": "1px",
-              "overflow": "hidden",
-              "position": "absolute",
-              "width": "1px",
-            }
-          }
-        >
-          Url preview:
-        </span>
       </div>
       <div
         className="c1"

--- a/packages/search-metadata-previews/tests/__snapshots__/SnippetPreviewTest.js.snap
+++ b/packages/search-metadata-previews/tests/__snapshots__/SnippetPreviewTest.js.snap
@@ -1199,7 +1199,7 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
           }
         }
       >
-        SEO title preview:
+        Url preview:
       </span>
       <div
         className="c2"
@@ -1222,6 +1222,20 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
           </span>
         </div>
       </div>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        SEO title preview:
+      </span>
       <div
         className="c6"
         onMouseEnter={[Function]}
@@ -1238,20 +1252,6 @@ exports[`SnippetPreview mobile mode renders an AMP logo when isAmp is true 1`] =
           </span>
         </div>
       </div>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Url preview:
-      </span>
       <div
         className="c9"
       />
@@ -1419,7 +1419,7 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
           }
         }
       >
-        SEO title preview:
+        Url preview:
       </span>
       <div
         className="c2"
@@ -1442,6 +1442,20 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
           </span>
         </div>
       </div>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        SEO title preview:
+      </span>
       <div
         className="c6"
         onMouseEnter={[Function]}
@@ -1458,20 +1472,6 @@ exports[`SnippetPreview mobile mode renders differently than desktop 1`] = `
           </span>
         </div>
       </div>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Url preview:
-      </span>
     </div>
     <div
       className="c1"
@@ -1636,7 +1636,7 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
           }
         }
       >
-        SEO title preview:
+        Url preview:
       </span>
       <div
         className="c2"
@@ -1659,6 +1659,20 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
           </span>
         </div>
       </div>
+      <span
+        className="screen-reader-text"
+        style={
+          Object {
+            "clip": "rect(1px, 1px, 1px, 1px)",
+            "height": "1px",
+            "overflow": "hidden",
+            "position": "absolute",
+            "width": "1px",
+          }
+        }
+      >
+        SEO title preview:
+      </span>
       <div
         className="c6"
         onMouseEnter={[Function]}
@@ -1675,20 +1689,6 @@ exports[`SnippetPreview renders a SnippetPreview in the default mode 1`] = `
           </span>
         </div>
       </div>
-      <span
-        className="screen-reader-text"
-        style={
-          Object {
-            "clip": "rect(1px, 1px, 1px, 1px)",
-            "height": "1px",
-            "overflow": "hidden",
-            "position": "absolute",
-            "width": "1px",
-          }
-        }
-      >
-        Url preview:
-      </span>
     </div>
     <div
       className="c1"


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [search-metadata-previews] Fixes a bug where the Snippet Preview elements had misplaced visually hidden text.

## Relevant technical choices:

*

## Test instructions
- start the standalone app and go to the snippet preview tab
- since the order of the snippet elements changes between mobile and desktop, check both the mobile and desktop preview
- verify the following visually hidden text are in the correct order
- `Url preview:` before the URL
- `SEO title preview:` before the title
- `Meta description preview:` before the description

## Impact check
* This PR affects the following parts of the plugin, which may require extra testing:
  * Metabox

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/563