### PR TITLE
Add data for Dutch stemmer noun diminutive and plural exception

### DIFF
--- a/packages/yoastseo/spec/morphology/dutch/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/stemSpec.js
@@ -106,7 +106,30 @@ const wordsToStem = [
 	// An adjective with the comparative partitive suffix -ers.
 	[ "ronders", "rond" ],
 	// An adjective with stem ending in -rd.
-	[ "absurder", "absurd" ] ];
+	[ "absurder", "absurd" ],
+	// A noun with diminutive suffix -je.
+	[ "plaatje", "plaat" ],
+	// A noun with diminutive suffix -je.
+	[ "momentje", "moment" ],
+	// A noun with diminutive suffix -tje.
+	[ "citroentje", "citroen" ],
+	// A noun with diminutive suffix -tje.
+	[ "actietje", "actie" ],
+	// A noun with diminutive suffix -je. Input: exception list.
+	[ "patiëntje", "patiënt" ],
+	// A noun with diminutive suffix -tje. Input: exception list.
+	[ "aspergetje", "asperge" ],
+	// A noun with diminutive suffix -etje. Input: exception list.
+	[ "taxietje", "taxi" ],
+	// A noun with diminutive suffix -tje in which undergoes vowel doubling before adding the suffix -tje. Input: exception list.
+	[ "dynamootje", "dynamo" ],
+	// A noun with plural suffix -en. Input: exception list.
+	[ "residuen", "residu" ],
+	// A noun with plural suffix -eren. Input: exception list.
+	[ "volkeren", "volk" ],
+	// A noun with plural suffix -s. Input: exception list.
+	[ "zoos", "zoo" ],
+];
 
 // These words should not be stemmed (same form should be returned).
 

--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -10,6 +10,7 @@
  */
 
 import { flatten } from "lodash-es";
+import { removeSuffixFromFullForm } from "../morphoHelpers/stemHelpers";
 
 /**
  * Checks whether the word ends with what looks like a suffix but is actually part of the stem, and therefore should not be stemmed.
@@ -241,62 +242,20 @@ const stemAdjectiveEndingInRd = function( word, adjectivesEndingInRd ) {
 };
 
 /**
- * Checks whether the word is in the exception list of nouns with specific diminutive or plural suffix that needs to be stemmed.
- * e.g. agentje -> agent, kinderen -> kind. If it is, stem it.
- *
- * @param {Object} exceptionList The exception list.
- * @param {string} suffixToDelete The suffix that needs to be deleted.
- * @param {string} word The word to check.
- *
- * @returns {string} The stemmed word,
- */
-const checkExceptionPluralAndDiminutive = function( exceptionList, suffixToDelete, word ) {
-	for ( let i = 0; i < exceptionList.length; i++ ) {
-		if ( word.endsWith( exceptionList[ i ] ) ) {
-			return word.slice( 0, -suffixToDelete.length );
-		}
-	}
-};
-
-/**
  * Get the stem from noun diminutives and plurals exceptions.
  *
- * @param {Object} morphologyDataNLStemmingExceptions The data for stemming exception.
- * @param {string} word The word to check.
+ * @param {Object[]}    exceptionsRemoveSuffixFromFullForms The data for stemming exception.
+ * @param {string}      word                                The word to check.
+ *
  * @returns {string} The stemmed word.
  */
