### PR TITLE
Add superlative forms to Spanish stemming tests

### DIFF
--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -58,6 +58,24 @@ const wordsToStem = [
 	// // Input an adverb that ends in -mente.
 	// [ "actualmente", "actual" ],
 	// [ "aparentemente", "aparent" ],
+	// // Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by bil.
+	// [ "notabilísimo", "notabl" ],
+	// [ "respetabilísimas", "respetabl" ],
+	// // Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by qu, gu.
+	// [ "riquísimo", "ric" ],
+	// [ "amiguísimas", "amig" ],
+	// // Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by c.
+	// [ "felicísimo", "feliz" ],
+	// [ "velocísimas", "veloz" ],
+	// // Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by i.
+	// [ "friísimo", "fri" ],
+	// [ "impiísima", "impi" ],
+	// // Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by -b, -d, -f, -g, -h, -i, -l, -m, -n, -p, -q, -r, -s, -t, -v, -z, -x, -y, -w, -k, -j, -u.
+	// [ "rapidísimo", "rapid" ],
+	// [ "generalísimas", "general" ],
+	// // Input a word that ends in -érrimo, -érrima, -érrimos, érrimas.
+	// [ "genialérrima", "genial" ],
+	// [ "tristérrimo", "trist" ],
 ];
 
 describe( "Test for stemming Spanish words", () => {

--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -76,6 +76,14 @@ const wordsToStem = [
 	// // Input a word that ends in -érrimo, -érrima, -érrimos, érrimas.
 	// [ "genialérrima", "genial" ],
 	// [ "tristérrimo", "trist" ],
+	// // Exceptions in superlatives.
+	// [ "habilísima", "habil" ],
+	// [ "majérrimo", "majérrim" ],
+	// [ "cérrimo", "cérrim" ],
+	// [ "gérrimo", "gérrim" ],
+	// [ "torísimo", "torísim" ],
+	// [ "físima", "físim" ],
+	// [ "dísima", "dísim" ]
 ];
 
 describe( "Test for stemming Spanish words", () => {


### PR DESCRIPTION
## Summary
This PR can be summarized in the following changelog entry:

* Adds superlative forms to Spanish stemming tests

## Test instructions

This PR can be tested by following these steps:

Check that `yarn test` runs.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/jira/software/projects/LIN/boards/4?selectedIssue=LIN-268
