### PR TITLE
add extra entries to the Spanish stem test

### DIFF
--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -118,6 +118,6 @@
     }
   },
   "yoast": {
-    "premiumConfiguration": ""
+    "premiumConfiguration": "feature/Spanish-morphology"
   }
 }

--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -52,13 +52,12 @@ const wordsToStem = [
 	// // Input a word that looks like a verb form and is on the list of stems that belong together.
 	// [ "san", "san" ],
 	// [ "virgen", "virgen" ],
-	// Input a word that ends in -í, either a verb or a noun.
+	// // Input a word that ends in -í, either a verb or a noun.
 	// [ "entendí", "entend" ],
 	// [ "marroquí", "marroqu" ],
-	// Input an adverb that ends in -mente.
+	// // Input an adverb that ends in -mente.
 	// [ "actualmente", "actual" ],
 	// [ "aparentemente", "aparent" ],
-
 ];
 
 describe( "Test for stemming Spanish words", () => {

--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -52,6 +52,13 @@ const wordsToStem = [
 	// // Input a word that looks like a verb form and is on the list of stems that belong together.
 	// [ "san", "san" ],
 	// [ "virgen", "virgen" ],
+	// Input a word that ends in -í, either a verb or a noun.
+	// [ "entendí", "entend" ],
+	// [ "marroquí", "marroqu" ],
+	// Input an adverb that ends in -mente.
+	// [ "actualmente", "actual" ],
+	// [ "aparentemente", "aparent" ],
+
 ];
 
 describe( "Test for stemming Spanish words", () => {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Adds two examples on í and mente to the Spanish stemmer test.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `yarn test` and check that all tests pass

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-260
