### PR TITLE
Set node version in .travis.yml to 10.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-- lts/*
+- "10.16"
 - node
 matrix:
   allow_failures:
@@ -15,7 +15,7 @@ stages:
 jobs:
   include:
     - stage: 🚀 rc-deployment
-      node_js: lts/*
+      node_js: "10.16"
       name: "Deploy to the npm rc channel"
       script: skip
       deploy:
@@ -26,7 +26,7 @@ jobs:
           # Branch condition is in the stages configuration
           all_branches: true
     - stage: 🚀 deployment
-      node_js: lts/*
+      node_js: "10.16"
       name: "Deploy to the npm latest channel"
       script: skip
       deploy:


### PR DESCRIPTION
The current LTS in Travis is 12.13, but our node-sass is not compatible with that.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* N/A

## Relevant technical choices:

* 10.16 also has the LTS status until April 2020. I'll create a new issue to make our code work with node 12.13.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* See the travis builds succeed.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * None

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
