### PR TITLE
Change tree builer error output to the logger instead of the console

### DIFF
--- a/packages/yoastseo/src/worker/AnalysisWebWorker.js
+++ b/packages/yoastseo/src/worker/AnalysisWebWorker.js
@@ -783,7 +783,7 @@ export default class AnalysisWebWorker {
 			try {
 				this._tree = this._treeBuilder.build( text );
 			} catch ( exception ) {
-				console.error( "Yoast SEO and readability analysis: " +
+				logger.debug( "Yoast SEO and readability analysis: " +
 					"An error occurred during the building of the tree structure used for some assessments.\n\n", exception );
 				this._tree = null;
 			}


### PR DESCRIPTION
This should be a temporary move until we release the tree builder properly, so that users don't get errors about something that is not really in use yet.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Changes the tree builder error to output via the logger instead of the console.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Not really testable without changing code.
* Add a line in `src/worker/AnalysisWebWorker.js` after the `_treeBuilder.build`: `throw "test error!";`.
* Link to either free or premium.
* Build the code.
* Go to an edit post or page.
* Verify you have no console error.
* Enable the debug flags by adding the following to your `wp-config.php` file:
```
define( 'YOAST_SEO_DEBUG', true );
define( 'YOAST_SEO_DEBUG_ANALYSIS_WORKER', 'TRACE' );
```
* Reload the edit post/page.
* Verify you get the error in the console.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #437 
