### PR TITLE
Adds morphology data check in retrieveStemmer

### DIFF
--- a/packages/yoastseo/spec/helpers/retrieveStemmerSpec.js
+++ b/packages/yoastseo/spec/helpers/retrieveStemmerSpec.js
@@ -1,0 +1,22 @@
+import { determineStem as determineStemEnglish } from "../../src/morphology/english/determineStem";
+import retrieveStemmer from "../../src/helpers/retrieveStemmer";
+import getMorphologyData from "../specHelpers/getMorphologyData";
+
+describe( "tests whether the correct stemming function is retrieved", () => {
+	it( "checks that a stemming function is returned for a given locale if there is a stemming function for that locale" +
+		"and morphology data is available", () => {
+		const morphologyData = getMorphologyData( "en" );
+
+		expect( retrieveStemmer( "en", morphologyData ) ).toEqual( determineStemEnglish );
+	} );
+
+	it( "checks that an identity function is returned for a given locale if there is a stemming function for that locale" +
+		"but morphology data is not available", () => {
+		expect( retrieveStemmer( "en", false )( "test" ) ).toEqual( "test" );
+	} );
+
+	it( "checks that an identity function is returned for a given locale if there is no stemming function for that locale" +
+		"and morphology data is not available", () => {
+		expect( retrieveStemmer( "fr", false )( "test" ) ).toEqual( "test" );
+	} );
+} );

--- a/packages/yoastseo/spec/morphology/english/determineStemEnglishSpec.js
+++ b/packages/yoastseo/spec/morphology/english/determineStemEnglishSpec.js
@@ -303,12 +303,4 @@ describe( "determineStem", function() {
 		expect( determineStem( "best", morphologyDataEN ) ).toEqual( "good" );
 		expect( determineStem( "goods", morphologyDataEN ) ).toEqual( "good" );
 	} );
-
-	it( "returns the word itself if no morphologyData is available", function() {
-		expect( determineStem( "good", false ) ).toEqual( "good" );
-		expect( determineStem( "well", false ) ).toEqual( "well" );
-		expect( determineStem( "better", false ) ).toEqual( "better" );
-		expect( determineStem( "best", false ) ).toEqual( "best" );
-		expect( determineStem( "goods", false ) ).toEqual( "goods" );
-	} );
 } );

--- a/packages/yoastseo/src/helpers/retrieveStemmer.js
+++ b/packages/yoastseo/src/helpers/retrieveStemmer.js
@@ -1,15 +1,24 @@
-import { get } from "lodash-es";
 import getStemForLanguageFactory from "../helpers/getStemForLanguage";
 const stemFunctions = getStemForLanguageFactory();
 
 
 /**
- * Retrieves a stemmer function from the factory. Returns the identity function if the language does not have a stemmer.
+ * Retrieves a stemmer function from the factory.
+ * Returns the identity function if the language does not have a stemmer or if morphology data isn't available.
  *
- * @param {string} language The language to retrieve a stemmer function for.
+ * @param {string} language         The language to retrieve a stemmer function for.
+ * @param {Object} morphologyData   The morphology data.
  *
  * @returns {Function} A stemmer function for the language.
  */
