### PR TITLE
LIN-151 Create a research that gets word forms from the text

### DIFF
--- a/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
+++ b/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
@@ -8,7 +8,7 @@ describe( "A test for building stems for an array of words", function() {
 	it( "returns an empty array if the input keyphrase is undefined", function() {
 		let keyphrase;
 		const forms = buildStems( keyphrase, "en", morphologyDataEN.en );
-		expect( forms ).toEqual( [] );
+		expect( forms ).toEqual( { exactMatch: false, stemOriginalPairs: [] } );
 	} );
 
 	it( "returns the exact match if the input string is embedded in quotation marks (the language and morphAnalyzer do not matter)", function() {
@@ -278,7 +278,7 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 
 	it( "returns empty structure if no keyword or synonyms are supplied", function() {
 		const expectedResult = {
-			keyphraseStems: [],
+			keyphraseStems: { exactMatch: false, stemOriginalPairs: [] },
 			synonymsStems: [],
 		};
 		expect( collectStems( "", "", "en_EN", morphologyDataEN.en ) ).toEqual( expectedResult );
@@ -289,7 +289,7 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 		const language = "en";
 
 		const expectedResult = {
-			keyphraseStems: [],
+			keyphraseStems: { exactMatch: false, stemOriginalPairs: [] },
 			synonymsStems: [
 				new TopicPhrase(
 					[

--- a/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
+++ b/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
@@ -109,7 +109,7 @@ describe( "A test for building stems for an array of words", function() {
 	it( "returns stems of all content words for German if Premium", function() {
 		const forms = buildStems( "Schnell und einfach Altbauwohnungen finden.", "de", morphologyDataDE.de );
 		expect( forms ).toEqual(
-			new TopicPhrase( [ new StemOriginalPair( "altbauwohnung", "Altbauwohnungen" ) ], false)
+			new TopicPhrase( [ new StemOriginalPair( "altbauwohnung", "Altbauwohnungen" ) ], false )
 		);
 	} );
 } );
@@ -123,7 +123,7 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 		const expectedResult = {
 			keyphraseStems: new TopicPhrase(
 				[
-					new StemOriginalPair("I am going for a walk", "I am going for a walk" ),
+					new StemOriginalPair( "I am going for a walk", "I am going for a walk" ),
 				],
 				true
 			),
@@ -142,7 +142,7 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 				),
 				new TopicPhrase(
 					[
-						new StemOriginalPair("work", "work" ),
+						new StemOriginalPair( "work", "work" ),
 						new StemOriginalPair( "diligent", "diligently" ),
 					],
 					false

--- a/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
+++ b/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
@@ -1,4 +1,4 @@
-import { buildStems, collectStems } from "../../src/researches/buildTopicStems.js";
+import { buildStems, collectStems, StemOriginalPair, TopicPhrase } from "../../src/researches/buildTopicStems.js";
 import getMorphologyData from "../specHelpers/getMorphologyData";
 
 const morphologyDataEN = getMorphologyData( "en" );
@@ -12,46 +12,105 @@ describe( "A test for building stems for an array of words", function() {
 	} );
 
 	it( "returns the exact match if the input string is embedded in quotation marks (the language and morphAnalyzer do not matter)", function() {
-		const forms = buildStems( "\"I am going for a walk\"", "en", morphologyDataEN.en );
-		expect( forms ).toEqual( [ "I am going for a walk" ] );
+		const keyphrase = "\"I am going for a walk\"";
+		const forms = buildStems( keyphrase, "en", morphologyDataEN.en );
+		expect( forms ).toEqual(
+			new TopicPhrase(
+				[ new StemOriginalPair( "I am going for a walk", keyphrase.substring( 1, keyphrase.length - 1 ) ) ],
+				true
+			)
+		);
 	} );
 
 	it( "returns all (content) words if there is no morphological analyzer for this language yet", function() {
 		const forms = buildStems( "Je ne vais pas rire", "fr", false );
-		expect( forms ).toEqual( [ "rire" ] );
+		expect( forms ).toEqual(
+			new TopicPhrase(
+				[ new StemOriginalPair( "rire", "rire" ) ],
+				false )
+		);
 	} );
 
 	it( "returns all (content) words if there is no morphological analyzer for this language yet", function() {
 		const forms = buildStems( "Como hacer guacamole como los mexicanos", "es", false );
-		expect( forms ).toEqual( [ "guacamole", "mexicanos" ] );
+		expect( forms ).toEqual(
+			new TopicPhrase(
+				[
+					new StemOriginalPair( "guacamole", "guacamole" ),
+					new StemOriginalPair( "mexicanos", "mexicanos" ),
+				],
+				false
+			)
+		);
 	} );
 
 	it( "returns all (content) words if there is no morphological analyzer for this language yet and takes care of apostrophe variations", function() {
-		expect( buildStems( "слово'слово", "ru", {} ) ).toEqual( [ "слово'слово" ] );
-		expect( buildStems( "слово‘слово", "ru", {} ) ).toEqual( [ "слово'слово" ] );
-		expect( buildStems( "слово‛слово", "ru", {} ) ).toEqual( [ "слово'слово" ] );
-		expect( buildStems( "слово’слово", "ru", {} ) ).toEqual( [ "слово'слово" ] );
-		expect( buildStems( "слово`слово", "ru", {} ) ).toEqual( [ "слово'слово" ] );
+		expect( buildStems( "слово'слово", "ru", {} ) ).toEqual(
+			new TopicPhrase( [ new StemOriginalPair( "слово'слово", "слово'слово" ) ], false )
+		);
+
+		expect( buildStems( "слово‘слово", "ru", {} ) ).toEqual(
+			new TopicPhrase( [ new StemOriginalPair( "слово'слово", "слово‘слово" ) ], false )
+		);
+
+		expect( buildStems( "слово‛слово", "ru", {} ) ).toEqual(
+			new TopicPhrase( [ new StemOriginalPair( "слово'слово", "слово‛слово" ) ], false )
+		);
+
+		expect( buildStems( "слово’слово", "ru", {} ) ).toEqual(
+			new TopicPhrase( [ new StemOriginalPair( "слово'слово", "слово’слово" ) ], false )
+		);
+
+		expect( buildStems( "слово`слово", "ru", {} ) ).toEqual(
+			new TopicPhrase( [ new StemOriginalPair( "слово'слово", "слово`слово" ) ], false )
+		);
 	} );
 
 	it( "returns all content words for English if Free", function() {
 		const forms = buildStems( "I am walking and singing in the rain", "en", false );
-		expect( forms ).toEqual( [ "walking", "singing", "rain" ] );
+		expect( forms ).toEqual( new TopicPhrase(
+			[
+				new StemOriginalPair( "walking", "walking" ),
+				new StemOriginalPair( "singing", "singing" ),
+				new StemOriginalPair( "rain", "rain" ),
+			],
+			false
+		) );
 	} );
 
 	it( "returns stems of all words for English if Premium if only function words are supplied", function() {
 		const forms = buildStems( "One and two", "en", morphologyDataEN.en );
-		expect( forms ).toEqual( [ "one", "and", "two" ] );
+		expect( forms ).toEqual(
+			new TopicPhrase(
+				[
+					new StemOriginalPair( "one", "One" ),
+					new StemOriginalPair( "and", "and" ),
+					new StemOriginalPair( "two", "two" ),
+				],
+				false
+			)
+		);
 	} );
 
 	it( "returns stems of all content words for English if Premium", function() {
 		const forms = buildStems( "I am walking and singing in the rain", "en", morphologyDataEN.en );
-		expect( forms ).toEqual( [ "walk", "sing", "rain" ] );
+		expect( forms ).toEqual(
+			new TopicPhrase(
+				[
+					new StemOriginalPair( "walk", "walking" ),
+					new StemOriginalPair( "sing", "singing" ),
+					new StemOriginalPair( "rain", "rain" ),
+				],
+				false
+			)
+		);
 	} );
 
 	it( "returns stems of all content words for German if Premium", function() {
 		const forms = buildStems( "Schnell und einfach Altbauwohnungen finden.", "de", morphologyDataDE.de );
-		expect( forms ).toEqual( [ "altbauwohnung" ] );
+		expect( forms ).toEqual(
+			new TopicPhrase( [ new StemOriginalPair( "altbauwohnung", "Altbauwohnungen" ) ], false)
+		);
 	} );
 } );
 
@@ -62,13 +121,35 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 		let language;
 
 		const expectedResult = {
-			keyphraseStems: [ "I am going for a walk" ],
+			keyphraseStems: new TopicPhrase(
+				[
+					new StemOriginalPair("I am going for a walk", "I am going for a walk" ),
+				],
+				true
+			),
 			synonymsStems: [
-				[ "You are not going for a walk" ],
-				[ "movie" ],
-				[ "work", "diligent" ],
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "You are not going for a walk", "You are not going for a walk" ),
+					],
+					true
+				),
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "movie", "movie" ),
+					],
+					false
+				),
+				new TopicPhrase(
+					[
+						new StemOriginalPair("work", "work" ),
+						new StemOriginalPair( "diligent", "diligently" ),
+					],
+					false
+				),
 			],
 		};
+
 		expect( collectStems( keyword, synonyms, language, morphologyDataEN.en ) ).toEqual( expectedResult );
 	} );
 
@@ -78,13 +159,35 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 		const language = "en";
 
 		const expectedResult = {
-			keyphraseStems: [ "I am going for a walk" ],
+			keyphraseStems: new TopicPhrase(
+				[
+					new StemOriginalPair( "I am going for a walk", "I am going for a walk" ),
+				],
+				true
+			),
 			synonymsStems: [
-				[ "You are not going for a walk" ],
-				[ "movie" ],
-				[ "work", "diligent" ],
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "You are not going for a walk", "You are not going for a walk" ),
+					],
+					true
+				),
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "movie", "movie" ),
+					],
+					false
+				),
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "work", "work" ),
+						new StemOriginalPair( "diligent", "diligently" ),
+					],
+					false
+				),
 			],
 		};
