### PR TITLE
Update changelog introduction to prevent empty entries

### DIFF
--- a/packages/analysis-report/CHANGELOG.MD
+++ b/packages/analysis-report/CHANGELOG.MD
@@ -2,11 +2,8 @@
 
 This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. Releases without a changelog entry contain only minor changes that are irrelevant for users of this library.
 We follow [Semantic Versioning](http://semver.org/).
-
-## 0.8.0 October 14th, 2019
-* No user-facing changes.
 
 ## 0.4.0 June 11th, 2019
 ### Changed

--- a/packages/browserslist-config/CHANGELOG.md
+++ b/packages/browserslist-config/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. Releases without a changelog entry contain only minor changes that are irrelevant for users of this library.
 We follow [Semantic Versioning](http://semver.org/).
 
 ## 1.0.0

--- a/packages/components/CHANGELOG.MD
+++ b/packages/components/CHANGELOG.MD
@@ -2,7 +2,7 @@
 
 This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. Releases without a changelog entry contain only minor changes that are irrelevant for users of this library.
 We follow [Semantic Versioning](http://semver.org/).
 
 

--- a/packages/configuration-wizard/CHANGELOG.md
+++ b/packages/configuration-wizard/CHANGELOG.md
@@ -2,11 +2,8 @@
 
 This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. Releases without a changelog entry contain only minor changes that are irrelevant for users of this library.
 We follow [Semantic Versioning](http://semver.org/).
-
-## 1.7.0 October 14th, 2019
-* No user-facing changes.
 
 ## 1.1.0 May 14th, 2019
 ### Added

--- a/packages/feature-flag/CHANGELOG.md
+++ b/packages/feature-flag/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. Releases without a changelog entry contain only minor changes that are irrelevant for users of this library.
 We follow [Semantic Versioning](http://semver.org/).
 
 

--- a/packages/helpers/CHANGELOG.md
+++ b/packages/helpers/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. Releases without a changelog entry contain only minor changes that are irrelevant for users of this library.
 We follow [Semantic Versioning](http://semver.org/).
 
 ## 0.3.0 May 27th, 2019

--- a/packages/search-metadata-previews/CHANGELOG.md
+++ b/packages/search-metadata-previews/CHANGELOG.md
@@ -2,11 +2,8 @@
 
 This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. Releases without a changelog entry contain only minor changes that are irrelevant for users of this library.
 We follow [Semantic Versioning](http://semver.org/).
-
-## 1.13.1 November 25th, 2019
-* No user-facing changes.
 
 ## 1.13.0 November 25th, 2019
 ### Fixes
@@ -20,44 +17,15 @@ We follow [Semantic Versioning](http://semver.org/).
 ### Enhancements:
  * Increases the specificity of the width and height CSS of the `MobileDescriptionImage`.
 
-## 1.10.1 October 14th, 2019
-* No user-facing changes.
-
-## 1.10.0 October 14th, 2019
-* No user-facing changes.
-
-## 1.9.0 September 30th, 2019
-* No user-facing changes.
-
 ## 1.8.0 September 17th, 2019
 ### Enhancements
 
 * Changes desktop snippet preview to match Google's new font sizes. [#345](https://github.com/Yoast/javascript/pull/345)
 
-## 1.6.0 July 22nd, 2019
-
-* No user-facing changes.
-
-## 1.5.0 July 8th, 2019
-
-* No user-facing changes.
-
 ## 1.4.0 June 24th, 2019
 ### Changed
 
 * Updates the Google Mobile Snippet Preview.
-
-## 1.3.0 June 11th, 2019
-
-* No user-facing changes.
-
-## 1.2.0 May 27th, 2019
-
-* No user-facing changes.
-
-## 1.1.0 May 14th, 2019
-
-* No user-facing changes.
 
 ## 1.0.0 April 29th, 2019
 

--- a/packages/style-guide/CHANGELOG.md
+++ b/packages/style-guide/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. Releases without a changelog entry contain only minor changes that are irrelevant for users of this library.
 We follow [Semantic Versioning](http://semver.org/).
 
 ## 0.5.0 September 30th, 2019
 ### Added
 * Adds new status colors: error, info, success, warning.
-
-## 0.4.0 September 17th, 2019
-* No user-facing changes.
 
 ## 0.2.0 May 14th, 2019
 ### Fixed

--- a/packages/yoast-components/CHANGELOG.MD
+++ b/packages/yoast-components/CHANGELOG.MD
@@ -2,31 +2,18 @@
 
 This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. Releases without a changelog entry contain only minor changes that are irrelevant for users of this library.
+
 We follow [Semantic Versioning](http://semver.org/).
+
 
 ## 4.36.0 November 11th, 2019
 ### Enhancements
 * Improves the `KeywordInput` and `SynonymsInput` styling for consistency with the new WordPress 5.3 admin styles.
 
-## 4.35.0 October 28th, 2019
-No user-facing changes.
-
-## 4.34.1 October 14th, 2019
-No user-facing changes.
-
 ## 4.34.0 October 14th, 2019
 ### Fixed
 * Fixes a bug where internal linking suggestions were not aligned correctly, but were indented instead.
-
-## 4.33.0 September 30th, 2019
-No user-facing changes.
-
-## 4.32.0 September 16th, 2019
-No user-facing changes.
-
-## 4.31.0 September 2nd, 2019
-No user-facing changes.
 
 ## 4.30.0 July 22nd, 2019
 ### Added

--- a/packages/yoast-social-previews/CHANGELOG.md
+++ b/packages/yoast-social-previews/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. Releases without a changelog entry contain only minor changes that are irrelevant for users of this library.
 We follow [Semantic Versioning](http://semver.org/).
 
 ## 1.4.9: June 24th, 2019

--- a/packages/yoastseo/CHANGELOG.md
+++ b/packages/yoastseo/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This changelog is according to [Keep a Changelog](http://keepachangelog.com).
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. Releases without a changelog entry contain only minor changes that are irrelevant for users of this library.
 We will follow [Semantic Versioning](http://semver.org/) from version 2 and onwards.
 
 ## 1.63.0 November 13th, 2019


### PR DESCRIPTION
## Relevant technical choices:

* To speed up the release process, we'd like to not document every version bump release. To that end, we added a catch-all phrase at the top of each changelog