-export default function( language ) {
-	return get( stemFunctions, language, word => word );
+export default function( language, morphologyData ) {
+	const stemFunction = stemFunctions[ language ];
+
+	// Return the stem function if there is one for the given language and if morphology data is available.
+	if ( morphologyData && stemFunction ) {
+		return stemFunction;
+	}
+
+	// Return an identity function if the stem function and/or morphology data aren't available.
+	return word => word;
 }

--- a/packages/yoastseo/src/morphology/english/determineStem.js
+++ b/packages/yoastseo/src/morphology/english/determineStem.js
@@ -131,10 +131,6 @@ export function determineRegularStem( word, morphologyData ) {
  * @returns {string} Stemmed (or base) form of the word.
  */
 export function determineStem( word, morphologyData ) {
-	if ( ! morphologyData ) {
-		return word;
-	}
-
 	const nounMorphology = morphologyData.nouns;
 
 	const baseIfPossessive = buildOneFormFromRegex( word, createRulesFromMorphologyData( nounMorphology.regexNoun.possessiveToBase ) );

--- a/packages/yoastseo/src/researches/buildTopicStems.js
+++ b/packages/yoastseo/src/researches/buildTopicStems.js
@@ -1,6 +1,5 @@
-import getStemForLanguageFactory from "../helpers/getStemForLanguage.js";
-
 import filterFunctionWordsFromArray from "../helpers/filterFunctionWordsFromArray.js";
+import retrieveStemmer from "../helpers/retrieveStemmer.js";
 import getWords from "../stringProcessing/getWords.js";
 import parseSynonyms from "../stringProcessing/parseSynonyms";
 import { normalizeSingle } from "../stringProcessing/quotes";
@@ -9,8 +8,6 @@ import { includes } from "lodash-es";
 import { isUndefined } from "lodash-es";
 import { escapeRegExp } from "lodash-es";
 import { memoize } from "lodash-es";
-
-const getStemForLanguage = getStemForLanguageFactory();
 
 /**
  * A topic phrase (i.e., a keyphrase or synonym) with stem-original pairs for the words in the topic phrase.
@@ -81,19 +78,12 @@ const buildStems = function( keyphrase, language, morphologyData ) {
 	}
 
 	const words = filterFunctionWordsFromArray( getWords( keyphrase ), language );
-	const getStem = getStemForLanguage[ language ];
 
-	// Simply returns lowCased words from the keyphrase if stems cannot be built.
-	if ( morphologyData === false || isUndefined( getStem ) ) {
-		const lowerCasedOriginalPairs = words.map(
-			word => new StemOriginalPair(
-				normalizeSingle( escapeRegExp( word.toLocaleLowerCase( language ) ) ),
-				word
-			),
-		);
-
-		return new TopicPhrase( lowerCasedOriginalPairs );
-	}
+	/**
+	 * Extract a stemming function (it available, and if there is morphologyData available for this language).
+	 * Otherwise, take an identity function.
+	 */
+	const getStem = retrieveStemmer( language, morphologyData );
 
 	const stemOriginalPairs = words.map( word => {
 		const lowCaseWord = escapeRegExp( word.toLocaleLowerCase( language ) );

--- a/packages/yoastseo/src/researches/buildTopicStems.js
+++ b/packages/yoastseo/src/researches/buildTopicStems.js
@@ -80,7 +80,7 @@ const buildStems = function( keyphrase, language, morphologyData ) {
 	const words = filterFunctionWordsFromArray( getWords( keyphrase ), language );
 
 	/**
-	 * Extract a stemming function (it available, and if there is morphologyData available for this language).
+	 * Extract a stemming function (if available, and if there is morphologyData available for this language).
 	 * Otherwise, take an identity function.
 	 */
 	const getStem = retrieveStemmer( language, morphologyData );

--- a/packages/yoastseo/src/researches/getWordFormsFromText.js
+++ b/packages/yoastseo/src/researches/getWordFormsFromText.js
@@ -135,8 +135,8 @@ function constructTopicPhraseResult( topicPhrase, paperWordsGroupedByStems, lang
  */
 function getWordFormsFromText( paper, researcher ) {
 	const language = getLanguage( paper.getLocale() );
-	const determineStem = retrieveStemmer( language );
 	const morphologyData = get( researcher.getData( "morphology" ), language, false );
+	const determineStem = retrieveStemmer( language, morphologyData );
 	const topicPhrases = collectStems( paper.getKeyword(), paper.getSynonyms(), language, morphologyData );
 	const keyphrase = topicPhrases.keyphraseStems;
 	const synonyms = topicPhrases.synonymsStems;

--- a/packages/yoastseo/src/stringProcessing/determineProminentWords.js
+++ b/packages/yoastseo/src/stringProcessing/determineProminentWords.js
@@ -149,7 +149,7 @@ function retrieveAbbreviations( text ) {
  */
 function computeProminentWords( words, abbreviations, language, morphologyData ) {
 	const functionWords = retrieveFunctionWords( language );
-	const determineStem = retrieveStemmer( language );
+	const determineStem = retrieveStemmer( language, morphologyData );
 
 	if ( words.length === 0 ) {
 		return [];


### PR DESCRIPTION
Checks whether morphology data is available when retrieving language-specific stemmers from the factory instead of executing that check locally in each language-specific stemmer.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Checks whether morphology data is available when retrieving language-specific stemmers from the factory instead of executing that check locally in each language-specific stemmer.

## Relevant technical choices:

* When checking whether the identity function is returned in the specs, I do so by actually running it and checking its output. I initially tried to test whether the function that's returned is indeed the identity function, but jest then tells me `Expected value to equal: [Function anonymous] Received: [Function anonymous]` and `Compared values have no visual difference.`. That's why I'm using this workaround now which still tells me that what is returned is indeed the identity function.
* I removed the test for no morphology data in `determineStemEnglishSpec.js` because `determineStem` function shouldn't be called anymore when there is no morphology data.
* I've made an issue to also use `retrieveStemmer` in the internal linking functionality after all the necessary merges: https://yoast.atlassian.net/browse/LIN-262

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run the tests and check that everything passes.
* In the codebase, confirm that all occurrences of `retrieveStemmer` now also get the morphology data passed as an argument.
* In the codebase, confirm that `determineStem` is only ever called via `retrieveStemmer`.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-232
