### PR TITLE
Refactor calculateTextIndices and add tests

### DIFF
--- a/packages/yoastseo/spec/parsedPaper/build/tree/cleanup/calculateTextIndicesSpec.js
+++ b/packages/yoastseo/spec/parsedPaper/build/tree/cleanup/calculateTextIndicesSpec.js
@@ -20,11 +20,13 @@ describe( "calculateTextIndices", () => {
 
 		const treeAdapter = new TreeAdapter();
 		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
-		const element = tree.children[ 0 ]; // Define the paragraph element that we will use in this test.
+
+		// Define the paragraph element that we will use in this test.
+		const element = tree.children[ 0 ];
 
 		calculateTextIndices( element, source );
 
-		const formattingElement = element.textContainer.formatting[0];
+		const formattingElement = element.textContainer.formatting[ 0 ];
 
 		expect( formattingElement.type ).toEqual( "b" );
 		expect( formattingElement.textStartIndex ).toEqual( 10 );
@@ -36,12 +38,14 @@ describe( "calculateTextIndices", () => {
 
 		const treeAdapter = new TreeAdapter();
 		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
-		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		// Define the paragraph element that we will use in this test.
+		const element = tree.children[ 0 ];
 
 		calculateTextIndices( element, source );
 
-		const formattingElementBold = element.textContainer.formatting[0];
-		const formattingElementItalics = element.textContainer.formatting[1];
+		const formattingElementBold = element.textContainer.formatting[ 0 ];
+		const formattingElementItalics = element.textContainer.formatting[ 1 ];
 
 		expect( formattingElementBold.type ).toEqual( "b" );
 		expect( formattingElementBold.textStartIndex ).toEqual( 10 );
@@ -57,13 +61,15 @@ describe( "calculateTextIndices", () => {
 
 		const treeAdapter = new TreeAdapter();
 		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
-		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		// Define the paragraph element that we will use in this test.
+		const element = tree.children[ 0 ];
 
 		calculateTextIndices( element, source );
 
-		const formattingElementItalicsEmpty = element.textContainer.formatting[0];
-		const formattingElementBold = element.textContainer.formatting[1];
-		const formattingElementItalicsMeaningful = element.textContainer.formatting[2];
+		const formattingElementItalicsEmpty = element.textContainer.formatting[ 0 ];
+		const formattingElementBold = element.textContainer.formatting[ 1 ];
+		const formattingElementItalicsMeaningful = element.textContainer.formatting[ 2 ];
 
 		expect( formattingElementItalicsEmpty.type ).toEqual( "em" );
 		expect( formattingElementItalicsEmpty.textStartIndex ).toEqual( 10 );
@@ -83,13 +89,15 @@ describe( "calculateTextIndices", () => {
 
 		const treeAdapter = new TreeAdapter();
 		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
-		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		// Define the paragraph element that we will use in this test.
+		const element = tree.children[ 0 ];
 
 		calculateTextIndices( element, source );
 
-		const formattingElementBold = element.textContainer.formatting[0];
-		const formattingElementItalicsEmpty = element.textContainer.formatting[1];
-		const formattingElementItalicsNonEmpty = element.textContainer.formatting[2];
+		const formattingElementBold = element.textContainer.formatting[ 0 ];
+		const formattingElementItalicsEmpty = element.textContainer.formatting[ 1 ];
+		const formattingElementItalicsNonEmpty = element.textContainer.formatting[ 2 ];
 
 		expect( formattingElementBold.type ).toEqual( "b" );
 		expect( formattingElementBold.textStartIndex ).toEqual( 10 );
@@ -109,12 +117,14 @@ describe( "calculateTextIndices", () => {
 
 		const treeAdapter = new TreeAdapter();
 		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
-		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		// Define the paragraph element that we will use in this test.
+		const element = tree.children[ 0 ];
 
 		calculateTextIndices( element, source );
 
-		const formattingElementScript = element.textContainer.formatting[0];
-		const formattingElementBold = element.textContainer.formatting[1];
+		const formattingElementScript = element.textContainer.formatting[ 0 ];
+		const formattingElementBold = element.textContainer.formatting[ 1 ];
 
 		expect( formattingElementScript.type ).toEqual( "Ignored" );
 		expect( formattingElementScript.textStartIndex ).toEqual( 10 );
@@ -130,12 +140,14 @@ describe( "calculateTextIndices", () => {
 
 		const treeAdapter = new TreeAdapter();
 		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
-		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		// Define the paragraph element that we will use in this test.
+		const element = tree.children[ 0 ];
 
 		calculateTextIndices( element, source );
 
-		const formattingElementBold = element.textContainer.formatting[0];
-		const formattingElementScript = element.textContainer.formatting[1];
+		const formattingElementBold = element.textContainer.formatting[ 0 ];
+		const formattingElementScript = element.textContainer.formatting[ 1 ];
 
 		expect( formattingElementBold.type ).toEqual( "b" );
 		expect( formattingElementBold.textStartIndex ).toEqual( 10 );
@@ -145,20 +157,58 @@ describe( "calculateTextIndices", () => {
 		expect( formattingElementScript.textStartIndex ).toEqual( 10 );
 		expect( formattingElementScript.textEndIndex ).toEqual( 10 );
 	} );
+
+	it( "correctly processes comments", () => {
+		const source = "<p>This is a <!--Here is a comment!-->paragraph</p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+
+		// Define the paragraph element that we will use in this test.
+		const element = tree.children[ 0 ];
+
+		calculateTextIndices( element, source );
+
+		const formattingElement = element.textContainer.formatting[ 0 ];
+
+		expect( formattingElement.type ).toEqual( "Ignored" );
+		expect( formattingElement.textStartIndex ).toEqual( 10 );
+		expect( formattingElement.textEndIndex ).toEqual( 10 );
+	} );
+
+	it( "correctly processes self-closing elements", () => {
+		const source = "<p>This is a <img src=\"example.jpg\" alt=\"An awesome example\">paragraph</p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+
+		// Define the paragraph element that we will use in this test.
+		const element = tree.children[ 0 ];
+
+		calculateTextIndices( element, source );
+
+		const formattingElement = element.textContainer.formatting[ 0 ];
+
+		expect( formattingElement.type ).toEqual( "img" );
+		expect( formattingElement.textStartIndex ).toEqual( 10 );
+		expect( formattingElement.textEndIndex ).toEqual( 10 );
+	} );
 } );
 
 describe.skip( "These tests are currently broken, will be fixed in https://github.com/Yoast/javascript/issues/409", () => {
-	it( "correctly processes comments", () => {
+	it( "correctly processes comments before another tag", () => {
 		const source = "<p>This is a <!--Here is a comment!--><b>paragraph</b></p>";
 
 		const treeAdapter = new TreeAdapter();
 		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
-		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		// Define the paragraph element that we will use in this test.
+		const element = tree.children[ 0 ];
 
 		calculateTextIndices( element, source );
 
-		const formattingElementComment = element.textContainer.formatting[0];
-		const formattingElementBold = element.textContainer.formatting[1];
+		const formattingElementComment = element.textContainer.formatting[ 0 ];
+		const formattingElementBold = element.textContainer.formatting[ 1 ];
 
 
 		expect( formattingElementComment.type ).toEqual( "Ignored" );
@@ -175,12 +225,14 @@ describe.skip( "These tests are currently broken, will be fixed in https://githu
 
 		const treeAdapter = new TreeAdapter();
 		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
-		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		// Define the paragraph element that we will use in this test.
+		const element = tree.children[ 0 ];
 
 		calculateTextIndices( element, source );
 
-		const formattingElementComment = element.textContainer.formatting[0];
-		const formattingElementBold = element.textContainer.formatting[1];
+		const formattingElementComment = element.textContainer.formatting[ 0 ];
+		const formattingElementBold = element.textContainer.formatting[ 1 ];
 
 
 		expect( formattingElementComment.type ).toEqual( "Ignored" );
@@ -197,14 +249,16 @@ describe.skip( "These tests are currently broken, will be fixed in https://githu
 
 		const treeAdapter = new TreeAdapter();
 		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
-		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		// Define the paragraph element that we will use in this test.
+		const element = tree.children[ 0 ];
 
 		calculateTextIndices( element, source );
 
-		const formattingElementFirstComment = element.textContainer.formatting[0];
-		const formattingElementBold = element.textContainer.formatting[1];
-		const formattingElementSecondComment = element.textContainer.formatting[2];
-		const formattingElementItalics = element.textContainer.formatting[3];
+		const formattingElementFirstComment = element.textContainer.formatting[ 0 ];
+		const formattingElementBold = element.textContainer.formatting[ 1 ];
+		const formattingElementSecondComment = element.textContainer.formatting[ 2 ];
+		const formattingElementItalics = element.textContainer.formatting[ 3 ];
 
 		expect( formattingElementFirstComment.type ).toEqual( "Ignored" );
 		expect( formattingElementFirstComment.textStartIndex ).toEqual( 10 );

--- a/packages/yoastseo/spec/parsedPaper/build/tree/cleanup/calculateTextIndicesSpec.js
+++ b/packages/yoastseo/spec/parsedPaper/build/tree/cleanup/calculateTextIndicesSpec.js
@@ -1,0 +1,225 @@
+import TreeAdapter from "../../../../../src/parsedPaper/build/tree/html/TreeAdapter";
+import calculateTextIndices from "../../../../../src/parsedPaper/build/tree/cleanup/calculateTextIndices";
+import { parseFragment } from "parse5";
+
+describe( "calculateTextIndices", () => {
+	it( "does nothing if the input node has no formatting", () => {
+		const source = "<p>This is a paragraph</p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+		const element = tree.children[ 0 ];
+
+		calculateTextIndices( element, source );
+
+		expect( element.textContainer.formatting ).toEqual( [] );
+	} );
+
+	it( "adds textStartIndex and textEndIndex to the formatting of a paragraph", () => {
+		const source = "<p>This is a <b>paragraph</b></p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+		const element = tree.children[ 0 ]; // Define the paragraph element that we will use in this test.
+
+		calculateTextIndices( element, source );
+
+		const formattingElement = element.textContainer.formatting[0];
+
+		expect( formattingElement.type ).toEqual( "b" );
+		expect( formattingElement.textStartIndex ).toEqual( 10 );
+		expect( formattingElement.textEndIndex ).toEqual( 19 );
+	} );
+
+	it( "correctly processes nested formatting elements", () => {
+		const source = "<p>This is a <b><em>paragraph</em></b></p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		calculateTextIndices( element, source );
+
+		const formattingElementBold = element.textContainer.formatting[0];
+		const formattingElementItalics = element.textContainer.formatting[1];
+
+		expect( formattingElementBold.type ).toEqual( "b" );
+		expect( formattingElementBold.textStartIndex ).toEqual( 10 );
+		expect( formattingElementBold.textEndIndex ).toEqual( 19 );
+
+		expect( formattingElementItalics.type ).toEqual( "em" );
+		expect( formattingElementItalics.textStartIndex ).toEqual( 10 );
+		expect( formattingElementItalics.textEndIndex ).toEqual( 19 );
+	} );
+
+	it( "does not get confused by empty formatting elements", () => {
+		const source = "<p>This is a <em></em><b><em>paragraph</em></b></p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		calculateTextIndices( element, source );
+
+		const formattingElementItalicsEmpty = element.textContainer.formatting[0];
+		const formattingElementBold = element.textContainer.formatting[1];
+		const formattingElementItalicsMeaningful = element.textContainer.formatting[2];
+
+		expect( formattingElementItalicsEmpty.type ).toEqual( "em" );
+		expect( formattingElementItalicsEmpty.textStartIndex ).toEqual( 10 );
+		expect( formattingElementItalicsEmpty.textEndIndex ).toEqual( 10 );
+
+		expect( formattingElementBold.type ).toEqual( "b" );
+		expect( formattingElementBold.textStartIndex ).toEqual( 10 );
+		expect( formattingElementBold.textEndIndex ).toEqual( 19 );
+
+		expect( formattingElementItalicsMeaningful.type ).toEqual( "em" );
+		expect( formattingElementItalicsMeaningful.textStartIndex ).toEqual( 10 );
+		expect( formattingElementItalicsMeaningful.textEndIndex ).toEqual( 19 );
+	} );
+
+	it( "does not get confused by empty nested formatting elements", () => {
+		const source = "<p>This is a <b><em></em><em>paragraph</em></b></p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		calculateTextIndices( element, source );
+
+		const formattingElementBold = element.textContainer.formatting[0];
+		const formattingElementItalicsEmpty = element.textContainer.formatting[1];
+		const formattingElementItalicsNonEmpty = element.textContainer.formatting[2];
+
+		expect( formattingElementBold.type ).toEqual( "b" );
+		expect( formattingElementBold.textStartIndex ).toEqual( 10 );
+		expect( formattingElementBold.textEndIndex ).toEqual( 19 );
+
+		expect( formattingElementItalicsEmpty.type ).toEqual( "em" );
+		expect( formattingElementItalicsEmpty.textStartIndex ).toEqual( 10 );
+		expect( formattingElementItalicsEmpty.textEndIndex ).toEqual( 10 );
+
+		expect( formattingElementItalicsNonEmpty.type ).toEqual( "em" );
+		expect( formattingElementItalicsNonEmpty.textStartIndex ).toEqual( 10 );
+		expect( formattingElementItalicsNonEmpty.textEndIndex ).toEqual( 19 );
+	} );
+
+	it( "correctly processes ignored formatting elements", () => {
+		const source = "<p>This is a <script>script</script><b>paragraph</b></p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		calculateTextIndices( element, source );
+
+		const formattingElementScript = element.textContainer.formatting[0];
+		const formattingElementBold = element.textContainer.formatting[1];
+
+		expect( formattingElementScript.type ).toEqual( "Ignored" );
+		expect( formattingElementScript.textStartIndex ).toEqual( 10 );
+		expect( formattingElementScript.textEndIndex ).toEqual( 10 );
+
+		expect( formattingElementBold.type ).toEqual( "b" );
+		expect( formattingElementBold.textStartIndex ).toEqual( 10 );
+		expect( formattingElementBold.textEndIndex ).toEqual( 19 );
+	} );
+
+	it( "correctly processes ignored formatting elements nested in other formatting elements", () => {
+		const source = "<p>This is a <b><script>script</script>paragraph</b></p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		calculateTextIndices( element, source );
+
+		const formattingElementBold = element.textContainer.formatting[0];
+		const formattingElementScript = element.textContainer.formatting[1];
+
+		expect( formattingElementBold.type ).toEqual( "b" );
+		expect( formattingElementBold.textStartIndex ).toEqual( 10 );
+		expect( formattingElementBold.textEndIndex ).toEqual( 19 );
+
+		expect( formattingElementScript.type ).toEqual( "Ignored" );
+		expect( formattingElementScript.textStartIndex ).toEqual( 10 );
+		expect( formattingElementScript.textEndIndex ).toEqual( 10 );
+	} );
+} );
+
+describe.skip( "These tests are currently broken, will be fixed in https://github.com/Yoast/javascript/issues/409", () => {
+	it( "correctly processes comments", () => {
+		const source = "<p>This is a <!--Here is a comment!--><b>paragraph</b></p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		calculateTextIndices( element, source );
+
+		const formattingElementComment = element.textContainer.formatting[0];
+		const formattingElementBold = element.textContainer.formatting[1];
+
+
+		expect( formattingElementComment.type ).toEqual( "Ignored" );
+		expect( formattingElementComment.textStartIndex ).toEqual( 10 );
+		expect( formattingElementComment.textEndIndex ).toEqual( 10 );
+
+		expect( formattingElementBold.type ).toEqual( "b" );
+		expect( formattingElementBold.textStartIndex ).toEqual( 10 );
+		expect( formattingElementBold.textEndIndex ).toEqual( 19 );
+	} );
+
+	it( "correctly processes comments when embedded in other formatting elements", () => {
+		const source = "<p>This is a <b><!--Here is a comment!-->paragraph</b></p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		calculateTextIndices( element, source );
+
+		const formattingElementComment = element.textContainer.formatting[0];
+		const formattingElementBold = element.textContainer.formatting[1];
+
+
+		expect( formattingElementComment.type ).toEqual( "Ignored" );
+		expect( formattingElementComment.textStartIndex ).toEqual( 10 );
+		expect( formattingElementComment.textEndIndex ).toEqual( 10 );
+
+		expect( formattingElementBold.type ).toEqual( "b" );
+		expect( formattingElementBold.textStartIndex ).toEqual( 10 );
+		expect( formattingElementBold.textEndIndex ).toEqual( 19 );
+	} );
+
+	it( "correctly processes multiple comments", () => {
+		const source = "<p>This is a <!--Here is a comment!--><b>paragraph</b><!--Here is another comment!--> with <em>some text</em>.</p>";
+
+		const treeAdapter = new TreeAdapter();
+		const tree = parseFragment( source, { treeAdapter: treeAdapter, sourceCodeLocationInfo: true } );
+		const element = tree.children[ 0 ];  // Define the paragraph element that we will use in this test.
+
+		calculateTextIndices( element, source );
+
+		const formattingElementFirstComment = element.textContainer.formatting[0];
+		const formattingElementBold = element.textContainer.formatting[1];
+		const formattingElementSecondComment = element.textContainer.formatting[2];
+		const formattingElementItalics = element.textContainer.formatting[3];
+
+		expect( formattingElementFirstComment.type ).toEqual( "Ignored" );
+		expect( formattingElementFirstComment.textStartIndex ).toEqual( 10 );
+		expect( formattingElementFirstComment.textEndIndex ).toEqual( 10 );
+
+		expect( formattingElementBold.type ).toEqual( "b" );
+		expect( formattingElementBold.textStartIndex ).toEqual( 10 );
+		expect( formattingElementBold.textEndIndex ).toEqual( 19 );
+
+		expect( formattingElementSecondComment.type ).toEqual( "Ignored" );
+		expect( formattingElementSecondComment.textStartIndex ).toEqual( 19 );
+		expect( formattingElementSecondComment.textEndIndex ).toEqual( 19 );
+
+		expect( formattingElementItalics.type ).toEqual( "em" );
+		expect( formattingElementItalics.textStartIndex ).toEqual( 25 );
+		expect( formattingElementItalics.textEndIndex ).toEqual( 33 );
+	} );
+} );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Refactors the clean-up function that assigns textStart and textEnd indices to formatting elements.
* Adds specs for the calcuateTextIndices function.

## Relevant technical choices:

* I found a number of use-cases related to comment processing that don't work now. I made a special issue for those https://github.com/Yoast/javascript/issues/409.
* These use-cases already received a spec, but those reside now under a `describe.skip` to make sure builds pass. When the comment issue is fixed, the tests can obviously move to the regular `describe`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use the development tool to confirm that refactoring did not result in a different tree structure
* Check that the tests pass.
* Check the coverage of the `calculateTextIndices` function.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #195 
