### PR TITLE
Check whether the -t/d at the end of a detected participle should be stemmed or not

### DIFF
--- a/packages/yoastseo/spec/morphology/dutch/detectAndStemRegularParticipleSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/detectAndStemRegularParticipleSpec.js
@@ -6,37 +6,61 @@ const morphologyDataNL = getMorphologyData( "nl" ).nl;
 
 describe( "Detects and stems participles", () => {
 	it( "does not stem a word if it is on an exception list of non-participles", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL.verbs, "geduld" ) ).toEqual( "" );
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "geduld" ) ).toEqual( "" );
 	} );
 	it( "does not stem a word if it ends with one of the non-participle endings", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL.verbs, "geaardheid" ) ).toEqual( "" );
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "geaardheid" ) ).toEqual( "" );
 	} );
 	it( "does not stem a word that does not match any of the participle stemming regexes", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL.verbs, "afgeladen" ) ).toEqual( null );
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "afgeladen" ) ).toEqual( null );
 	} );
 	it( "correctly stems a regular participle without prefixes", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL.verbs, "geaaid" ) ).toEqual( "aai" );
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "geaaid" ) ).toEqual( "aai" );
 	} );
 	it( "correctly stems a regular participle with a separable prefix", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL.verbs, "aangebeld" ) ).toEqual( "aanbel" );
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "aangebeld" ) ).toEqual( "aanbel" );
 	} );
 	it( "correctly stems a regular participle with an inseparable prefix", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL.verbs, "herhaald" ) ).toEqual( "herhaal" );
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "herhaald" ) ).toEqual( "herhaal" );
 	} );
 	it( "correctly stems a regular participle with an inseparable prefix that is usually separable", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL.verbs, "omwikkeld" ) ).toEqual( "omwikkel" );
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "omwikkeld" ) ).toEqual( "omwikkel" );
 	} );
 	it( "returns the participle if it is the same as the stem", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL.verbs, "misleid" ) ).toEqual( "misleid" );
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "misleid" ) ).toEqual( "misleid" );
 	} );
 	it( "if the stem of the participle begins in ge-, the ge- does not get stemmed", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL.verbs, "gebruikt" ) ).toEqual( "gebruik" );
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "gebruikt" ) ).toEqual( "gebruik" );
 	} );
 	it( "if the ge- following a separable prefix is part of the stem, it should not be stemmed", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL.verbs, "opgebruikt" ) ).toEqual( "opgebruik" );
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "opgebruikt" ) ).toEqual( "opgebruik" );
 	} );
 	it( "correctly stems a participle with a separable prefix beginning in her- (herop- in this case), even though the her- " +
 		"prefix on its own is inseparable", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL.verbs, "heropgebouwd" ) ).toEqual( "heropbouw" );
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "heropgebouwd" ) ).toEqual( "heropbouw" );
+	} );
+	it( "correctly stems a participle that is found on the list of verbs for which -t should be stemmed (exception to a rule)", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "gestretcht" ) ).toEqual( "stretch" );
+	} );
+	it( "correctly stems a participle that matches the regex for when -t should not be stemmed.", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "gegroet" ) ).toEqual( "groet" );
+	} );
+	it( "correctly stems a participle that is found on the list of verbs for which -t should not be stemmed.", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "getest" ) ).toEqual( "test" );
+	} );
+	it( "correctly stems a compound participle that is matches the regex for when -t should not be stemmed.", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "verzoet" ) ).toEqual( "verzoet" );
+	} );
+	it( "correctly stems a compound participle that is found on the list of verbs for which -t should not be stemmed.", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "aangevat" ) ).toEqual( "aanvat" );
+	} );
+	it( "correctly stems a participle that is found on the list of verbs for which -d should not be stemmed.", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "geleid" ) ).toEqual( "leid" );
+	} );
+	it( "correctly stems a participle of a compound verb that is found on the list of verbs for which -d should not be stemmed.", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "aangemeld" ) ).toEqual( "aanmeld" );
+	} );
+	it( "correctly stems a participle of a compound verb that is found on the list of verbs for which -t should not be stemmed.", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "afgemest" ) ).toEqual( "afmest" );
 	} );
 } );

