### PR TITLE
Introduce a stemming research

### DIFF
--- a/packages/yoastseo/spec/helpers/filterFunctionWordsFromArraySpec.js
+++ b/packages/yoastseo/spec/helpers/filterFunctionWordsFromArraySpec.js
@@ -1,0 +1,33 @@
+import filterFunctionWordsFromArray from "../../src/helpers/filterFunctionWordsFromArray.js";
+
+describe( "A test for filtering out function words from an array of words for a given language", function() {
+	it( "returns the array of content words for absent locale", function() {
+		const filteredArray = filterFunctionWordsFromArray( [ "I", "am", "going", "for", "a", "walk" ] );
+		expect( filteredArray ).toEqual( [].concat( "walk" ) );
+	} );
+
+	it( "returns the array of content words for an empty language as if it was English", function() {
+		const filteredArray = filterFunctionWordsFromArray( [ "I", "am", "going", "for", "a", "walk" ], "" );
+		expect( filteredArray ).toEqual( [].concat( "walk" ) );
+	} );
+
+	it( "returns the original array of words for a non-existing language", function() {
+		const filteredArray = filterFunctionWordsFromArray( [ "I", "am", "going", "for", "a", "walk" ], "yep" );
+		expect( filteredArray ).toEqual( [ "I", "am", "going", "for", "a", "walk" ] );
+	} );
+
+	it( "returns the array of content words for English", function() {
+		const filteredArray = filterFunctionWordsFromArray( [ "I", "am", "going", "for", "a", "walk" ], "en" );
+		expect( filteredArray ).toEqual( [].concat( "walk" ) );
+	} );
+
+	it( "returns the array of content words for French", function() {
+		const filteredArray = filterFunctionWordsFromArray( [ "Je", "ne", "vais", "pas", "rire" ], "fr" );
+		expect( filteredArray ).toEqual( [].concat( "rire" ) );
+	} );
+
+	it( "returns the array of content words for Spanish", function() {
+		const filteredArray = filterFunctionWordsFromArray( [ "Como", "hacer", "guacamole", "como", "los", "mexicanos" ], "es" );
+		expect( filteredArray ).toEqual( [].concat( "guacamole", "mexicanos" ) );
+	} );
+} );

--- a/packages/yoastseo/spec/researches/buildKeywordFormsSpec.js
+++ b/packages/yoastseo/spec/researches/buildKeywordFormsSpec.js
@@ -1,44 +1,11 @@
 import Paper from "../../src/values/Paper";
 import Researcher from "../../src/researcher";
 
-import { filterFunctionWords, buildForms, collectForms } from "../../src/researches/buildKeywordForms.js";
+import { buildForms, collectForms } from "../../src/researches/buildKeywordForms.js";
 import getMorphologyData from "../specHelpers/getMorphologyData";
-
 
 const morphologyDataEN = getMorphologyData( "en" );
 const morphologyDataDE = getMorphologyData( "de" );
