### PR TITLE
Lin 258 add test for mente words

### DIFF
--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -57,9 +57,15 @@ const wordsToStem = [
 	// // Input a word that ends in -í, either a verb or a noun.
 	// [ "entendí", "entend" ],
 	// [ "marroquí", "marroqu" ],
-	// // Input an adverb that ends in -mente.
+	// // Input an adverb that ends in -mente preceded by a consonant.
 	// [ "actualmente", "actual" ],
+	// [ "hábilmente", "habil" ],
+	// // Input an adverb that ends in -mente preceded by a vowel.
+	// [ "rápidamente", "rapid" ],
 	// [ "aparentemente", "aparent" ],
+	// // Input a word that ends in -mente but is not an adverb.
+	// [ "mentes", "ment" ],
+	// [ "fundamente", "fundament" ],
 	// // Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by bil.
 	// [ "notabilísimo", "notabl" ],
 	// [ "respetabilísimas", "respetabl" ],


### PR DESCRIPTION
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds 4 test for adverbs ending in -mente and its exceptions 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* run yarn test and make sure it passes

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes # https://yoast.atlassian.net/browse/LIN-258