--- a/packages/yoastseo/spec/morphology/dutch/detectAndStemRegularParticipleSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/detectAndStemRegularParticipleSpec.js
@@ -36,31 +36,35 @@ describe( "Detects and stems participles", () => {
 		expect( detectAndStemRegularParticiple( morphologyDataNL, "opgebruikt" ) ).toEqual( "opgebruik" );
 	} );
 	it( "correctly stems a participle with a separable prefix beginning in her- (herop- in this case), even though the her- " +
-		"prefix on its own is inseparable", () => {
+		"prefix on its own is inseparable. Condition: compoundVerbsPrefixes.separable + participle", () => {
 		expect( detectAndStemRegularParticiple( morphologyDataNL, "heropgebouwd" ) ).toEqual( "heropbouw" );
 	} );
-	it( "correctly stems a participle that is found on the list of verbs for which -t should be stemmed (exception to a rule)", () => {
+	it( "correctly stems a participle that is found on the list of verbs for which -t should be stemmed (exception to a rule)" +
+		"Condition: matched by verbsTShouldBeStemmed exception list", () => {
 		expect( detectAndStemRegularParticiple( morphologyDataNL, "gestretcht" ) ).toEqual( "stretch" );
 	} );
-	it( "correctly stems a participle that matches the regex for when -t should not be stemmed.", () => {
+	it( "correctly stems a participle that matches the regex for when -t should not be stemmed." +
+		"Condition: matched by tOrDArePartOfStem.tEnding regex", () => {
 		expect( detectAndStemRegularParticiple( morphologyDataNL, "gegroet" ) ).toEqual( "groet" );
 	} );
-	it( "correctly stems a participle that is found on the list of verbs for which -t should not be stemmed.", () => {
+	it( "correctly stems a participle that is found on the list of verbs for which -t should not be stemmed." +
+		"Condition: word on wordsNotToBeStemmedExceptions.verbStemEndingInT exception list", () => {
 		expect( detectAndStemRegularParticiple( morphologyDataNL, "getest" ) ).toEqual( "test" );
 	} );
-	it( "correctly stems a compound participle that is matches the regex for when -t should not be stemmed.", () => {
+	it( "correctly stems a compound participle that is matched by the regex for when -t should not be stemmed." +
+		"Condition: compound participle matched by tOrDArePartOfStem.tEnding regex", () => {
 		expect( detectAndStemRegularParticiple( morphologyDataNL, "verzoet" ) ).toEqual( "verzoet" );
 	} );
-	it( "correctly stems a compound participle that is found on the list of verbs for which -t should not be stemmed.", () => {
+	it( "correctly stems a compound participle that is found on the list of verbs for which -t should not be stemmed." +
+		"Condition: compound matched by wordsNotToBeStemmedExceptions.verbStemEndingInT exception list", () => {
 		expect( detectAndStemRegularParticiple( morphologyDataNL, "aangevat" ) ).toEqual( "aanvat" );
 	} );
-	it( "correctly stems a participle that is found on the list of verbs for which -d should not be stemmed.", () => {
+	it( "correctly stems a participle that is found on the list of verbs for which -d should not be stemmed." +
+		"Condition: word is on doNotStemD exception list", () => {
 		expect( detectAndStemRegularParticiple( morphologyDataNL, "geleid" ) ).toEqual( "leid" );
 	} );
-	it( "correctly stems a participle of a compound verb that is found on the list of verbs for which -d should not be stemmed.", () => {
+	it( "correctly stems a participle of a compound verb that is found on the list of verbs for which -d should not be stemmed." +
+		"Condition: compound matched by doNotStemD exception list", () => {
 		expect( detectAndStemRegularParticiple( morphologyDataNL, "aangemeld" ) ).toEqual( "aanmeld" );
-	} );
-	it( "correctly stems a participle of a compound verb that is found on the list of verbs for which -t should not be stemmed.", () => {
-		expect( detectAndStemRegularParticiple( morphologyDataNL, "afgemest" ) ).toEqual( "afmest" );
 	} );
 } );

--- a/packages/yoastseo/spec/morphology/dutch/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/stemSpec.js
@@ -65,8 +65,6 @@ const wordsToStem = [
 	[ "tevreeër", "tevree" ],
 	// Suffix -st preceded by a valid -st ending.
 	[ "warmst", "warm" ],
-	// Suffix -st preceded by a vowel and e.
-	[ "tevreest", "tevree" ],
 	// Suffix -est.
 	[ "mooiest", "mooi" ],
 	// Suffix -er preceded by a vowel and i.

--- a/packages/yoastseo/src/morphology/dutch/createSecondStemWithoutAmbiguousEnding.js
+++ b/packages/yoastseo/src/morphology/dutch/createSecondStemWithoutAmbiguousEnding.js
@@ -16,7 +16,7 @@ import { generateCorrectStemWithTAndDEnding } from "./getStemWordsWithTAndDEndin
  * @returns {?string}				    The stemmed word or null if the -t/-d should not be stemmed.
  */
 export function createSecondStemWithoutAmbiguousEnding( morphologyDataNL, stemmedWord, word ) {
-	if ( detectAndStemRegularParticiple( morphologyDataNL.verbs, word ) ||
+	if ( detectAndStemRegularParticiple( morphologyDataNL, word ) ||
 		generateCorrectStemWithTAndDEnding( morphologyDataNL.stemming, word ||
 		checkIfWordEndingIsOnExceptionList( word, morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions ) ) ) {
 		return null;

--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -2,6 +2,7 @@ import { checkIfWordEndingIsOnExceptionList } from "../morphoHelpers/exceptionLi
 import { removeSuffixFromFullForm } from "../morphoHelpers/stemHelpers";
 import { isVowelDoublingAllowed } from "./stemModificationHelpers";
 import { generateCorrectStemWithTAndDEnding } from "./getStemWordsWithTAndDEnding.js";
+import { flatten } from "lodash-es";
 
 /**
  * @file Dutch stemming algorithm. Adapted from:
@@ -193,7 +194,8 @@ const removeSuffixFromFullForms = function( exceptionsRemoveSuffixFromFullForms,
  */
 export default function stem( word, morphologyDataNL ) {
 	// Check whether the word is on an exception list of words that shouldn't be stemmed. If it is, return the word.
-	if ( checkIfWordEndingIsOnExceptionList( word, morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions ) ) {
+	const wordsThatShouldNotBeStemmed = flatten( Object.values( morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions ) );
+	if ( checkIfWordEndingIsOnExceptionList( word, wordsThatShouldNotBeStemmed ) ) {
 		return word;
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds a check to the Dutch participle stemmer to make sure that when word-final -t/-d is part of the stem, it does not get stemmed.

## Relevant technical choices:

* We use an exception list of verbs ending in -t that shouldn't be stemmed for one of the checks. This list is part of the larger 'wordsNotToBeStemmed' object that is checked at the beginning of the non-participle stemmer. The verbs ending in -t were separated from the other words and listed as a separate array inside of the object. Because of this new nested structure, the object is now flattened before checking the list in stem.js

* The list of verbs ending in -t that shouldn't be stemmed was also expanded with some additional entries. The word 'eest' was added, which caused the adjective 'tevreest' to not be stemmed anymore in stemSpec.js. This is because we check whether the current word ends with an entry from the exception list of words that shouldn't be stemmed, and 'tevreest' ends with 'eest'. This will be fixed after dividing the exception lists into those where we match with the ending of the word, and those where we look for the exact match. This will be a separate issue. For now, 'tevreest' was removed from stemSpec.js to avoid failed tests.

## Test instructions

This PR can be tested by following these steps:

* Add more examples of participles that fall under the added exception checks to the specs, and make sure that they are stemmed correctly.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended
