### PR TITLE
LIN-152 Disable everything tree-related in the web worker and distribution

### DIFF
--- a/packages/yoastseo/grunt/config/babel.js
+++ b/packages/yoastseo/grunt/config/babel.js
@@ -3,6 +3,18 @@ module.exports = {
 		files: [ {
 			expand: true,
 			src: "src/**/*.js",
+			/**
+			 * Filters the source files.
+			 *
+			 * @param {string} filePath The path of the current file.
+			 *
+			 * @returns {boolean} Whether to process this file.
+			 */
+			filter: function( filePath ) {
+				const insideParsedPaper = filePath.startsWith( "src/parsedPaper/" );
+				const insideParsedPaperScoreAggregator = filePath.startsWith( "src/parsedPaper/assess/scoreAggregators/" );
+				return ( ! insideParsedPaper ) || insideParsedPaperScoreAggregator;
+			},
 			dest: "dist/",
 		} ],
 		options: {

--- a/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
+++ b/packages/yoastseo/spec/worker/AnalysisWebWorkerSpec.js
@@ -1543,7 +1543,7 @@ describe( "AnalysisWebWorker", () => {
 			worker = new AnalysisWebWorker( scope );
 		} );
 
-		it( "creates an SEO assessor", () => {
+		it.skip( "creates an SEO assessor", () => {
 			const assessor = worker.createSEOTreeAssessor( {} );
 
 			expect( assessor.getAssessments() ).toEqual( [] );
@@ -1576,7 +1576,7 @@ describe( "AnalysisWebWorker", () => {
 			researcher.addResearch( "test research", testResearch );
 		} );
 
-		it( "still runs the assessments that use the old assessor when building the tree fails", done => {
+		it.skip( "still runs the assessments that use the old assessor when building the tree fails", done => {
 			const paper = new Paper( "This is some content." );
 
 			// Add tree assessment.


### PR DESCRIPTION
## DO NO MERGE THIS YET 
Waiting until the remaining issues for the TreeParser in this sprint are merged:
- https://yoast.atlassian.net/browse/LIN-80
- https://yoast.atlassian.net/browse/LIN-128

## Summary

Based the changes on "reverting" changes made in https://github.com/Yoast/javascript/pull/60/files

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Disables everything tree-related in the web worker and distribution.

## Relevant technical choices:

* Made the choice to still use the score aggregators in the `parsedPaper` folder. It gives for an easier PR and changes less logic.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if, from the `parsedPaper`, only the `parsedPaper/assess/scoreAggregators` is left in the `dist` build. Run `grunt publish` to populate the `dist` folder. Don't worry, that command does not do the actual publishing.
* Link this with premium and build it. Then smoke test if you still get proper analysis results.
* You might go one step further and check the difference in the bundle analyzer. Run `BUNDLE_ANALYZER=1 yarn start` on the linked plugin repo. Then search for `parsedPaper` in the `analysis` entry.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-152