+
 		expect( collectStems( keyword, synonyms, language, morphologyDataEN.en ) ).toEqual( expectedResult );
 	} );
 
@@ -94,11 +197,33 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 		const language = "fr";
 
 		const expectedResult = {
-			keyphraseStems: [ "promener" ],
+			keyphraseStems: new TopicPhrase(
+				[
+					new StemOriginalPair( "promener", "promener" ),
+				],
+				false
+			),
 			synonymsStems: [
-				[ "Tu ne vas pas te promener" ],
-				[ "voir", "film" ],
-				[ "travailler", "dur" ],
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "Tu ne vas pas te promener", "Tu ne vas pas te promener" ),
+					],
+					true
+				),
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "voir", "voir" ),
+						new StemOriginalPair( "film", "film" ),
+					],
+					false
+				),
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "travailler", "travailler" ),
+						new StemOriginalPair( "dur", "dur" ),
+					],
+					false
+				),
 			],
 		};
 		expect( collectStems( keyword, synonyms, language, {} ) ).toEqual( expectedResult );
@@ -110,11 +235,42 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 		const language = "yep";
 
 		const expectedResult = {
-			keyphraseStems: [ "I am going for a walk" ],
+			keyphraseStems: new TopicPhrase(
+				[
+					new StemOriginalPair( "I am going for a walk", "I am going for a walk" ),
+				],
+				true
+			),
 			synonymsStems: [
-				[ "You are not going for a walk" ],
-				[ "you", "are", "going", "for", "a", "movie" ],
-				[ "and", "he", "is", "going", "to", "work", "diligently" ],
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "You are not going for a walk", "You are not going for a walk" ),
+					],
+					true
+				),
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "you", "You" ),
+						new StemOriginalPair( "are", "are" ),
+						new StemOriginalPair( "going", "going" ),
+						new StemOriginalPair( "for", "for" ),
+						new StemOriginalPair( "a", "a" ),
+						new StemOriginalPair( "movie", "movie" ),
+					],
+					false
+				),
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "and", "And" ),
+						new StemOriginalPair( "he", "he" ),
+						new StemOriginalPair( "is", "is" ),
+						new StemOriginalPair( "going", "going" ),
+						new StemOriginalPair( "to", "to" ),
+						new StemOriginalPair( "work", "work" ),
+						new StemOriginalPair( "diligently", "diligently" ),
+					],
+					false
+				),
 			],
 		};
 		expect( collectStems( keyword, synonyms, language, {} ) ).toEqual( expectedResult );
@@ -135,9 +291,25 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 		const expectedResult = {
 			keyphraseStems: [],
 			synonymsStems: [
-				[ "You are not going for a walk" ],
-				[ "movie" ],
-				[ "work", "diligent" ],
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "You are not going for a walk", "You are not going for a walk" ),
+					],
+					true
+				),
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "movie", "movie" ),
+					],
+					false
+				),
+				new TopicPhrase(
+					[
+						new StemOriginalPair( "work", "work" ),
+						new StemOriginalPair( "diligent", "diligently" ),
+					],
+					false
+				),
 			],
 		};
 		expect( collectStems( "", synonyms, language, morphologyDataEN.en ) ).toEqual( expectedResult );
@@ -148,7 +320,11 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 		const language = "en";
 
 		const expectedResult = {
-			keyphraseStems: [ "I am going for a walk" ],
+			keyphraseStems: new TopicPhrase(
+				[
+					new StemOriginalPair( "I am going for a walk", "I am going for a walk" ) ],
+				true
+			),
 			synonymsStems: [],
 		};
 		expect( collectStems( keyword, "", language, morphologyDataEN.en ) ).toEqual( expectedResult );

--- a/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
+++ b/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
@@ -330,3 +330,50 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 		expect( collectStems( keyword, "", language, morphologyDataEN.en ) ).toEqual( expectedResult );
 	} );
 } );
+
+describe( "A test for topic phrase objects", function() {
+	const testTopicPhrase = new TopicPhrase(
+		[
+			new StemOriginalPair( "movie", "movies" ),
+			new StemOriginalPair( "work", "work" ),
+		],
+		false,
+	);
+
+	it( "constructs a topic phrase", () => {
+		expect( testTopicPhrase ).toEqual(
+			{
+				exactMatch: false,
+				stemOriginalPairs: [
+					{ original: "movies", stem: "movie" },
+					{ original: "work", stem: "work" },
+				],
+			} );
+	} );
+
+	it( "constructs an empty topic phrase", () => {
+		const emptyTopicPhrase = new TopicPhrase();
+
+		expect( emptyTopicPhrase ).toEqual(
+			{
+				exactMatch: false,
+				stemOriginalPairs: [],
+			} );
+	} );
+
+	it( "gets stems from a topic phrase", () => {
+		expect( testTopicPhrase.getStems() ).toEqual( [ "movie", "work" ] );
+	} );
+} );
+
+describe( "A test for stem original pair objects", function() {
+	const testStemOriginalPair = new StemOriginalPair( "movie", "movies" );
+
+	it( "constructs a topic phrase", () => {
+		expect( testStemOriginalPair ).toEqual(
+			{
+				stem: "movie",
+				original: "movies",
+			} );
+	} );
+} );

--- a/packages/yoastseo/spec/researches/geWordFormsFromTextSpec.js
+++ b/packages/yoastseo/spec/researches/geWordFormsFromTextSpec.js
@@ -21,8 +21,8 @@ describe( "A test from getting word forms from the text, based on the stems of a
 
 		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
 			{
-				keyphraseForms: [ [ "cat's", "cat" ], [ "dog", "dog's" ] ],
-				synonymsForms: [ [ [ "purrs" ], [ "feline" ] ], [ [ "friendly" ], [ "canine" ] ] ],
+				keyphraseForms: [ [ "cats", "cat's", "cat" ], [ "dogs", "dog", "dog's" ] ],
+				synonymsForms: [ [ [ "purring", "purrs" ], [ "felines", "feline" ] ], [ [ "friendly" ], [ "canines", "canine" ] ] ],
 			}
 		);
 	} );
@@ -42,7 +42,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
 			{
 				keyphraseForms: [ [ "orangen" ], [ "heidelbeeren" ] ],
-				synonymsForms: [ [ [ "sauer" ], [ "apfelsine" ] ], [ [ "süß" ], [ "blaubeere" ] ] ],
+				synonymsForms: [ [ [ "saure", "sauer" ], [ "apfelsine" ] ], [ [ "süße", "süß" ], [ "blaubeere" ] ] ],
 			}
 		);
 	} );
@@ -89,7 +89,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 
 		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
 			{
-				keyphraseForms: [ [ "cat" ], [ "dog" ] ],
+				keyphraseForms: [ [ "cats", "cat" ], [ "dogs", "dog" ] ],
 				synonymsForms: [],
 			}
 		);
@@ -106,15 +106,11 @@ describe( "A test from getting word forms from the text, based on the stems of a
 
 		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
 			{
-				keyphraseForms: [ [ "cat" ], [ "dog" ] ],
-				synonymsForms: [ [ [ "feline" ] ], [ [ "canine" ] ] ],
+				keyphraseForms: [ [  "cats", "cat" ], [ "dogs", "dog" ] ],
+				synonymsForms: [ [ [ "felines", "feline" ] ], [ [ "canines", "canine" ] ] ],
 			}
 		);
 	} );
