### PR TITLE
Add window.location.origin as second argument to the URL constructor

### DIFF
--- a/packages/yoastseo/src/worker/createWorker.js
+++ b/packages/yoastseo/src/worker/createWorker.js
@@ -37,8 +37,8 @@ function createBlobScript( url ) {
  * @returns {boolean} Whether the URLs have the same origin.
  */
 function isSameOrigin( urlA, urlB ) {
-	urlA = new URL( urlA );
-	urlB = new URL( urlB );
+	urlA = new URL( urlA, window.location.origin );
+	urlB = new URL( urlB, window.location.origin );
 
 	return urlA.hostname === urlB.hostname &&
 		urlA.port === urlB.port &&


### PR DESCRIPTION
This will add support to relative as well as absolute URLs.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Fixes a bug where the metabox would be broken when a relative URL was configured as `WP_CONTENT_URL`. Props to [FPCSJames](https://github.com/FPCSJames).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### To reproduce
* Run/activate the Yoast SEO's current release.
* Add `define('WP_CONTENT_URL', '/wp-content');` to for example `wp-config.php`.
* Go to a post.
* It is expected that you get the following error in the console: `createWorker.js?a02a:41 Uncaught TypeError: Failed to construct 'URL': Invalid URL`

### Test PR
* Switch to this branch.
* Verify the error is no longer there.
* Test the analysis results (SEO & Readability). Basically it is already working because of no error, but if you can get a point to change it definitely communicated correctly.
* Remove the `define('WP_CONTENT_URL', '/wp-content');` you entered in the reproduce steps.
* Verify the error is still not there.
* Test the analysis results again.
* Add `define('WP_CONTENT_URL', 'http://local.wordpress.test/wp-content');` to for example `wp-config.php`. If your test site URL is different, please adjust it accordingly. The point is to test an absolute URL override.
* Verify the error is still not there.
* Test the analysis results again.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #418 
