### PR TITLE
Flatten object with words not to be stemmed

### DIFF
--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -2,6 +2,7 @@ import { checkIfWordEndingIsOnExceptionList } from "../morphoHelpers/exceptionLi
 import { removeSuffixFromFullForm } from "../morphoHelpers/stemHelpers";
 import { isVowelDoublingAllowed } from "./stemModificationHelpers";
 import { generateCorrectStemWithTAndDEnding } from "./getStemWordsWithTAndDEnding.js";
+import { flatten } from "lodash-es";
 
 /**
  * @file Dutch stemming algorithm. Adapted from:
@@ -193,7 +194,9 @@ const removeSuffixFromFullForms = function( exceptionsRemoveSuffixFromFullForms,
  */
 export default function stem( word, morphologyDataNL ) {
 	// Check whether the word is on an exception list of words that shouldn't be stemmed. If it is, return the word.
-	if ( checkIfWordEndingIsOnExceptionList( word, morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions ) ) {
+	const wordsNotToBeStemmed = flatten( Object.values( morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions ) )
+
+	if ( checkIfWordEndingIsOnExceptionList( word, wordsNotToBeStemmed ) ) {
 		return word;
 	}
 

--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -194,7 +194,7 @@ const removeSuffixFromFullForms = function( exceptionsRemoveSuffixFromFullForms,
  */
 export default function stem( word, morphologyDataNL ) {
 	// Check whether the word is on an exception list of words that shouldn't be stemmed. If it is, return the word.
-	const wordsNotToBeStemmed = flatten( Object.values( morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions ) )
+	const wordsNotToBeStemmed = flatten( Object.values( morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions ) );
 
 	if ( checkIfWordEndingIsOnExceptionList( word, wordsNotToBeStemmed ) ) {
 		return word;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adapts the Dutch stemming function to work with changes in the data file.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