-
-	// keyphrase undefined -> return empty
-
-
 
 	it( "returns the (sanitized) original form of a word if no forms were found in the paper", function() {
 		const attributes = {
@@ -146,7 +142,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 
 		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
 			{
-				keyphraseForms: [ [ "cat", "cats" ], [ "walked", "walking", "walk"  ] ],
+				keyphraseForms: [ [ "cat", "cats" ], [ "walks", "walked", "walking", "walk"  ] ],
 				synonymsForms: [],
 			}
 		);
@@ -166,7 +162,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 
 		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
 			{
-				keyphraseForms: [ [ "walk's", "walks", "walked", "walking" ] ],
+				keyphraseForms: [ [ "walk", "walk's", "walks", "walked", "walking" ] ],
 				synonymsForms: [],
 			}
 		);
@@ -184,7 +180,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
 			{
 				keyphraseForms: [ [ "cats and dogs" ] ],
-				synonymsForms: [ [ [ "feline"  ] ], [ [ "canine" ] ] ],
+				synonymsForms: [ [ [ "felines", "feline"  ] ], [ [ "canines", "canine" ] ] ],
 			}
 		);
 	} );
@@ -200,7 +196,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 
 		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
 			{
-				keyphraseForms: [ [ "cat" ], [ "dog" ] ],
+				keyphraseForms: [ [ "cats", "cat" ], [ "dogs", "dog" ] ],
 				synonymsForms: [ [ [ "some purring felines"  ] ], [ [ "canines" ] ] ],
 			}
 		);

--- a/packages/yoastseo/spec/researches/geWordFormsFromTextSpec.js
+++ b/packages/yoastseo/spec/researches/geWordFormsFromTextSpec.js
@@ -1,0 +1,259 @@
+import Researcher from "../../src/researcher";
+import getWordFormsFromText from "../../src/researches/getWordFormsFromText";
+import Paper from "../../src/values/Paper";
+import getMorphologyData from "../specHelpers/getMorphologyData";
+const morphologyDataEN = getMorphologyData( "en" );
+const morphologyDataDE = getMorphologyData( "de" );
+
+const testText = "I walked my dog. The cat walks along. The canine and the feline were walking.";
+
+describe( "A test from getting word forms from the text, based on the stems of a keyphrase", function() {
+	it( "returns forms found in the text for multiple keyphrases and synonyms with multiple words;" +
+		"English stemmer", function() {
+		const text = "A cat's dog and a dog's cat. The feline purrs. The canine is friendly."
+		const attributes = {
+			keyword: "cats and dogs",
+			synonyms: "purring felines, friendly canines",
+		};
+		const testPaper = new Paper( text, attributes );
+		const researcher = new Researcher( testPaper );
+		researcher.addResearchData( "morphology", morphologyDataEN );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "cat's", "cat" ], [ "dog", "dog's" ] ],
+				synonymsForms: [ [ [ "purrs" ], [ "feline" ] ], [ [ "friendly" ], [ "canine" ] ] ],
+			}
+		);
+	} );
+
+	it( "returns forms found in the text for multiple keyphrases and synonyms with multiple words;" +
+		"German stemmer", function() {
+		const text = "Eine Orange und eine Heidelbeere. Die Apfelsinen sind sauer. Die Blaubeeren sind süß."
+		const attributes = {
+			keyword: "Orangen und Heidelbeeren",
+			synonyms: "saure Apfelsine, süße Blaubeere",
+			locale: "de_DE",
+		};
+		const testPaper = new Paper( text, attributes );
+		const researcher = new Researcher( testPaper );
+		researcher.addResearchData( "morphology", morphologyDataDE );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "orangen" ], [ "heidelbeeren" ] ],
+				synonymsForms: [ [ [ "sauer" ], [ "apfelsine" ] ], [ [ "süß" ], [ "blaubeere" ] ] ],
+			}
+		);
+	} );
+
+	it( "returns empty structure if no keyword or synonyms are supplied", function() {
+		const attributes = {
+			keyword: "",
+			synonyms: "",
+		};
+		const testPaper = new Paper( testText, attributes );
+		const researcher = new Researcher( testPaper );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [],
+				synonymsForms: [],
+			}
+		);
+	} );
+
+	it( "returns an empty keyphrase field if only synonyms are supplied", function() {
+		const attributes = {
+			keyword: "",
+			synonyms: "cats and dogs",
+		};
+		const testPaper = new Paper( testText, attributes );
+		const researcher = new Researcher( testPaper );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [],
+				synonymsForms: [ [ [ "cats" ], [ "dogs" ] ] ],
+			}
+		);
+	} );
+
+	it( "returns keyphrase forms found in the paper", function() {
+		const attributes = {
+			keyword: "cats and dogs",
+		};
+		const testPaper = new Paper( testText, attributes );
+		const researcher = new Researcher( testPaper );
+		researcher.addResearchData( "morphology", morphologyDataEN );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "cat" ], [ "dog" ] ],
+				synonymsForms: [],
+			}
+		);
+	} );
+
+	it( "returns forms for a keyphrase and multiple synonyms", function() {
+		const attributes = {
+			keyword: "cats and dogs",
+			synonyms: "felines, canines",
+		};
+		const testPaper = new Paper( testText, attributes );
+		const researcher = new Researcher( testPaper );
+		researcher.addResearchData( "morphology", morphologyDataEN );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "cat" ], [ "dog" ] ],
+				synonymsForms: [ [ [ "feline" ] ], [ [ "canine" ] ] ],
+			}
+		);
+	} );
+
+	// keyphrase undefined -> return empty
+
+
+
+	it( "returns the (sanitized) original form of a word if no forms were found in the paper", function() {
+		const attributes = {
+			keyword: "Cats and dogs",
+		};
+
+		const testPaper = new Paper( "", attributes );
+		const researcher = new Researcher( testPaper );
+		researcher.addResearchData( "morphology", morphologyDataEN );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "cats" ], [ "dogs" ] ],
+				synonymsForms: [],
+			}
+		);
+	} );
+
+	it( "returns multiple forms of a stem found in the text of the paper", function() {
+		const testTextWalkMultipleForms = "The cat walked quickly." +
+			"More cats are walking up there." +
+			"They just walk and walk.";
+		const attributes = {
+			keyword: "the cat walks",
+		};
+		const testPaper = new Paper( testTextWalkMultipleForms, attributes );
+		const researcher = new Researcher( testPaper );
+		researcher.addResearchData( "morphology", morphologyDataEN );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "cat", "cats" ], [ "walked", "walking", "walk"  ] ],
+				synonymsForms: [],
+			}
+		);
+	} );
+
+	it( "returns multiple forms of a stem found in the text, slug, title and meta description of the paper", function() {
+		const attributes = {
+			keyword: "walk",
+			description: "walking",
+			title: "walks",
+			url: "walked",
+		};
+
+		const testPaper = new Paper( "walk's", attributes );
+		const researcher = new Researcher( testPaper );
+		researcher.addResearchData( "morphology", morphologyDataEN );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "walk's", "walks", "walked", "walking" ] ],
+				synonymsForms: [],
+			}
+		);
+	} );
+
+	it( "returns the exact match if the keyphrase is embedded in quotation marks", function() {
+		const attributes = {
+			keyword: "\"cats and dogs\"",
+			synonyms: "felines, canines",
+		};
+		const testPaper = new Paper( "A canine and a feline are walking.", attributes );
+		const researcher = new Researcher( testPaper );
+		researcher.addResearchData( "morphology", morphologyDataEN );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "cats and dogs" ] ],
+				synonymsForms: [ [ [ "feline"  ] ], [ [ "canine" ] ] ],
+			}
+		);
+	} );
+
+	it( "returns the exact match if a synonym is embedded in quotation marks", function() {
+		const attributes = {
+			keyword: "cats and dogs",
+			synonyms: "\"some purring felines\", canines",
+		};
+		const testPaper = new Paper( "A cat and a dog are walking.", attributes );
+		const researcher = new Researcher( testPaper );
+		researcher.addResearchData( "morphology", morphologyDataEN );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "cat" ], [ "dog" ] ],
+				synonymsForms: [ [ [ "some purring felines"  ] ], [ [ "canines" ] ] ],
+			}
+		);
+	} );
+
+	it( "returns the keyphrase and synonyms unaltered for a language when there for which we have a stemmer," +
+		"and function word support, but no morphology data is available", function() {
+		const attributes = {
+			keyword: "cats and dogs",
+			synonyms: "felines, canines",
+		};
+		const testPaper = new Paper( testText, attributes );
+		const researcher = new Researcher( testPaper );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "cats" ], [ "dogs" ] ],
+				synonymsForms: [ [ [ "felines" ] ], [ [ "canines" ] ] ],
+			}
+		);
+	} );
+
+	it( "returns unaltered topic words for a language which has neither a stemmer nor morphology data," +
+		"but which has function word support", function() {
+		const attributes = {
+			keyword: "cane e gatto",
+			locale: "it_IT",
+		};
+		const testPaper = new Paper( "Cane e gatto. Cani e gatti.", attributes );
+		const researcher = new Researcher( testPaper );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "cane" ], [ "gatto" ] ],
+				synonymsForms: [  ],
+			}
+		);
+	} );
+
+	it( "returns the keyphrase and synonyms with function words filtered for a language without morphology" +
+		"or function word support", function() {
+		const attributes = {
+			keyword: "katte en honde",
+			locale: "af_ZA",
+		};
+		const testPaper = new Paper( "", attributes );
+		const researcher = new Researcher( testPaper );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "katte" ], [ "en" ], [ "honde" ] ],
+				synonymsForms: [],
+			}
+		);
+	} );
+} );

