### PR TITLE
Fix grunt get-premium-configuration switching

### DIFF
--- a/packages/yoastseo/grunt/config/shell.js
+++ b/packages/yoastseo/grunt/config/shell.js
@@ -23,22 +23,12 @@ module.exports = function( grunt ) {
 	}
 
 	/**
-	 * Gets the bash command to get the current branch of the premium-configuration directory.
+	 * Gets the bash command to get the current branch of the repository.
 	 *
-	 * @returns {string} The bash command to get the current branch of the premium-configuration directory.
+	 * @returns {string} The bash command to get the current branch of the repository.
 	 */
 	function getCurrentBranchCommand() {
-		const commands = [];
-
-		if ( grunt.file.exists( "premium-configuration" ) ) {
-			commands.push( "cd premium-configuration" );
-			commands.push( "git branch | grep \\* | cut -d ' ' -f2" );
-			commands.push( "cd .." );
-		} else {
-			commands.push( "git branch | grep \\* | cut -d ' ' -f2" );
-		}
-
-		return commands.join( "&&" );
+		return "git branch | grep \\* | cut -d ' ' -f2";
 	}
 
 	/**


### PR DESCRIPTION

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Fixes `grunt get-premium-configuration` switching to the same branch again

## Relevant technical choices:

* Now tries to switch to the branch of the monorepo instead of the same branch again

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Switch to the develop branch: `git checkout develop`.
* Go to the yoastseo package: `cd packages/yoastseo`.
* Run `grunt get-premium-configuration`. This should clone (if not already done) the premium configuration and switch it to the develop branch.
* Switch to this branch: `git checkout fix-grunt-get-premium-configuration`.
* Run `grunt get-premium-configuration`
* You should get the output: `error: pathspec 'fix-grunt-get-premium-configuration' did not match any file(s) known to git`.
* This means that it did try to switch to the same branch on the `premium-configuration` as you are on on the `monorepo`.

You could create the same branch on the premium configuration and check if it actually switches correctly. But I think this is overkill.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