-
-describe( "A test for filtering out function words from an array of words for a given language", function() {
-	it( "returns the array of content words for absent locale", function() {
-		const filteredArray = filterFunctionWords( [ "I", "am", "going", "for", "a", "walk" ] );
-		expect( filteredArray ).toEqual( [].concat( "walk" ) );
-	} );
-
-	it( "returns the array of content words for an empty language as if it was English", function() {
-		const filteredArray = filterFunctionWords( [ "I", "am", "going", "for", "a", "walk" ], "" );
-		expect( filteredArray ).toEqual( [].concat( "walk" ) );
-	} );
-
-	it( "returns the original array of words for a non-existing language", function() {
-		const filteredArray = filterFunctionWords( [ "I", "am", "going", "for", "a", "walk" ], "yep" );
-		expect( filteredArray ).toEqual( [ "I", "am", "going", "for", "a", "walk" ] );
-	} );
-
-	it( "returns the array of content words for English", function() {
-		const filteredArray = filterFunctionWords( [ "I", "am", "going", "for", "a", "walk" ], "en" );
-		expect( filteredArray ).toEqual( [].concat( "walk" ) );
-	} );
-
-	it( "returns the array of content words for French", function() {
-		const filteredArray = filterFunctionWords( [ "Je", "ne", "vais", "pas", "rire" ], "fr" );
-		expect( filteredArray ).toEqual( [].concat( "rire" ) );
-	} );
-
-	it( "returns the array of content words for Spanish", function() {
-		const filteredArray = filterFunctionWords( [ "Como", "hacer", "guacamole", "como", "los", "mexicanos" ], "es" );
-		expect( filteredArray ).toEqual( [].concat( "guacamole", "mexicanos" ) );
-	} );
-} );
 
 const movieForms = [ "movie", "movies", "movie's", "movies's", "movies'", "moviing", "movied", "moviely",
 	"movier", "moviest", "movie‘s", "movie’s", "movie‛s", "movie`s", "movies‘s", "movies’s", "movies‛s",

--- a/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
+++ b/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
@@ -1,0 +1,156 @@
+import { buildStems, collectStems } from "../../src/researches/buildTopicStems.js";
+import getMorphologyData from "../specHelpers/getMorphologyData";
+
+const morphologyDataEN = getMorphologyData( "en" );
+const morphologyDataDE = getMorphologyData( "de" );
+
+describe( "A test for building stems for an array of words", function() {
+	it( "returns an empty array if the input keyphrase is undefined", function() {
+		let keyphrase;
+		const forms = buildStems( keyphrase, "en", morphologyDataEN.en );
+		expect( forms ).toEqual( [] );
+	} );
+
+	it( "returns the exact match if the input string is embedded in quotation marks (the language and morphAnalyzer do not matter)", function() {
+		const forms = buildStems( "\"I am going for a walk\"", "en", morphologyDataEN.en );
+		expect( forms ).toEqual( [ "I am going for a walk" ] );
+	} );
+
+	it( "returns all (content) words if there is no morphological analyzer for this language yet", function() {
+		const forms = buildStems( "Je ne vais pas rire", "fr", false );
+		expect( forms ).toEqual( [ "rire" ] );
+	} );
+
+	it( "returns all (content) words if there is no morphological analyzer for this language yet", function() {
+		const forms = buildStems( "Como hacer guacamole como los mexicanos", "es", false );
+		expect( forms ).toEqual( [ "guacamole", "mexicanos" ] );
+	} );
+
+	it( "returns all (content) words if there is no morphological analyzer for this language yet and takes care of apostrophe variations", function() {
+		expect( buildStems( "слово'слово", "ru", {} ) ).toEqual( [ "слово'слово" ] );
+		expect( buildStems( "слово‘слово", "ru", {} ) ).toEqual( [ "слово'слово" ] );
+		expect( buildStems( "слово‛слово", "ru", {} ) ).toEqual( [ "слово'слово" ] );
+		expect( buildStems( "слово’слово", "ru", {} ) ).toEqual( [ "слово'слово" ] );
+		expect( buildStems( "слово`слово", "ru", {} ) ).toEqual( [ "слово'слово" ] );
+	} );
+
+	it( "returns all content words for English if Free", function() {
+		const forms = buildStems( "I am walking and singing in the rain", "en", false );
+		expect( forms ).toEqual( [ "walking", "singing", "rain" ] );
+	} );
+
+	it( "returns stems of all words for English if Premium if only function words are supplied", function() {
+		const forms = buildStems( "One and two", "en", morphologyDataEN.en );
+		expect( forms ).toEqual( [ "one", "and", "two" ] );
+	} );
+
+	it( "returns stems of all content words for English if Premium", function() {
+		const forms = buildStems( "I am walking and singing in the rain", "en", morphologyDataEN.en );
+		expect( forms ).toEqual( [ "walk", "sing", "rain" ] );
+	} );
+
+	it( "returns stems of all content words for German if Premium", function() {
+		const forms = buildStems( "Schnell und einfach Altbauwohnungen finden.", "de", morphologyDataDE.de );
+		expect( forms ).toEqual( [ "altbauwohnung" ] );
+	} );
+} );
+
+describe( "A test for building keyword and synonyms stems for a paper", function() {
+	it( "returns the exact matches if the input strings are embedded in quotation marks and separate words if not; for empty language", function() {
+		const keyword = "\"I am going for a walk\"";
+		const synonyms = "\"You are not going for a walk\", You are going for a movie, And he is going to work diligently.";
+		let language;
+
+		const expectedResult = {
+			keyphraseStems: [ "I am going for a walk" ],
+			synonymsStems: [
+				[ "You are not going for a walk" ],
+				[ "movie" ],
+				[ "work", "diligent" ],
+			],
+		};
+		expect( collectStems( keyword, synonyms, language, morphologyDataEN.en ) ).toEqual( expectedResult );
+	} );
+
+	it( "returns the exact matches if the input strings are embedded in quotation marks and separate words if not; for English", function() {
+		const keyword = "\"I am going for a walk\"";
+		const synonyms = "\"You are not going for a walk\", You are going for a movie, And he is going to work diligently.";
+		const language = "en";
+
+		const expectedResult = {
+			keyphraseStems: [ "I am going for a walk" ],
+			synonymsStems: [
+				[ "You are not going for a walk" ],
+				[ "movie" ],
+				[ "work", "diligent" ],
+			],
+		};
+		expect( collectStems( keyword, synonyms, language, morphologyDataEN.en ) ).toEqual( expectedResult );
+	} );
+
+	it( "returns the exact matches if the input strings are embedded in quotation marks and separate words if not; for French (no morphology yet)", function() {
+		const keyword = "Je vais me promener";
+		const synonyms = "\"Tu ne vas pas te promener\", Tu vas voir un film, Et lui il va travailler dur.";
+		const language = "fr";
+
+		const expectedResult = {
+			keyphraseStems: [ "promener" ],
+			synonymsStems: [
+				[ "Tu ne vas pas te promener" ],
+				[ "voir", "film" ],
+				[ "travailler", "dur" ],
+			],
+		};
+		expect( collectStems( keyword, synonyms, language, {} ) ).toEqual( expectedResult );
+	} );
+
+	it( "returns the exact matches if the input strings are embedded in quotation marks and separate words if not; for an unexisting language (no morphology and function words)", function() {
+		const keyword = "\"I am going for a walk\"";
+		const synonyms = "\"You are not going for a walk\", You are going for a movie, And he is going to work diligently.";
+		const language = "yep";
+
+		const expectedResult = {
+			keyphraseStems: [ "I am going for a walk" ],
+			synonymsStems: [
+				[ "You are not going for a walk" ],
+				[ "you", "are", "going", "for", "a", "movie" ],
+				[ "and", "he", "is", "going", "to", "work", "diligently" ],
+			],
+		};
+		expect( collectStems( keyword, synonyms, language, {} ) ).toEqual( expectedResult );
+	} );
+
+	it( "returns empty structure if no keyword or synonyms are supplied", function() {
+		const expectedResult = {
+			keyphraseStems: [],
+			synonymsStems: [],
+		};
+		expect( collectStems( "", "", "en_EN", morphologyDataEN.en ) ).toEqual( expectedResult );
+	} );
+
+	it( "returns an empty field if no keyword was supplied ", function() {
+		const synonyms = "\"You are not going for a walk\", You are going for a movie, And he is going to work diligently.";
+		const language = "en";
+
+		const expectedResult = {
+			keyphraseStems: [],
+			synonymsStems: [
+				[ "You are not going for a walk" ],
+				[ "movie" ],
+				[ "work", "diligent" ],
+			],
+		};
+		expect( collectStems( "", synonyms, language, morphologyDataEN.en ) ).toEqual( expectedResult );
+	} );
+
+	it( "returns an empty field if no synonyms were supplied ", function() {
+		const keyword = "\"I am going for a walk\"";
+		const language = "en";
+
+		const expectedResult = {
+			keyphraseStems: [ "I am going for a walk" ],
+			synonymsStems: [],
+		};
+		expect( collectStems( keyword, "", language, morphologyDataEN.en ) ).toEqual( expectedResult );
+	} );
+} );

--- a/packages/yoastseo/src/helpers/filterFunctionWordsFromArray.js
+++ b/packages/yoastseo/src/helpers/filterFunctionWordsFromArray.js
@@ -1,0 +1,32 @@
+import getFunctionWordsFactory from "../helpers/getFunctionWords.js";
+import { filter, get, includes, isUndefined } from "lodash-es";
+
+const getFunctionWords = getFunctionWordsFactory();
+
+/**
+ * Filters function words from an array of words based on the language.
+ *
+ * @param {Array} array The words to check.
+ * @param {string} language The language to take function words for.
+ *
+ * @returns {Array} The original array with the function words filtered out.
+ */
+export default function( array, language ) {
+	if ( isUndefined( language ) || language === "" ) {
+		language = "en";
+	}
+
+	const functionWords = get( getFunctionWords, [ language ], [] );
+
+	if ( array.length > 1 ) {
+		const arrayFiltered = filter( array, function( word ) {
+			return ( ! includes( functionWords.all, word.trim().toLocaleLowerCase() ) );
+		} );
+
+		if ( arrayFiltered.length > 0 ) {
+			return arrayFiltered;
+		}
+	}
+
+	return array;
+}

--- a/packages/yoastseo/src/researches/buildKeywordForms.js
+++ b/packages/yoastseo/src/researches/buildKeywordForms.js
@@ -1,49 +1,19 @@
 import getFormsForLanguageFactory from "../helpers/getFormsForLanguage.js";
 const getFormsForLanguage = getFormsForLanguageFactory();
 import getWords from "../stringProcessing/getWords.js";
+import filterFunctionWordsFromArray from "../helpers/filterFunctionWordsFromArray.js";
 import getLanguage from "../helpers/getLanguage.js";
-import getFunctionWordsFactory from "../helpers/getFunctionWords.js";
-const getFunctionWords = getFunctionWordsFactory();
 import parseSynonyms from "../stringProcessing/parseSynonyms";
 import { getVariationsApostrophe } from "../stringProcessing/getVariationsApostrophe";
 import { getVariationsApostropheInArray } from "../stringProcessing/getVariationsApostrophe";
 
 import { includes } from "lodash-es";
-import { filter } from "lodash-es";
 import { isUndefined } from "lodash-es";
 import { escapeRegExp } from "lodash-es";
 import { uniq as unique } from "lodash-es";
 import { flatten } from "lodash-es";
 import { get } from "lodash-es";
 import { memoize } from "lodash-es";
-
-/**
- * Filters function words from an array of words based on the language.
- *
- * @param {Array} array The words to check.
- * @param {string} language The language to take function words for.
- *
- * @returns {Array} The original array with the function words filtered out.
- */
-const filterFunctionWords = function( array, language ) {
-	if ( isUndefined( language ) || language === "" ) {
-		language = "en";
-	}
-
-	const functionWords = get( getFunctionWords, [ language ], [] );
-
-	if ( array.length > 1 ) {
-		const arrayFiltered = filter( array, function( word ) {
-			return ( ! includes( functionWords.all, word.trim().toLocaleLowerCase() ) );
-		} );
-
-		if ( arrayFiltered.length > 0 ) {
-			return arrayFiltered;
-		}
-	}
-
-	return array;
-};
 
 /**
  * Analyzes the focus keyword string. Checks if morphology is requested or if the user wants to match exact string.
@@ -72,7 +42,7 @@ const buildForms = function( keyphrase, language, morphologyData ) {
 		return [ unique( [].concat( escapeRegExp( keyphrase ), getVariationsApostrophe( keyphrase ) ) ) ];
 	}
 
-	const words = filterFunctionWords( getWords( keyphrase ), language );
+	const words = filterFunctionWordsFromArray( getWords( keyphrase ), language );
 
 	const forms = [];
 
@@ -177,7 +147,6 @@ function research( paper, researcher ) {
 }
 
 export {
-	filterFunctionWords,
 	buildForms,
 	collectForms,
 	research,

--- a/packages/yoastseo/src/researches/buildTopicStems.js
+++ b/packages/yoastseo/src/researches/buildTopicStems.js
@@ -18,7 +18,7 @@ const getStemForLanguage = getStemForLanguageFactory();
  * If morphology is required the module finds a stem for all words (if no function words list available) or
  * for all content words (i.e., excluding prepositions, articles, conjunctions, if the function words list is available).
  *
- * @param {string} keyphrase The keyphrase of the paper (or a synonym phrase) to get stemd for.
+ * @param {string} keyphrase The keyphrase of the paper (or a synonym phrase) to get stem for.
  * @param {string} language The language to use for morphological analyzer and for function words.
  * @param {Object} morphologyData The available morphology data per language (false if unavailable).
  *
@@ -39,7 +39,7 @@ const buildStems = function( keyphrase, language, morphologyData ) {
 	const words = filterFunctionWordsFromArray( getWords( keyphrase ), language );
 	const getStem = getStemForLanguage[ language ];
 
-	// Simply returns lowCased words from the keyphrase if morphological forms cannot be built.
+	// Simply returns lowCased words from the keyphrase if stems cannot be built.
 	if ( morphologyData === false || isUndefined( getStem ) ) {
 		return words.map( word => normalizeSingle( escapeRegExp( word.toLocaleLowerCase( language ) ) ) );
 	}

--- a/packages/yoastseo/src/researches/buildTopicStems.js
+++ b/packages/yoastseo/src/researches/buildTopicStems.js
@@ -1,0 +1,117 @@
+import getStemForLanguageFactory from "../helpers/getStemForLanguage.js";
+
+import filterFunctionWordsFromArray from "../helpers/filterFunctionWordsFromArray.js";
+import getWords from "../stringProcessing/getWords.js";
+import parseSynonyms from "../stringProcessing/parseSynonyms";
+import { normalizeSingle } from "../stringProcessing/quotes";
+
+import { includes } from "lodash-es";
+import { isUndefined } from "lodash-es";
+import { escapeRegExp } from "lodash-es";
+import { memoize } from "lodash-es";
+
+const getStemForLanguage = getStemForLanguageFactory();
+
+/**
+ * Analyzes the focus keyword string or one synonym phrase.
+ * Checks if morphology is requested or if the user wants to match exact string.
+ * If morphology is required the module finds a stem for all words (if no function words list available) or
+ * for all content words (i.e., excluding prepositions, articles, conjunctions, if the function words list is available).
+ *
+ * @param {string} keyphrase The keyphrase of the paper (or a synonym phrase) to get stemd for.
+ * @param {string} language The language to use for morphological analyzer and for function words.
+ * @param {Object} morphologyData The available morphology data per language (false if unavailable).
+ *
+ * @returns {Array} Array of stems of all (content) words in the keyphrase or synonym phrase.
+ */
+const buildStems = function( keyphrase, language, morphologyData ) {
+	if ( isUndefined( keyphrase ) || keyphrase === "" ) {
+		return [];
+	}
+
+	// If the keyphrase is embedded in double quotation marks, return keyword itself, without outer-most quotation marks.
+	const doubleQuotes = [ "“", "”", "〝", "〞", "〟", "‟", "„", "\"" ];
+	if ( includes( doubleQuotes, keyphrase[ 0 ] ) && includes( doubleQuotes, keyphrase[ keyphrase.length - 1 ] ) ) {
+		keyphrase = keyphrase.substring( 1, keyphrase.length - 1 );
+		return [ escapeRegExp( keyphrase ) ];
+	}
+
+	const words = filterFunctionWordsFromArray( getWords( keyphrase ), language );
+	const getStem = getStemForLanguage[ language ];
+
+	// Simply returns lowCased words from the keyphrase if morphological forms cannot be built.
+	if ( morphologyData === false || isUndefined( getStem ) ) {
+		return words.map( word => normalizeSingle( escapeRegExp( word.toLocaleLowerCase( language ) ) ) );
+	}
+
+	return words.map( word => {
+		const lowCaseWord = escapeRegExp( word.toLocaleLowerCase( language ) );
+		return getStem( normalizeSingle( lowCaseWord ), morphologyData );
+	} );
+};
+
+/**
+ * Builds stems of words of the keyphrase and of each synonym phrase.
+ *
+ * @param {string} keyphrase The paper's keyphrase.
+ * @param {string} synonyms The paper's synonyms.
+ * @param {string} language The paper's language.
+ * @param {Object} morphologyData The available morphology data to be used by the getStem function (language specific).
+ *
+ * @returns {Object} Object with an array of stems of words in the keyphrase and an array of arrays of stems of words in the synonyms.
+ */
+const collectKeyphraseAndSynonymsStems = function( keyphrase, synonyms, language = "en", morphologyData ) {
+	const synonymsSplit = parseSynonyms( synonyms );
+
+	const keyphraseStems = buildStems( keyphrase, language, morphologyData );
+	const synonymsStems = synonymsSplit.map( synonym => buildStems( synonym, language, morphologyData ) );
+
+	return {
+		keyphraseStems,
+		synonymsStems,
+	};
+};
+
+/**
+ * Caches stems depending on the currently available morphologyData and (separately) keyphrase, synonyms,
+ * and language. In this way, if the morphologyData remains the same in multiple calls of this function, the function
+ * that collects actual stems only needs to check if the keyphrase, synonyms and language also remain the
+ * same to return the cached result. The joining of keyphrase, synonyms and language for this function is needed,
+ * because by default memoize caches by the first key only, which in the current case would mean that the function would
+ * return the cached forms if the keyphrase has not changed (without checking if synonyms and language were changed).
+ *
+ * @param {Object|boolean} morphologyData The available morphology data.
+ *
+ * @returns {function} The function that collects the stems for a given set of keyphrase, synonyms, language and
+ * morphologyData.
+ */
+const primeMorphologyData = memoize( ( morphologyData ) => {
+	return memoize( ( keyphrase, synonyms, language = "en" ) => {
+		return collectKeyphraseAndSynonymsStems( keyphrase, synonyms, language, morphologyData );
+	}, ( keyphrase, synonyms, language ) => {
+		return keyphrase + "," + synonyms + "," + language;
+	} );
+} );
+
+
+/**
+ * Retrieves stems of words of the keyphrase and of each synonym phrase using the function that caches
+ * the results of previous calls of this function.
+ *
+ * @param {string} keyphrase The paper's keyphrase.
+ * @param {string} synonyms The paper's synonyms.
+ * @param {string} language The paper's language.
+ * @param {Object} morphologyData The available morphology data to be used by the getStems function (language specific).
+ *
+ * @returns {Object} Object with an array of stems of words in the keyphrase and an array of arrays of stems of words in the synonyms.
+ */
+function collectStems( keyphrase, synonyms, language = "en", morphologyData ) {
+	const collectStemsWithMorphologyData = primeMorphologyData( morphologyData );
+
+	return collectStemsWithMorphologyData( keyphrase, synonyms, language );
+}
+
+export {
+	buildStems,
+	collectStems,
+};


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Introduces a function that collects stems of all words in the keyphrase and all synonyms.

## Relevant technical choices:

* Caches the result on morphologyData and keyphrase, synonyms and language.
* Because we do not need the result of the function to be called in any assessment directly, but only within another research, I decided to not make a full-blown research function.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check that all tests pass and that the coverage is full.
* Add more specs to the new functions.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Nothing yet - the new function is never used.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-150?atlOrigin=eyJpIjoiMTc0NTRkNTdiYzc0NDYzNGFhYTM3MGFiNjE0MzM0ZmIiLCJwIjoiaiJ9