--- a/packages/yoastseo/spec/researches/getWordFormsFromTextSpec.js
+++ b/packages/yoastseo/spec/researches/getWordFormsFromTextSpec.js
@@ -211,6 +211,24 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		);
 	} );
 
+	it( "returns exact match es for all topic phrases if all topic phrases are exact matches", () => {
+		const attributes = {
+			keyword: "\"cats and dogs\"",
+			synonyms: "\"some purring felines\", \"these friendly canines\"",
+		};
+		const testPaper = new Paper( "A cat and a dog are walking.", attributes );
+		const researcher = new Researcher( testPaper );
+		researcher.addResearchData( "morphology", morphologyDataEN );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "cats and dogs" ] ],
+				synonymsForms: [ [ [ "some purring felines"  ] ], [ [ "these friendly canines" ] ] ],
+			}
+		);
+	} );
+
+
 	it( "returns the keyphrase and synonyms unaltered for a language when there for which we have a stemmer," +
 		"and function word support, but no morphology data is available (e.g., English in Free)", () => {
 		const attributes = {

--- a/packages/yoastseo/spec/researches/getWordFormsFromTextSpec.js
+++ b/packages/yoastseo/spec/researches/getWordFormsFromTextSpec.js
@@ -177,6 +177,26 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		);
 	} );
 
+	it( "returns multiple forms of a stem found in the text, slug, title and meta description of the paper", () => {
+		const attributes = {
+			keyword: "walk's",
+			description: "walking",
+			title: "walks",
+			url: "walked",
+		};
+
+		const testPaper = new Paper( "walk", attributes );
+		const researcher = new Researcher( testPaper );
+		researcher.addResearchData( "morphology", morphologyDataEN );
+
+		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [ [ "walk's", "walk", "walks", "walked", "walking" ] ],
+				synonymsForms: [],
+			}
+		);
+	} );
+
 	it( "returns the exact match if the keyphrase is embedded in quotation marks", () => {
 		const attributes = {
 			keyword: "\"cats and dogs\"",
@@ -199,19 +219,19 @@ describe( "A test from getting word forms from the text, based on the stems of a
 			keyword: "cats and dogs",
 			synonyms: "\"some purring felines\", canines",
 		};
-		const testPaper = new Paper( "A cat and a dog are walking.", attributes );
+		const testPaper = new Paper( "A cat and a dog are walking. The canine is friendly. A feline does not purr.", attributes );
 		const researcher = new Researcher( testPaper );
 		researcher.addResearchData( "morphology", morphologyDataEN );
 
 		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
 			{
 				keyphraseForms: [ [ "cats", "cat" ], [ "dogs", "dog" ] ],
-				synonymsForms: [ [ [ "some purring felines"  ] ], [ [ "canines" ] ] ],
+				synonymsForms: [ [ [ "some purring felines"  ] ], [ [ "canines", "canine" ] ] ],
 			}
 		);
 	} );
 