-const getStemExceptionPluralAndDiminutive = function( morphologyDataNLStemmingExceptions, word ) {
-	const diminutiveSuffixes = morphologyDataNLStemmingExceptions.diminutiveSuffixes;
-	const pluralSuffixes = morphologyDataNLStemmingExceptions.pluralSuffixesEndAndS;
-	const diminutiveExceptionLists = [ morphologyDataNLStemmingExceptions.diminutiveExceptions.diminutiveStemEtje,
-		morphologyDataNLStemmingExceptions.diminutiveExceptions.stemSuffixTje,
-		morphologyDataNLStemmingExceptions.diminutiveExceptions.diminutiveOnlyStemJe ];
-	// Check if the word is in the exception lists of diminutives that receive suffix -etje, -tje, or -je. If it is, and stem it accordingly.
-	for ( let i = 0; i < diminutiveExceptionLists.length; i++ ) {
-		const checkDiminutiveException = checkExceptionPluralAndDiminutive( diminutiveExceptionLists[ i ], diminutiveSuffixes[ i ], word );
-		if ( checkDiminutiveException ) {
-			return checkDiminutiveException;
+const removeSuffixFromFullForms = function( exceptionsRemoveSuffixFromFullForms, word ) {
+	for ( const exceptionClass of exceptionsRemoveSuffixFromFullForms ) {
+		const stemmedWord = removeSuffixFromFullForm( exceptionClass.forms, exceptionClass.suffix, word );
+
+		if ( stemmedWord ) {
+			return stemmedWord;
 		}
-	}
-	// Check if the word is in the exception lists of plurals that receive suffix -eren, -en, or -s. If it is, stem it accordingly.
-	const pluralExceptionLists = [ morphologyDataNLStemmingExceptions.nounStemExceptions.stemEren,
-		morphologyDataNLStemmingExceptions.nounStemExceptions.stemSuffixEn,
-		morphologyDataNLStemmingExceptions.nounStemExceptions.stemSuffixS ];
-	for ( let i = 0; i < pluralExceptionLists.length; i++ ) {
-		const checkPluralException = checkExceptionPluralAndDiminutive( pluralExceptionLists[ i ], pluralSuffixes[ i ], word );
-		if ( checkPluralException ) {
-			return checkPluralException;
-		}
-	}
-	/*
-	 * Check if the word is in the list of diminutives that receive -tje and undergo vowel doubling before attaching the suffix.
-	 * If it is, stem it accordingly.
-	 */
-	if ( checkExceptionPluralAndDiminutive(
-		morphologyDataNLStemmingExceptions.diminutiveExceptions.stemTjeAndOnePrecedingVowel,  diminutiveSuffixes[ 1 ], word ) ) {
-		const correctNounStem = checkExceptionPluralAndDiminutive(
-			morphologyDataNLStemmingExceptions.diminutiveExceptions.stemTjeAndOnePrecedingVowel,  diminutiveSuffixes[ 1 ], word ).slice( 0, -1 );
-		return correctNounStem;
 	}
 };
 
@@ -324,9 +283,25 @@ export default function stem( word, morphologyDataNL ) {
 	/* Checks whether the word is in the exception list of nouns with specific diminutive or plural suffixes that needs to be stemmed.
 	 * If it is return the stem here.
 	 */
-	if ( getStemExceptionPluralAndDiminutive( morphologyDataNL.stemming.stemExceptions, word ) ) {
-		return getStemExceptionPluralAndDiminutive( morphologyDataNL.stemming.stemExceptions, word );
+	const stemFromFullForm = removeSuffixFromFullForms( morphologyDataNL.stemming.stemExceptions.removeSuffixFromFullForms, word );
+	if ( stemFromFullForm ) {
+		return stemFromFullForm;
 	}
+
+	/*
+	 * Checks whether the word is in the exception list of diminutives that need to be stemmed and that additionally need
+	 * to have the final vowel removed. If it is return the stem here.
+	 */
+	const stemFromFullFormAndDeleteFinalVowel = removeSuffixFromFullForm(
+		morphologyDataNL.stemming.stemExceptions.stemTjeAndOnePrecedingVowel.forms,
+		morphologyDataNL.stemming.stemExceptions.stemTjeAndOnePrecedingVowel.suffix,
+		word
+	);
+
+	if ( stemFromFullFormAndDeleteFinalVowel ) {
+		return stemFromFullFormAndDeleteFinalVowel.slice( 0, -1 );
+	}
+
 	/*
 	 * Put i and y in between vowels, initial y, and y after a vowel into upper case. This is because they should
 	 * be treated as consonants so we want to differentiate them from other i's and y's when matching regexes.

--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -9,14 +9,17 @@
  * Redistribution and use in source and binary forms, with or without modification, is covered by the standard BSD license.
  */
 
+import { flatten } from "lodash-es";
+
 /**
  * Checks whether the word ends with what looks like a suffix but is actually part of the stem, and therefore should not be stemmed.
  *
  * @param {string} word The word to check.
- * @param {string[]} wordsNotToStem The exception list of words that should not be stemmed.
+ * @param {Object} dataWordsNotToStem The exception list of words that should not be stemmed.
  * @returns {boolean} Whether or not the word should be stemmed.
  */
-const shouldNotBeStemmed = function( word, wordsNotToStem ) {
+const shouldNotBeStemmed = function( word, dataWordsNotToStem ) {
+	const wordsNotToStem = flatten( Object.values( dataWordsNotToStem ) );
 	return ( wordsNotToStem.includes( word ) );
 };
 
@@ -42,7 +45,6 @@ const determineR1 = function( word ) {
 
 	return r1Index;
 };
-
 
 /**
  * Searches for suffixes in a word.
@@ -239,6 +241,66 @@ const stemAdjectiveEndingInRd = function( word, adjectivesEndingInRd ) {
 };
 
 /**
+ * Checks whether the word is in the exception list of nouns with specific diminutive or plural suffix that needs to be stemmed.
+ * e.g. agentje -> agent, kinderen -> kind. If it is, stem it.
+ *
+ * @param {Object} exceptionList The exception list.
+ * @param {string} suffixToDelete The suffix that needs to be deleted.
+ * @param {string} word The word to check.
+ *
+ * @returns {string} The stemmed word,
+ */
+const checkExceptionPluralAndDiminutive = function( exceptionList, suffixToDelete, word ) {
+	for ( let i = 0; i < exceptionList.length; i++ ) {
+		if ( word.endsWith( exceptionList[ i ] ) ) {
+			return word.slice( 0, -suffixToDelete.length );
+		}
+	}
+};
+
+/**
+ * Get the stem from noun diminutives and plurals exceptions.
+ *
+ * @param {Object} morphologyDataNLStemmingExceptions The data for stemming exception.
+ * @param {string} word The word to check.
+ * @returns {string} The stemmed word.
+ */
+const getStemExceptionPluralAndDiminutive = function( morphologyDataNLStemmingExceptions, word ) {
+	const diminutiveSuffixes = morphologyDataNLStemmingExceptions.diminutiveSuffixes;
+	const pluralSuffixes = morphologyDataNLStemmingExceptions.pluralSuffixesEndAndS;
+	const diminutiveExceptionLists = [ morphologyDataNLStemmingExceptions.diminutiveExceptions.diminutiveStemEtje,
+		morphologyDataNLStemmingExceptions.diminutiveExceptions.stemSuffixTje,
+		morphologyDataNLStemmingExceptions.diminutiveExceptions.diminutiveOnlyStemJe ];
+	// Check if the word is in the exception lists of diminutives that receive suffix -etje, -tje, or -je. If it is, and stem it accordingly.
+	for ( let i = 0; i < diminutiveExceptionLists.length; i++ ) {
+		const checkDiminutiveException = checkExceptionPluralAndDiminutive( diminutiveExceptionLists[ i ], diminutiveSuffixes[ i ], word );
+		if ( checkDiminutiveException ) {
+			return checkDiminutiveException;
+		}
+	}
+	// Check if the word is in the exception lists of plurals that receive suffix -eren, -en, or -s. If it is, stem it accordingly.
+	const pluralExceptionLists = [ morphologyDataNLStemmingExceptions.nounStemExceptions.stemEren,
+		morphologyDataNLStemmingExceptions.nounStemExceptions.stemSuffixEn,
+		morphologyDataNLStemmingExceptions.nounStemExceptions.stemSuffixS ];
+	for ( let i = 0; i < pluralExceptionLists.length; i++ ) {
+		const checkPluralException = checkExceptionPluralAndDiminutive( pluralExceptionLists[ i ], pluralSuffixes[ i ], word );
+		if ( checkPluralException ) {
+			return checkPluralException;
+		}
+	}
+	/*
+	 * Check if the word is in the list of diminutives that receive -tje and undergo vowel doubling before attaching the suffix.
+	 * If it is, stem it accordingly.
+	 */
+	if ( checkExceptionPluralAndDiminutive(
+		morphologyDataNLStemmingExceptions.diminutiveExceptions.stemTjeAndOnePrecedingVowel,  diminutiveSuffixes[ 1 ], word ) ) {
+		const correctNounStem = checkExceptionPluralAndDiminutive(
+			morphologyDataNLStemmingExceptions.diminutiveExceptions.stemTjeAndOnePrecedingVowel,  diminutiveSuffixes[ 1 ], word ).slice( 0, -1 );
+		return correctNounStem;
+	}
+};
+
+/**
  * Stems Dutch words.
  *
  * @param {string} word  The word to stem.
@@ -251,7 +313,7 @@ export default function stem( word, morphologyDataNL ) {
 	if ( shouldNotBeStemmed( word, morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions ) ) {
 		return word;
 	}
-	/**
+	/*
 	 * Check whether the word is on an exception list of adjectives with stem ending in -rd. If it is, stem and
 	 * return the word here, instead of going through the regular stemmer.
  	 */
@@ -259,7 +321,13 @@ export default function stem( word, morphologyDataNL ) {
 	if ( wordAfterRdExceptionCheck !== word ) {
 		return wordAfterRdExceptionCheck;
 	}
-	/**
+	/* Checks whether the word is in the exception list of nouns with specific diminutive or plural suffixes that needs to be stemmed.
+	 * If it is return the stem here.
+	 */
+	if ( getStemExceptionPluralAndDiminutive( morphologyDataNL.stemming.stemExceptions, word ) ) {
+		return getStemExceptionPluralAndDiminutive( morphologyDataNL.stemming.stemExceptions, word );
+	}
+	/*
 	 * Put i and y in between vowels, initial y, and y after a vowel into upper case. This is because they should
 	 * be treated as consonants so we want to differentiate them from other i's and y's when matching regexes.
 	 */

--- a/packages/yoastseo/src/morphology/morphoHelpers/stemHelpers.js
+++ b/packages/yoastseo/src/morphology/morphoHelpers/stemHelpers.js
@@ -1,0 +1,20 @@
+/**
+ * Checks whether the word is in a given list of exceptions and if so, deletes a given suffix.
+ *
+ * @param {string[]}    exceptions  The exception list.
+ * @param {string}      suffix      The suffix that needs to be deleted.
+ * @param {string}      word        The word to check.
+ *
+ * @returns {string} The stemmed word.
+ */
+const removeSuffixFromFullForm = function( exceptions, suffix, word ) {
+	for ( let i = 0; i < exceptions.length; i++ ) {
+		if ( word.endsWith( exceptions[ i ] ) ) {
+			return word.slice( 0, -suffix.length );
+		}
+	}
+};
+
+export {
+	removeSuffixFromFullForm,
+};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* It improves the Dutch stemmer by adding more detailed rules for stemming diminutives and adds checks for exceptions to these rules and noun plural exception as well.

## Test instructions

This PR can be tested by following these steps:

* Add more tests to the specs by specifying the forms of the noun (plural or diminutive) and the expected stem form. 
* The noun forms to be tested can also be taken from the exception lists in the data file ( diminutiveOnlyStemJe, stemSuffixTje, stemTjeAndOnePrecedingVowel, diminutiveStemEtje, stemEren, stemSuffixS and stemSuffixEn)


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #448
