### PR TITLE
Twitter preview styling tweaks

### DIFF
--- a/packages/social-metadata-previews/src/twitter/TwitterDescription.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterDescription.js
@@ -10,7 +10,9 @@ import PropTypes from "prop-types";
  * @returns {React.Component} The rendered element.
  */
 const TwitterDescription = styled.p`
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 14px;
+	font-weight: 400;
 	max-height: ${ props => props.isLarge ? "36px" : "55px" };
 	line-height: 18px;
 	overflow: hidden;

--- a/packages/social-metadata-previews/src/twitter/TwitterSiteName.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterSiteName.js
@@ -4,10 +4,13 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 
 const TwitterSiteNameWrapper = styled.p`
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-size: 14px;
+	line-height: 18px;
+	font-weight: 400;
 	text-transform: lowercase;
 	color: #8899a6;
 	max-height: 18px;
-	line-height: 18px;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/social-metadata-previews/src/twitter/TwitterTitle.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterTitle.js
@@ -4,7 +4,8 @@ import styled from "styled-components";
 import PropTypes from "prop-types";
 
 const TwitterTitleWrapper = styled.p`
-	font-weight: bold;
+	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	font-weight: 700;
 	font-size: 14px;
 	max-height: 18px;
 	line-height: 18px;

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterDescriptionTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterDescriptionTest.js.snap
@@ -2,7 +2,9 @@
 
 exports[`TwitterDescription matches the snapshot for the summary card 1`] = `
 .c0 {
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
   font-size: 14px;
+  font-weight: 400;
   max-height: 55px;
   line-height: 18px;
   overflow: hidden;
@@ -17,7 +19,9 @@ exports[`TwitterDescription matches the snapshot for the summary card 1`] = `
 
 exports[`TwitterDescription matches the snapshot for the summary with large image card 1`] = `
 .c0 {
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
   font-size: 14px;
+  font-weight: 400;
   max-height: 36px;
   line-height: 18px;
   overflow: hidden;

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
@@ -37,7 +37,8 @@ Array [
     Select image
   </div>,
   .c0 {
-  font-weight: bold;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-weight: 700;
   font-size: 14px;
   max-height: 18px;
   line-height: 18px;
@@ -53,7 +54,9 @@ Array [
     YoastCon Workshops • Yoast
   </p>,
   .c0 {
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
   font-size: 14px;
+  font-weight: 400;
   max-height: 55px;
   line-height: 18px;
   overflow: hidden;
@@ -67,10 +70,13 @@ Array [
     
   </p>,
   .c0 {
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 18px;
+  font-weight: 400;
   text-transform: lowercase;
   color: #8899a6;
   max-height: 18px;
-  line-height: 18px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterSiteNameTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterSiteNameTest.js.snap
@@ -2,10 +2,13 @@
 
 exports[`TwitterSiteName matches the snapshot by default 1`] = `
 .c0 {
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size: 14px;
+  line-height: 18px;
+  font-weight: 400;
   text-transform: lowercase;
   color: #8899a6;
   max-height: 18px;
-  line-height: 18px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterTitleTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterTitleTest.js.snap
@@ -2,7 +2,8 @@
 
 exports[`TwitterTitle matches the snapshot by default 1`] = `
 .c0 {
-  font-weight: bold;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-weight: 700;
   font-size: 14px;
   max-height: 18px;
   line-height: 18px;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* N/A - Adjusted twitter preview styling to match Twitter's card.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check if the text styling matches the example in #256 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #256 