-	it( "returns exact match es for all topic phrases if all topic phrases are exact matches", () => {
+	it( "returns exact matches for all topic phrases if all topic phrases are exact matches", () => {
 		const attributes = {
 			keyword: "\"cats and dogs\"",
 			synonyms: "\"some purring felines\", \"these friendly canines\"",
@@ -263,7 +283,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		);
 	} );
 
-	it( "returns the keyphrase and synonyms with function words filtered for a language without morphology" +
+	it( "returns the keyphrase and synonyms with function words not filtered for a language without morphology" +
 		"or function word support", () => {
 		const attributes = {
 			keyword: "katte en honde",

--- a/packages/yoastseo/spec/researches/getWordFormsFromTextSpec.js
+++ b/packages/yoastseo/spec/researches/getWordFormsFromTextSpec.js
@@ -7,10 +7,10 @@ const morphologyDataDE = getMorphologyData( "de" );
 
 const testText = "I walked my dog. The cat walks along. The canine and the feline were walking.";
 
-describe( "A test from getting word forms from the text, based on the stems of a keyphrase", function() {
+describe( "A test from getting word forms from the text, based on the stems of a keyphrase", () => {
 	it( "returns forms found in the text for multiple keyphrases and synonyms with multiple words;" +
-		"English stemmer", function() {
-		const text = "A cat's dog and a dog's cat. The feline purrs. The canine is friendly."
+		"English stemmer", () => {
+		const text = "A cat's dog and a dog's cat. The feline purrs. The canine is friendly.";
 		const attributes = {
 			keyword: "cats and dogs",
 			synonyms: "purring felines, friendly canines",
@@ -28,8 +28,8 @@ describe( "A test from getting word forms from the text, based on the stems of a
 	} );
 
 	it( "returns forms found in the text for multiple keyphrases and synonyms with multiple words;" +
-		"German stemmer", function() {
-		const text = "Eine Orange und eine Heidelbeere. Die Apfelsinen sind sauer. Die Blaubeeren sind süß."
+		"German stemmer", () => {
+		const text = "Eine Orange und eine Heidelbeere. Die Apfelsinen sind sauer. Die Blaubeeren sind süß.";
 		const attributes = {
 			keyword: "Orangen und Heidelbeeren",
 			synonyms: "saure Apfelsine, süße Blaubeere",
@@ -41,13 +41,22 @@ describe( "A test from getting word forms from the text, based on the stems of a
 
 		expect( getWordFormsFromText( testPaper, researcher ) ).toEqual(
 			{
-				keyphraseForms: [ [ "orangen" ], [ "heidelbeeren" ] ],
-				synonymsForms: [ [ [ "saure", "sauer" ], [ "apfelsine" ] ], [ [ "süße", "süß" ], [ "blaubeere" ] ] ],
+				keyphraseForms: [ [ "orangen", "orange" ], [ "heidelbeeren", "heidelbeere" ] ],
+				synonymsForms: [
+					[
+						[ "saure", "sauer" ],
+						[ "apfelsine", "apfelsinen" ],
+					],
+					[
+						[ "süße", "süß" ],
+						[ "blaubeere", "blaubeeren" ],
+					],
+				],
 			}
 		);
 	} );
 
-	it( "returns empty structure if no keyword or synonyms are supplied", function() {
+	it( "returns empty structure if no keyword or synonyms are supplied", () => {
 		const attributes = {
 			keyword: "",
 			synonyms: "",
@@ -63,7 +72,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		);
 	} );
 
-	it( "returns an empty keyphrase field if only synonyms are supplied", function() {
+	it( "returns an empty keyphrase field if only synonyms are supplied", () => {
 		const attributes = {
 			keyword: "",
 			synonyms: "cats and dogs",
@@ -79,7 +88,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		);
 	} );
 
-	it( "returns keyphrase forms found in the paper", function() {
+	it( "returns keyphrase forms found in the paper", () => {
 		const attributes = {
 			keyword: "cats and dogs",
 		};
@@ -95,7 +104,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		);
 	} );
 
-	it( "returns forms for a keyphrase and multiple synonyms", function() {
+	it( "returns forms for a keyphrase and multiple synonyms", () => {
 		const attributes = {
 			keyword: "cats and dogs",
 			synonyms: "felines, canines",
@@ -112,7 +121,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		);
 	} );
 
-	it( "returns the (sanitized) original form of a word if no forms were found in the paper", function() {
+	it( "returns the (sanitized) original form of a word if no forms were found in the paper", () => {
 		const attributes = {
 			keyword: "Cats and dogs",
 		};
@@ -129,7 +138,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		);
 	} );
 
-	it( "returns multiple forms of a stem found in the text of the paper", function() {
+	it( "returns multiple forms of a stem found in the text of the paper", () => {
 		const testTextWalkMultipleForms = "The cat walked quickly." +
 			"More cats are walking up there." +
 			"They just walk and walk.";
@@ -148,7 +157,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		);
 	} );
 
-	it( "returns multiple forms of a stem found in the text, slug, title and meta description of the paper", function() {
+	it( "returns multiple forms of a stem found in the text, slug, title and meta description of the paper", () => {
 		const attributes = {
 			keyword: "walk",
 			description: "walking",
@@ -168,7 +177,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		);
 	} );
 
-	it( "returns the exact match if the keyphrase is embedded in quotation marks", function() {
+	it( "returns the exact match if the keyphrase is embedded in quotation marks", () => {
 		const attributes = {
 			keyword: "\"cats and dogs\"",
 			synonyms: "felines, canines",
@@ -185,7 +194,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 		);
 	} );
 
-	it( "returns the exact match if a synonym is embedded in quotation marks", function() {
+	it( "returns the exact match if a synonym is embedded in quotation marks", () => {
 		const attributes = {
 			keyword: "cats and dogs",
 			synonyms: "\"some purring felines\", canines",
@@ -203,7 +212,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 	} );
 
 	it( "returns the keyphrase and synonyms unaltered for a language when there for which we have a stemmer," +
-		"and function word support, but no morphology data is available", function() {
+		"and function word support, but no morphology data is available (e.g., English in Free)", () => {
 		const attributes = {
 			keyword: "cats and dogs",
 			synonyms: "felines, canines",
@@ -220,7 +229,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 	} );
 
 	it( "returns unaltered topic words for a language which has neither a stemmer nor morphology data," +
-		"but which has function word support", function() {
+		"but which has function word support", () => {
 		const attributes = {
 			keyword: "cane e gatto",
 			locale: "it_IT",
@@ -237,7 +246,7 @@ describe( "A test from getting word forms from the text, based on the stems of a
 	} );
 
 	it( "returns the keyphrase and synonyms with function words filtered for a language without morphology" +
-		"or function word support", function() {
+		"or function word support", () => {
 		const attributes = {
 			keyword: "katte en honde",
 			locale: "af_ZA",

--- a/packages/yoastseo/src/helpers/retrieveStemmer.js
+++ b/packages/yoastseo/src/helpers/retrieveStemmer.js
@@ -1,0 +1,15 @@
+import { get } from "lodash-es";
+import getStemForLanguageFactory from "../helpers/getStemForLanguage";
+const stemFunctions = getStemForLanguageFactory();
+
+
+/**
+ * Retrieves a stemmer function from the factory. Returns the identity function if the language does not have a stemmer.
+ *
+ * @param {string} language The language to retrieve a stemmer function for.
+ *
+ * @returns {Function} A stemmer function for the language.
+ */
+export default function( language ) {
+	return get( stemFunctions, language, word => word );
+}

--- a/packages/yoastseo/src/researcher.js
+++ b/packages/yoastseo/src/researcher.js
@@ -47,6 +47,7 @@ import functionWordsInKeyphrase from "./researches/functionWordsInKeyphrase";
 import h1s from "./researches/h1s";
 import getProminentWordsForInsights from "./researches/getProminentWordsForInsights";
 import getProminentWordsForInternalLinking from "./researches/getProminentWordsForInternalLinking";
+import getWordFormsFromText from "./researches/getWordFormsFromText";
 
 /**
  * This contains all possible, default researches.
@@ -97,6 +98,7 @@ var Researcher = function( paper ) {
 		h1s: h1s,
 		prominentWordsForInsights: getProminentWordsForInsights,
 		prominentWordsForInternalLinking: getProminentWordsForInternalLinking,
+		getWordFormsFromText: getWordFormsFromText,
 	};
 
 	this._data = {};

--- a/packages/yoastseo/src/researches/buildTopicStems.js
+++ b/packages/yoastseo/src/researches/buildTopicStems.js
@@ -12,12 +12,26 @@ import { memoize } from "lodash-es";
 
 const getStemForLanguage = getStemForLanguageFactory();
 
+/**
+ * A topic phrase (i.e., a keyphrase or synonym) with stem-original pairs for the words in the topic phrase.
+ *
+ * @param {TopicPhrase[]}   stemOriginalPairs   The stem-original pairs for the words in the topic phrase.
+ * @param {boolean}         exactMatch          Whether the topic phrase is an exact match.
+ *
+ * @constructor
+ */
 function TopicPhrase( stemOriginalPairs = [], exactMatch = false ) {
 	this.stemOriginalPairs = stemOriginalPairs;
 	this.exactMatch = exactMatch;
 }
 
+/**
+ * Returns all stems in the topic phrase.
+ *
+ * @returns {string[]|[]} The stems in the topic phrase or empty array if the topic phrase is exact match.
+ */
 TopicPhrase.prototype.getStems = function() {
+	// An exact match keyphrase doesn't have stems.
 	if ( this.exactMatch ) {
 		return [];
 	}
@@ -25,6 +39,14 @@ TopicPhrase.prototype.getStems = function() {
 	return this.stemOriginalPairs.map( stemOriginalPair => stemOriginalPair.stem );
 };
 
+/**
+ * A stem-original pair ƒor a word in a topic phrase.
+ *
+ * @param {string}  stem        The stem of the topic phrase word.
+ * @param {string}  original    The original word form the topic phrase (unsanitized)
+ *
+ * @constructor
+ */
 function StemOriginalPair( stem, original ) {
 	this.stem = stem;
 	this.original = original;

--- a/packages/yoastseo/src/researches/buildTopicStems.js
+++ b/packages/yoastseo/src/researches/buildTopicStems.js
@@ -17,6 +17,14 @@ function TopicPhrase( stemOriginalPairs = [], exactMatch = false ) {
 	this.exactMatch = exactMatch;
 }
 
+TopicPhrase.prototype.getStems = function() {
+	if ( this.exactMatch ) {
+		return [];
+	}
+
+	return this.stemOriginalPairs.map( stemOriginalPair => stemOriginalPair.stem );
+};
+
 function StemOriginalPair( stem, original ) {
 	this.stem = stem;
 	this.original = original;

--- a/packages/yoastseo/src/researches/buildTopicStems.js
+++ b/packages/yoastseo/src/researches/buildTopicStems.js
@@ -15,8 +15,8 @@ const getStemForLanguage = getStemForLanguageFactory();
 /**
  * A topic phrase (i.e., a keyphrase or synonym) with stem-original pairs for the words in the topic phrase.
  *
- * @param {TopicPhrase[]}   stemOriginalPairs   The stem-original pairs for the words in the topic phrase.
- * @param {boolean}         exactMatch          Whether the topic phrase is an exact match.
+ * @param {StemOriginalPair[]} stemOriginalPairs   The stem-original pairs for the words in the topic phrase.
+ * @param {boolean}            exactMatch          Whether the topic phrase is an exact match.
  *
  * @constructor
  */
@@ -62,11 +62,12 @@ function StemOriginalPair( stem, original ) {
  * @param {string} language The language to use for morphological analyzer and for function words.
  * @param {Object} morphologyData The available morphology data per language (false if unavailable).
  *
- * @returns {Array} Array of stems of all (content) words in the keyphrase or synonym phrase.
+ * @returns {TopicPhrase} Object with an array of StemOriginalPairs of all (content) words in the keyphrase or synonym
+ * phrase and information about whether the keyphrase/synonym should be matched exactly.
  */
 const buildStems = function( keyphrase, language, morphologyData ) {
 	if ( isUndefined( keyphrase ) || keyphrase === "" ) {
-		return [];
+		return new TopicPhrase();
 	}
 
 	// If the keyphrase is embedded in double quotation marks, return keyword itself, without outer-most quotation marks.

--- a/packages/yoastseo/src/researches/getWordFormsFromText.js
+++ b/packages/yoastseo/src/researches/getWordFormsFromText.js
@@ -105,7 +105,7 @@ function extractStems( keyphrase, synonyms ) {
  */
 function constructTopicPhraseResult( topicPhrase, paperWordsGroupedByStems, language ) {
 	// Empty result for an empty topic phrase.
-	if ( topicPhrase.length === 0 ) {
+	if ( topicPhrase.stemOriginalPairs.length === 0 ) {
 		return [];
 	}
 

--- a/packages/yoastseo/src/researches/getWordFormsFromText.js
+++ b/packages/yoastseo/src/researches/getWordFormsFromText.js
@@ -2,8 +2,7 @@ import { escapeRegExp, get, includes, uniq } from "lodash-es";
 import flattenDeep from "lodash-es/flattenDeep";
 import filterFunctionWordsFromArray from "../helpers/filterFunctionWordsFromArray";
 import getLanguage from "../helpers/getLanguage";
-import getStemForLanguageFactory from "../helpers/getStemForLanguage";
-const stemFunctions = getStemForLanguageFactory();
+import retrieveStemmer from "../helpers/retrieveStemmer";
 
 import getWords from "../stringProcessing/getWords";
 import { normalizeSingle } from "../stringProcessing/quotes";
@@ -19,16 +18,7 @@ function Result( keyphraseStems = [], synonymsStems = [] ) {
 	this.synonymsForms = synonymsStems;
 }
 
-/**
- * Retrieves a stemmer function from the factory. Returns the identity function if the language does not have a stemmer.
- *
- * @param {string} language The language to retrieve a stemmer function for.
- *
- * @returns {Function} A stemmer function for the language.
- */
-function retrieveStemmer( language ) {
-	return get( stemFunctions, language, word => word );
-}
+
 
 function getAllWordsFromPaper( paper ) {
 	const wordsText = getWords( paper.getText() );

--- a/packages/yoastseo/src/researches/getWordFormsFromText.js
+++ b/packages/yoastseo/src/researches/getWordFormsFromText.js
@@ -1,4 +1,4 @@
-import { escapeRegExp, get, includes, uniq } from "lodash-es";
+import { escapeRegExp, get, uniq } from "lodash-es";
 import flattenDeep from "lodash-es/flattenDeep";
 import filterFunctionWordsFromArray from "../helpers/filterFunctionWordsFromArray";
 import getLanguage from "../helpers/getLanguage";
@@ -9,27 +9,59 @@ import parseSlug from "../stringProcessing/parseSlug";
 import { normalizeSingle } from "../stringProcessing/quotes";
 import { collectStems } from "./buildTopicStems";
 
+/**
+ * A stem with accompanying forms.
+ *
+ * @param {string}      stem    The word stem.
+ * @param {string[]}    forms   The word forms for the stem.
+ *
+ * @constructor
+ */
 function StemWithForms( stem, forms ) {
 	this.stem = stem;
 	this.forms = forms;
 }
 
-function Result( keyphraseStems = [], synonymsStems = [] ) {
-	this.keyphraseForms = keyphraseStems;
-	this.synonymsForms = synonymsStems;
+/**
+ * A result for all topic forms.
+ *
+ * @param {string[]}    keyphraseForms  All keyphrase forms.
+ * @param {Array<string[]>[]}    synonymsForms   All synonym forms.
+ * @constructor
+ */
+function Result( keyphraseForms = [], synonymsForms = [] ) {
+	this.keyphraseForms = keyphraseForms;
+	this.synonymsForms = synonymsForms;
 }
 
-
-
-function getAllWordsFromPaper( paper ) {
+/**
+ * Gets all words found in the text, title, slug and meta description of a given paper.
+ *
+ * @param {Paper} paper     The paper for which to get the words.
+ * @param {string} language The language of the paper.
+ *
+ * @returns {string[]} All words found.
+ */
+function getAllWordsFromPaper( paper, language ) {
 	const wordsText = getWords( paper.getText() );
 	const wordsTitle = getWords( paper.getTitle() );
 	const wordsSlug = getWords( parseSlug( paper.getUrl() ) );
 	const wordsMetaDescription = getWords( paper.getDescription() );
 
-	return [ ...wordsText, ...wordsTitle, ...wordsSlug, ...wordsMetaDescription ];
+	return [ ...wordsText, ...wordsTitle, ...wordsSlug, ...wordsMetaDescription ].map(
+		word => normalizeSingle( escapeRegExp( word.toLocaleLowerCase( language ) ) ) );
 }
 
+/**
+ * Takes a stem-original pair and returns the accompanying forms for the stem that were found in the paper. Additionally
+ * adds a sanitized version of the original word.
+ *
+ * @param {StemOriginalPair}    stemOriginalPair            The stem-original pair for which to get forms.
+ * @param {StemWithForms[]}     paperWordsGroupedByStems    All word forms in the paper grouped by stem.
+ * @param {string}              language                    The language for which to get forms.
+ *
+ * @returns {string[]} All forms found in the paper for the given stem, plus a sanitized version of the original word.
+ */
 function replaceStemWithForms( stemOriginalPair, paperWordsGroupedByStems, language ) {
 	const matchingStemFormPair = paperWordsGroupedByStems.find( element => element.stem === stemOriginalPair.stem );
 	const originalSanitized = normalizeSingle( escapeRegExp( stemOriginalPair.original.toLocaleLowerCase( language ) ) );
@@ -40,6 +72,14 @@ function replaceStemWithForms( stemOriginalPair, paperWordsGroupedByStems, langu
 		: [ originalSanitized ];
 }
 
+/**
+ * Extracts the stems from all keyphrase and synonym stems.
+ *
+ * @param {TopicPhrase|[]}   keyphraseStems  A topic phrase or an empty array.
+ * @param {TopicPhrase[]}    synonymsStems   An array of topic phrases.
+ *
+ * @returns {string[]} All word stems of they keyphrase and synonyms.
+ */
 function extractStems( keyphraseStems, synonymsStems ) {
 	const keyphraseStemsOnly = keyphraseStems.length === 0
 		? []
@@ -52,6 +92,15 @@ function extractStems( keyphraseStems, synonymsStems ) {
 	return ( [ ...keyphraseStemsOnly, ...flattenDeep( synonymsStemsOnly ) ] );
 }
 
+/**
+ * Constructs the result with forms for a topic phrase (i.e., a keyphrase or a synonym).
+ *
+ * @param {TopicPhrase}     topicPhrase                 The topic phrase for which to construct the result.
+ * @param {StemWithForms[]} paperWordsGroupedByStems    All word forms in the paper grouped by stem.
+ * @param {string}          language                    The language of the paper.
+ *
+ * @returns {Array.<string[]>} The word forms for a given topic phrase, grouped by original topic phrase word.
+ */
 function constructTopicPhraseResult( topicPhrase, paperWordsGroupedByStems, language ) {
 	// Empty result for an empty topic phrase.
 	if ( topicPhrase.length === 0 ) {
@@ -67,6 +116,15 @@ function constructTopicPhraseResult( topicPhrase, paperWordsGroupedByStems, lang
 	} );
 }
 
+/**
+ * Gets all word forms from a paper for the stems of the keyphrase and synonyms.
+ *
+ * @param {Paper}       paper       The paper to build keyphrase and synonym forms for.
+ * @param {Researcher}  researcher  The researcher.
+ *
+ * @returns {Object} Object with an array of keyphrase forms and an array of arrays of synonyms forms, based on the forms
+ * found in the text.
+ */
 function getWordFormsFromText( paper, researcher ) {
 	const language = getLanguage( paper.getLocale() );
 	const determineStem = retrieveStemmer( language );
@@ -75,7 +133,7 @@ function getWordFormsFromText( paper, researcher ) {
 	const keyphraseStems = topicStems.keyphraseStems;
 	const synonymsStems = topicStems.synonymsStems;
 
-	// Return an empty result when there are no keyphrase and synonyms have been set.
+	// Return an empty result when no keyphrase and synonyms have been set.
 	if ( keyphraseStems.length === 0 && synonymsStems.length === 0 ) {
 		return new Result();
 	}
@@ -83,21 +141,18 @@ function getWordFormsFromText( paper, researcher ) {
 	// Get all stems from the keyphrase and synonyms.
 	const keyphraseStemsFlat = uniq( extractStems( keyphraseStems, synonymsStems ) );
 
-	console.log( "keyphraseStemsFlat", keyphraseStemsFlat );
-
-	// Get words from the paper text, title, meta description and slug.
-	let paperWords = getAllWordsFromPaper( paper );
+	// Get all words from the paper text, title, meta description and slug.
+	let paperWords = getAllWordsFromPaper( paper, language );
 
 	// Filter doubles and function words.
-	paperWords = uniq( paperWords );
-	paperWords = filterFunctionWordsFromArray( paperWords, language );
+	paperWords = filterFunctionWordsFromArray( uniq( paperWords ), language );
 
 	// Add stems to words from the paper and filter out all forms that aren't in the keyphrase or synonyms.
 	const paperWordsWithStems = paperWords
 		.map( word => [ word, determineStem( word, morphologyData ) ] )
 		.filter( wordStemPair => keyphraseStemsFlat.includes( wordStemPair[ 1 ] ) );
 
-	// Group word-stem pairs from the paper content by stems.
+	// Group word-stem pairs from the paper by stems.
 	const paperWordsGroupedByStems = paperWordsWithStems.reduce( function( accumulator, wordStemPair ) {
 		const stem = wordStemPair[ 1 ];
 		const form = wordStemPair[ 0 ];
@@ -105,10 +160,10 @@ function getWordFormsFromText( paper, researcher ) {
 		const matchingStemFormPair = accumulator.find( element => element.stem === stem );
 		const matchingStemFormPairIndex = accumulator.findIndex( element => element.stem === stem );
 
-		if ( ! matchingStemFormPair ) {
-			accumulator.push( new StemWithForms( stem, [ form ] ) );
-		} else {
+		if ( matchingStemFormPair ) {
 			accumulator[ matchingStemFormPairIndex ].forms.push( form );
+		} else {
+			accumulator.push( new StemWithForms( stem, [ form ] ) );
 		}
 
 		return accumulator;

--- a/packages/yoastseo/src/researches/getWordFormsFromText.js
+++ b/packages/yoastseo/src/researches/getWordFormsFromText.js
@@ -41,10 +41,12 @@ function getAllWordsFromPaper( paper ) {
 
 function replaceStemWithForms( stemOriginalPair, paperWordsGroupedByStems, language ) {
 	const matchingStemFormPair = paperWordsGroupedByStems.find( element => element.stem === stemOriginalPair.stem );
+	const originalSanitized = normalizeSingle( escapeRegExp( stemOriginalPair.original.toLocaleLowerCase( language ) ) );
 
+	// Return original and found forms or only original if no matching forms were found in the text.
 	return matchingStemFormPair
-		? matchingStemFormPair.forms
-		: [ normalizeSingle( escapeRegExp( stemOriginalPair.original.toLocaleLowerCase( language ) ) ) ];
+		? uniq( [ originalSanitized, ...matchingStemFormPair.forms ] )
+		: [ originalSanitized ];
 }
 
 function extractStems( keyphraseStems, synonymsStems ) {

--- a/packages/yoastseo/src/researches/getWordFormsFromText.js
+++ b/packages/yoastseo/src/researches/getWordFormsFromText.js
@@ -81,7 +81,7 @@ function replaceStemWithForms( stemOriginalPair, paperWordsGroupedByStems, langu
  * @returns {string[]} All word stems of they keyphrase and synonyms.
  */
 function extractStems( keyphrase, synonyms ) {
-	const keyphraseStemsOnly = keyphrase.length === 0
+	const keyphraseStemsOnly = keyphrase.stemOriginalPairs.length === 0
 		? []
 		: keyphrase.getStems();
 
@@ -134,7 +134,7 @@ function getWordFormsFromText( paper, researcher ) {
 	const synonyms = topicPhrases.synonymsStems;
 
 	// Return an empty result when no keyphrase and synonyms have been set.
-	if ( keyphrase.length === 0 && synonyms.length === 0 ) {
+	if ( keyphrase.stemOriginalPairs.length === 0 && synonyms.length === 0 ) {
 		return new Result();
 	}
 

--- a/packages/yoastseo/src/researches/getWordFormsFromText.js
+++ b/packages/yoastseo/src/researches/getWordFormsFromText.js
@@ -1,4 +1,4 @@
-import { escapeRegExp, get, groupBy, uniq } from "lodash-es";
+import { escapeRegExp, get, uniq } from "lodash-es";
 import flattenDeep from "lodash-es/flattenDeep";
 import filterFunctionWordsFromArray from "../helpers/filterFunctionWordsFromArray";
 import getLanguage from "../helpers/getLanguage";
@@ -140,6 +140,17 @@ function getWordFormsFromText( paper, researcher ) {
 		return new Result();
 	}
 
+	// Return exact match if all topic phrases contain exact match. Forms don't need to be built in that case.
+	const allTopicPhrases = [ keyphrase, ...synonyms ];
+
+	if ( allTopicPhrases.every( topicPhrase => topicPhrase.exactMatch === true ) ) {
+		return new Result(
+			[ [ keyphrase.stemOriginalPairs[ 0 ].stem ] ],
+			synonyms.map( synonym => [ [ synonym.stemOriginalPairs[ 0 ].stem ] ]
+			)
+		);
+	}
+
 	// Get all stems from the keyphrase and synonyms.
 	const topicStemsFlat = uniq( extractStems( keyphrase, synonyms ) );
 
@@ -170,7 +181,8 @@ function getWordFormsFromText( paper, researcher ) {
 
 	return new Result(
 		constructTopicPhraseResult( keyphrase, paperWordsGroupedByStems, language ),
-		synonyms.map( synonym => constructTopicPhraseResult( synonym, paperWordsGroupedByStems, language ) ) );
+		synonyms.map( synonym => constructTopicPhraseResult( synonym, paperWordsGroupedByStems, language ) )
+	);
 }
 
 export default getWordFormsFromText;

--- a/packages/yoastseo/src/researches/getWordFormsFromText.js
+++ b/packages/yoastseo/src/researches/getWordFormsFromText.js
@@ -5,6 +5,7 @@ import getLanguage from "../helpers/getLanguage";
 import retrieveStemmer from "../helpers/retrieveStemmer";
 
 import getWords from "../stringProcessing/getWords";
+import parseSlug from "../stringProcessing/parseSlug";
 import { normalizeSingle } from "../stringProcessing/quotes";
 import { collectStems } from "./buildTopicStems";
 
@@ -23,7 +24,7 @@ function Result( keyphraseStems = [], synonymsStems = [] ) {
 function getAllWordsFromPaper( paper ) {
 	const wordsText = getWords( paper.getText() );
 	const wordsTitle = getWords( paper.getTitle() );
-	const wordsSlug = getWords( paper.getUrl().replace( /[-_]/ig, " " ) );
+	const wordsSlug = getWords( parseSlug( paper.getUrl() ) );
 	const wordsMetaDescription = getWords( paper.getDescription() );
 
 	return [ ...wordsText, ...wordsTitle, ...wordsSlug, ...wordsMetaDescription ];

--- a/packages/yoastseo/src/researches/getWordFormsFromText.js
+++ b/packages/yoastseo/src/researches/getWordFormsFromText.js
@@ -1,0 +1,129 @@
+import { escapeRegExp, get, includes, uniq } from "lodash-es";
+import flattenDeep from "lodash-es/flattenDeep";
+import filterFunctionWordsFromArray from "../helpers/filterFunctionWordsFromArray";
+import getLanguage from "../helpers/getLanguage";
+import getStemForLanguageFactory from "../helpers/getStemForLanguage";
+const stemFunctions = getStemForLanguageFactory();
+
+import getWords from "../stringProcessing/getWords";
+import { normalizeSingle } from "../stringProcessing/quotes";
+import { collectStems } from "./buildTopicStems";
+
+function StemWithForms( stem, forms ) {
+	this.stem = stem;
+	this.forms = forms;
+}
+
+function Result( keyphraseStems = [], synonymsStems = [] ) {
+	this.keyphraseForms = keyphraseStems;
+	this.synonymsForms = synonymsStems;
+}
+
+/**
+ * Retrieves a stemmer function from the factory. Returns the identity function if the language does not have a stemmer.
+ *
+ * @param {string} language The language to retrieve a stemmer function for.
+ *
+ * @returns {Function} A stemmer function for the language.
+ */
+function retrieveStemmer( language ) {
+	return get( stemFunctions, language, word => word );
+}
+
+function getAllWordsFromPaper( paper ) {
+	const wordsText = getWords( paper.getText() );
+	const wordsTitle = getWords( paper.getTitle() );
+	const wordsSlug = getWords( paper.getUrl().replace( /[-_]/ig, " " ) );
+	const wordsMetaDescription = getWords( paper.getDescription() );
+
+	return [ ...wordsText, ...wordsTitle, ...wordsSlug, ...wordsMetaDescription ];
+}
+
+function replaceStemWithForms( stemOriginalPair, paperWordsGroupedByStems, language ) {
+	const matchingStemFormPair = paperWordsGroupedByStems.find( element => element.stem === stemOriginalPair.stem );
+
+	return matchingStemFormPair
+		? matchingStemFormPair.forms
+		: [ normalizeSingle( escapeRegExp( stemOriginalPair.original.toLocaleLowerCase( language ) ) ) ];
+}
+
+function extractStems( keyphraseStems, synonymsStems ) {
+	const keyphraseStemsOnly = keyphraseStems.length === 0
+		? []
+		: keyphraseStems.getStems();
+
+	const synonymsStemsOnly = synonymsStems.length === 0
+		? []
+		: synonymsStems.map( topicPhrase => topicPhrase.getStems() );
+
+	return ( [ ...keyphraseStemsOnly, ...flattenDeep( synonymsStemsOnly ) ] );
+}
+
+function constructTopicPhraseResult( topicPhrase, paperWordsGroupedByStems, language ) {
+	// Empty result for an empty topic phrase.
+	if ( topicPhrase.length === 0 ) {
+		return [];
+	}
+
+	if ( topicPhrase.exactMatch ) {
+		return [ [ topicPhrase.stemOriginalPairs[ 0 ].stem ] ];
+	}
+
+	return topicPhrase.stemOriginalPairs.map( function( stemOriginalPair ) {
+		return replaceStemWithForms( stemOriginalPair, paperWordsGroupedByStems, language );
+	} );
+}
+
+function getWordFormsFromText( paper, researcher ) {
+	const language = getLanguage( paper.getLocale() );
+	const determineStem = retrieveStemmer( language );
+	const morphologyData = get( researcher.getData( "morphology" ), language, false );
+	const topicStems = collectStems( paper.getKeyword(), paper.getSynonyms(), language, morphologyData );
+	const keyphraseStems = topicStems.keyphraseStems;
+	const synonymsStems = topicStems.synonymsStems;
+
+	// Return an empty result when there are no keyphrase and synonyms have been set.
+	if ( keyphraseStems.length === 0 && synonymsStems.length === 0 ) {
+		return new Result();
+	}
+
+	// Get all stems from the keyphrase and synonyms.
+	const keyphraseStemsFlat = uniq( extractStems( keyphraseStems, synonymsStems ) );
+
+	console.log( "keyphraseStemsFlat", keyphraseStemsFlat );
+
+	// Get words from the paper text, title, meta description and slug.
+	let paperWords = getAllWordsFromPaper( paper );
+
+	// Filter doubles and function words.
+	paperWords = uniq( paperWords );
+	paperWords = filterFunctionWordsFromArray( paperWords, language );
+
+	// Add stems to words from the paper and filter out all forms that aren't in the keyphrase or synonyms.
+	const paperWordsWithStems = paperWords
+		.map( word => [ word, determineStem( word, morphologyData ) ] )
+		.filter( wordStemPair => keyphraseStemsFlat.includes( wordStemPair[ 1 ] ) );
+
+	// Group word-stem pairs from the paper content by stems.
+	const paperWordsGroupedByStems = paperWordsWithStems.reduce( function( accumulator, wordStemPair ) {
+		const stem = wordStemPair[ 1 ];
+		const form = wordStemPair[ 0 ];
+
+		const matchingStemFormPair = accumulator.find( element => element.stem === stem );
+		const matchingStemFormPairIndex = accumulator.findIndex( element => element.stem === stem );
+
+		if ( ! matchingStemFormPair ) {
+			accumulator.push( new StemWithForms( stem, [ form ] ) );
+		} else {
+			accumulator[ matchingStemFormPairIndex ].forms.push( form );
+		}
+
+		return accumulator;
+	}, [] );
+
+	return new Result(
+		constructTopicPhraseResult( keyphraseStems, paperWordsGroupedByStems, language ),
+		synonymsStems.map( synonymsStem => constructTopicPhraseResult( synonymsStem, paperWordsGroupedByStems, language ) ) );
+}
+
+export default getWordFormsFromText;

--- a/packages/yoastseo/src/researches/getWordFormsFromText.js
+++ b/packages/yoastseo/src/researches/getWordFormsFromText.js
@@ -43,12 +43,14 @@ function Result( keyphraseForms = [], synonymsForms = [] ) {
  * @returns {string[]} All words found.
  */
 function getAllWordsFromPaper( paper, language ) {
-	const wordsText = getWords( paper.getText() );
-	const wordsTitle = getWords( paper.getTitle() );
-	const wordsSlug = getWords( parseSlug( paper.getUrl() ) );
-	const wordsMetaDescription = getWords( paper.getDescription() );
+	const paperContent = [
+		paper.getText(),
+		paper.getTitle(),
+		parseSlug( paper.getUrl() ),
+		paper.getDescription(),
+	].join( " " );
 
-	return [ ...wordsText, ...wordsTitle, ...wordsSlug, ...wordsMetaDescription ].map(
+	return getWords( paperContent ).map(
 		word => normalizeSingle( escapeRegExp( word.toLocaleLowerCase( language ) ) ) );
 }
 

--- a/packages/yoastseo/src/researches/keywordCountInUrl.js
+++ b/packages/yoastseo/src/researches/keywordCountInUrl.js
@@ -1,5 +1,6 @@
 /** @module researches/countKeywordInUrl */
 
+import parseSlug from "../stringProcessing/parseSlug";
 import { findTopicFormsInString } from "./findKeywordFormsInString.js";
 
 /**
@@ -12,7 +13,7 @@ import { findTopicFormsInString } from "./findKeywordFormsInString.js";
  */
 export default function( paper, researcher ) {
 	const topicForms = researcher.getResearch( "morphology" );
-	const slug = paper.getUrl().replace( /[-_]/ig, " " );
+	const slug = parseSlug( paper.getUrl() );
 
 	const keyphraseInSlug = findTopicFormsInString( topicForms, slug, false, paper.getLocale() );
 

--- a/packages/yoastseo/src/stringProcessing/determineProminentWords.js
+++ b/packages/yoastseo/src/stringProcessing/determineProminentWords.js
@@ -1,15 +1,14 @@
 import { get } from "lodash-es";
 import { memoize } from "lodash-es";
 import { uniq } from "lodash-es";
+import retrieveStemmer from "../helpers/retrieveStemmer";
 
 import getWords from "../stringProcessing/getWords";
 import { normalizeSingle } from "../stringProcessing/quotes";
 import ProminentWord from "../values/ProminentWord";
 import functionWordListsFactory from "../helpers/getFunctionWords";
-import getStemForLanguageFactory from "../helpers/getStemForLanguage";
 
 const functionWordLists = functionWordListsFactory();
-const stemFunctions = getStemForLanguageFactory();
 const specialCharacters = /[1234567890‘’“”"'.…?!:;,¿¡«»&*@#±^%$|~=+§`[\](){}⟨⟩<>/\\–\-\u2014\u00d7\s]/g;
 
 /**
@@ -114,17 +113,6 @@ function collapseProminentWordsOnStem( prominentWords ) {
  */
 function retrieveFunctionWords( language ) {
 	return get( functionWordLists, language.concat( ".all" ), [] );
-}
-
-/**
- * Retrieves a stemmer function from the factory. Returns the identity function if the language does not have a stemmer.
- *
- * @param {string} language The language to retrieve a stemmer function for.
- *
- * @returns {Function} A stemmer function for the language.
- */
-function retrieveStemmer( language ) {
-	return get( stemFunctions, language, word => word );
 }
 
 /**

--- a/packages/yoastseo/src/stringProcessing/parseSlug.js
+++ b/packages/yoastseo/src/stringProcessing/parseSlug.js
@@ -1,0 +1,10 @@
+/**
+ * Parses the slug by transforming hyphens and underscores into white space.
+ *
+ * @param {string} slug The slug to parse
+ *
+ * @returns {string} The parsed slug.
+ */
+export default function( slug ) {
+	return slug.replace( /[-_]/ig, " " );
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ...
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds a `getWordFormsFromText` research which, based on a stemmed keyphrase, gets all word forms of the keyphrase from the paper.

## Relevant technical choices:
* The original form as found in the keyphrase (with additional sanitization) is always added to the forms. This is done to ensure that even if stemming fails, we can still match the original form.
* I didn't add memoization. I think that practically any change in the paper (modifying the keyphrase, but also modifying the text, meta description, title or slug) will require the research to be re-run. In other words, it should be re-run more or less every time an `analyze` request is triggered on the webworker. That's why I didn't see a meaningful way of implementing memoization. I think we should brainstorm a bit if there are meaningful ways to add caching; I've made a separate issue for this: https://yoast.atlassian.net/browse/LIN-201
* Compared to the previous functionality, treatment of keyphrases consisting of only function words is different, see this issue https://yoast.atlassian.net/browse/LIN-200. Keyphrases only consisting of function words are a relatively minor edge case on their own. Additionally, this change in treatment is not a clear deterioration compared to an ideal scenario. Therefore, this change can be deemed as very minor.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add more specs, making use of the following variations:
  * Include the keyphrase in the paper text, title, slug (attribute "Url") and meta description
  * Use full match keyphrases and/or synonyms
  * Test languages with and without morphology support
  * Test languages with morphology support but switch off morphology (i.e., mimic Free)
  * Test languages with and without function word support
  * Test any other variations you can think of

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-151
