### PR TITLE
Lin 293 Add external Spanish stemmer

### DIFF
--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -12,48 +12,48 @@ const wordsToStem = [
 	[ "abuela", "abuel" ],
 	// Input a word that ends with a clitic pronoun and is a verb.
 	[ "abofarse", "abof" ],
-	//[ "mírame", "mir" ],
+	// [ "mírame", "mir" ],
 	// Input a word that does not ends with a clitic pronoun and is on the exceptions full forms list.
-	//[ "sacratísimo", "sagrad" ],
-	//[ "veamos", "ver" ],
+	// [ "sacratísimo", "sagrad" ],
+	// [ "veamos", "ver" ],
 	// Input a word that looks like a diminutive but is not.
 	[ "acólito", "acolit" ],
 	[ "amalecitas", "amalecit" ],
 	// Input a word that is on the diminutive exceptions list.
-	//[ "reicito", "rey" ],
-	//[ "lucecita", "luz" ],
+	// [ "reicito", "rey" ],
+	// [ "lucecita", "luz" ],
 	// Input a word that is a canonical diminutive.
-	//[ "puertecita", "puert" ],
-	//[ "ventita", "vent" ],
+	// [ "puertecita", "puert" ],
+	// [ "ventita", "vent" ],
 	// Input a word that ends in a suffix preceded by uy.
 	[ "excluyendo", "exclu" ],
 	[ "atribuyes", "atribu" ],
 	// Input a word that undergoes stem modification changes.
-	//[ "recuerdan", "record" ],
-	//[ "comienzo", "comenz" ],
+	// [ "recuerdan", "record" ],
+	// [ "comienzo", "comenz" ],
 	// Input a word that ends in a common verb suffix.
 	[ "saltaron", "salt" ],
-	//[ "revocares", "revoc" ],
+	// [ "revocares", "revoc" ],
 	// Input a word that ends in -os, -s, -a, -o, -á, -í,-ó, -é, -e.
 	[ "agostinas", "agostin" ],
 	[ "boboré", "bobor" ],
 	// Input a word that is on the stems that belong together list.
-	//[ "dollar", "dolar" ],
-	//[ "chalets", "chale" ],
-	//[ "sé", "sab" ],
-	//[ "quepa", "cab" ],
+	// [ "dollar", "dolar" ],
+	// [ "chalets", "chale" ],
+	// [ "sé", "sab" ],
+	// [ "quepa", "cab" ],
 	// Input a word that ends in -en, -es, -éis, -emos and is not preceded by gu.
 	[ "valéis", "val" ],
 	[ "dirigen", "dirig" ],
 	// Input a word that ends in -en, -es, -éis, -emos and is preceded by gu.
-	//[ "distinguen", "distingu" ],
+	// [ "distinguen", "distingu" ],
 	[ "alarguemos", "alarg" ],
 	// Input a word that looks like a verb form but it's not.
-	//[ "cabalgada", "cabalgad" ],
-	//[ "abacerías", "abaceri" ],
+	// [ "cabalgada", "cabalgad" ],
+	// [ "abacerías", "abaceri" ],
 	// Input a word that looks like a verb form and is on the list of stems that belong together.
 	[ "san", "san" ],
-	//[ "virgen", "virgen" ],
+	// [ "virgen", "virgen" ],
 	// Input a word that ends in -í, either a verb or a noun.
 	[ "entendí", "entend" ],
 	[ "marroquí", "marroqu" ],
@@ -65,27 +65,27 @@ const wordsToStem = [
 	[ "aparentemente", "aparent" ],
 	// Input a word that ends in -mente but is not an adverb.
 	[ "mentes", "ment" ],
-	//[ "fundamente", "fundament" ],
+	// [ "fundamente", "fundament" ],
 	// Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by bil.
-	//[ "notabilísimo", "notabl" ],
-	//[ "respetabilísimas", "respetabl" ],
+	// [ "notabilísimo", "notabl" ],
+	// [ "respetabilísimas", "respetabl" ],
 	// Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by qu, gu.
-	//[ "riquísimo", "ric" ],
-	//[ "amiguísimas", "amig" ],
+	// [ "riquísimo", "ric" ],
+	// [ "amiguísimas", "amig" ],
 	// Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by c.
-	//[ "felicísimo", "feliz" ],
-	//[ "velocísimas", "veloz" ],
+	// [ "felicísimo", "feliz" ],
+	// [ "velocísimas", "veloz" ],
 	// Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by i.
-	//[ "friísimo", "fri" ],
-	//[ "impiísima", "impi" ],
+	// [ "friísimo", "fri" ],
+	// [ "impiísima", "impi" ],
 	// Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by -b, -d, -f, -g, -h, -i, -l, -m, -n, -p, -q, -r, -s, -t, -v, -z, -x, -y, -w, -k, -j, -u.
-	//[ "rapidísimo", "rapid" ],
-	//[ "generalísimas", "general" ],
+	// [ "rapidísimo", "rapid" ],
+	// [ "generalísimas", "general" ],
 	// Input a word that ends in -érrimo, -érrima, -érrimos, érrimas.
-	//[ "genialérrima", "genial" ],
-	//[ "tristérrimo", "trist" ],
+	// [ "genialérrima", "genial" ],
+	// [ "tristérrimo", "trist" ],
 	// Exceptions in superlatives.
-	//[ "habilísima", "habil" ],
+	// [ "habilísima", "habil" ],
 	[ "majérrimo", "majerrim" ],
 	[ "cérrimo", "cerrim" ],
 	[ "gérrimo", "gerrim" ],
@@ -93,35 +93,35 @@ const wordsToStem = [
 	[ "físima", "fisim" ],
 	[ "dísima", "disim" ],
 	// Input a word whose stem ends in ij ∧ suffix = {o, a, as, amos, áis, an}. [verbs in -igir]
-	//[ "dirijo","dirig" ],
-	//[ "exijamos","exig" ],
+	// [ "dirijo","dirig" ],
+	// [ "exijamos","exig" ],
 	// Input a word whose stem ends in ij ∧ suffix = {o, a, as, amos, áis, an}. [verbs in -egir]
-	//[ "elija","eleg" ],
-	//[ "corrijáis","correg" ],
+	// [ "elija","eleg" ],
+	// [ "corrijáis","correg" ],
 	// Input a word whose stem ends in ig ∧ suffix = {es, e, en, ió, ieron, iendo, [imp. & fut. subj suffixes]}. [verbs in -igir]
 	[ "infligieras", "inflig" ],
 	[ "transigió", "transig" ],
 	// Input a word whose stem ends in ig ∧ suffix = {es, e, en, ió, ieron, iendo, [imp. & fut. subj suffixes]}. [verbs in -egir]
-	//[ "colige", "coleg" ],
-	//[ "rigiera", "reg" ],
+	// [ "colige", "coleg" ],
+	// [ "rigiera", "reg" ],
 	// Input a word whose stem ends in zc ∧ suffix = {o, [pres. subj suffixes], a, as, amos, áis, an}.
-	//[ "conozco", "conoc" ],
-	//[ "traduzcamos", "traduc" ],
+	// [ "conozco", "conoc" ],
+	// [ "traduzcamos", "traduc" ],
 	// Input a word whose stem ends in -c ∧ suffix = {é}.
-	//[ "lancé", "lanz" ],
-	//[ "visualicé", "visualiz" ],
+	// [ "lancé", "lanz" ],
+	// [ "visualicé", "visualiz" ],
 	// Input a word whose stem ends in x: X = CVC(C) ∧ V = {i} ∧ suffix = {í, iste, ió, imos, isteis, ieron, amos, áis, iendo, [imp. & fut. subj suffixes], [pres. subj suffixes], e, o}.
-	//[ "sintió", "sent" ],
-	//[ "sugiriese", "suger" ],
+	// [ "sintió", "sent" ],
+	// [ "sugiriese", "suger" ],
 	// Input a word whose stem ends in x: X = CVC(C) ∧ V = {u} ∧ suffix = {í, iste, ió, imos, isteis, ieron, amos, áis, iendo, [imp. & fut. subj suffixes], [pres. subj suffixes], e, o}.
-	//[ "murieron", "mor" ],
-	//[ "durmió", "dorm" ],
+	// [ "murieron", "mor" ],
+	// [ "durmió", "dorm" ],
 	// Input a word whose stem contains ie (but not in the infinitive) ∧ suffix = {o, es, as, e, a, en, an}.
-	//[ "cierno", "cern" ],
-	//[ "aciertas", "acert" ],
+	// [ "cierno", "cern" ],
+	// [ "aciertas", "acert" ],
 	// Input a word whose stem contains ue (but not in the infinitive) ∧ suffix = {o, es, as, e, a, en, an}.
-	//[ "recuerdan", "record" ],
-	//[ "resuelves", "resolv" ],
+	// [ "recuerdan", "record" ],
+	// [ "resuelves", "resolv" ],
 	// Input a word whose stem contains ue in the infinitive.
 	[ "quejan", "quej" ],
 	[ "quemas", "quem" ],
@@ -131,12 +131,12 @@ const wordsToStem = [
 	[ "consensúas", "consensu" ],
 	[ "licúa", "licu" ],
 	// Input a verb where stem ends on -qu-, -gu- and precedes -é, -e, -es, -emos, -éis, -en
-	//[ "apliques", "aplic" ],
-	//[ "ataquemos", "atac" ],
+	// [ "apliques", "aplic" ],
+	// [ "ataquemos", "atac" ],
 	[ "conjuguen", "conjug" ],
 	[ "juzguéis", "juzg" ],
 	// Exceptions for rules on stem-modifying verbs.
-	[ "aguaste", "agu" ]
+	[ "aguaste", "agu" ],
 ];
 
 describe( "Test for stemming Spanish words", () => {

--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -80,12 +80,12 @@ const wordsToStem = [
 	// [ "tristérrimo", "trist" ],
 	// // Exceptions in superlatives.
 	// [ "habilísima", "habil" ],
-	// [ "majérrimo", "majérrim" ],
-	// [ "cérrimo", "cérrim" ],
-	// [ "gérrimo", "gérrim" ],
-	// [ "torísimo", "torísim" ],
-	// [ "físima", "físim" ],
-	// [ "dísima", "dísim" ],
+	// [ "majérrimo", "majerrim" ],
+	// [ "cérrimo", "cerrim" ],
+	// [ "gérrimo", "gerrim" ],
+	// [ "torísimo", "torisim" ],
+	// [ "físima", "fisim" ],
+	// [ "dísima", "disim" ],
 	// // Input a word whose stem ends in ij ∧ suffix = {o, a, as, amos, áis, an}. [verbs in -igir]
 	// [ "dirijo","dirig" ],
 	// [ "exijamos","exig" ],
@@ -123,19 +123,22 @@ const wordsToStem = [
 	// [ "espían", "espi" ],
 	// [ "envías", "envi" ],
 	// [ "consensúas", "consensu" ],
-	// [ "licúa", licu" ],
+	// [ "licúa", "licu" ],
 	// // Input a verb where stem ends on -qu-, -gu- and precedes -é, -e, -es, -emos, -éis, -en
 	// [ "apliques", "aplic" ],
-	// [ "ataquemos", atac" ],
+	// [ "ataquemos", "atac" ],
 	// [ "conjuguen", "conjug" ],
 	// [ "juzguéis", "juzg" ],
-	// Exceptions for rules on stem-modifying verbs.
+	// // Exceptions for rules on stem-modifying verbs.
 	// [ "aguaste", "agu" ]
 ];
 
 describe( "Test for stemming Spanish words", () => {
-	it( "stems Spanish words", () => {
-		wordsToStem.forEach( wordToStem => expect( stem( morphologyDataES, wordToStem[ 0 ] ) ).toBe( wordToStem[ 1 ] ) );
-	} );
+	for ( let i = 0; i < wordsToStem.length; i++ ) {
+		const wordToCheck = wordsToStem[ i ];
+		it( "stems the word " + wordToCheck[ 0 ], () => {
+			expect( stem( morphologyDataES, wordToCheck[ 0 ] ) ).toBe( wordToCheck[ 1 ] );
+		} );
+	}
 } );
 

--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -4,139 +4,139 @@ import getMorphologyData from "../../specHelpers/getMorphologyData";
 const morphologyDataES = getMorphologyData( "es" ).es;
 
 const wordsToStem = [
-	// // Input a word that ends in -s but is not a plural.
-	// [ "caos", "caos" ],
-	// [ "gas", "gas" ],
-	// // Input a word that ends with a clitic pronoun and is on the list of words that end like pronouns suffixes but are not verbs.
-	// [ "anime", "anim" ],
-	// [ "abuela", "abuel" ],
-	// // Input a word that ends with a clitic pronoun and is a verb.
-	// [ "abofarse", "abof" ],
-	// [ "mirame", "mir" ],
-	// // Input a word that does not ends with a clitic pronoun and is on the exceptions full forms list.
-	// [ "sacratísimo", "sagrad" ],
-	// [ "veamos", "ver" ],
-	// // Input a word that looks like a diminutive but is not.
-	// [ "acólito", "acolit" ],
-	// [ "amalecitas", "amalecit" ],
-	// // Input a word that is on the diminutive exceptions list.
-	// [ "reicito", "rey" ],
-	// [ "lucecita", "luz" ],
-	// // Input a word that is a canonical diminutive.
-	// [ "puertecita", "puert" ],
-	// [ "ventita", "vent" ],
-	// // Input a word that ends in a suffix preceded by uy.
-	// [ "excluyendo", "exclu" ],
-	// [ "atribuyes", "atribu" ],
-	// // Input a word that undergoes stem modification changes.
-	// [ "recuerdan", "record" ],
-	// [ "comienzo", "comenz" ],
-	// // Input a word that ends in a common verb suffix.
-	// [ "saltaron", "salt" ],
-	// [ "revocares", "revoc" ],
-	// // Input a word that ends in -os, -s, -a, -o, -á, -í,-ó, -é, -e.
-	// [ "agostinas", "agostin" ],
-	// [ "boboré", "bobor" ],
-	// // Input a word that is on the stems that belong together list.
-	// [ "dollar", "dolar" ],
-	// [ "chalets", "chale" ],
-	// [ "sé", "sab" ],
-	// [ "quepa", "cab" ],
-	// // Input a word that ends in -en, -es, -éis, -emos and is not preceded by gu.
-	// [ "valéis", "val" ],
-	// [ "dirigen", "dirig" ],
-	// // Input a word that ends in -en, -es, -éis, -emos and is preceded by gu.
-	// [ "distinguen", "distingu" ],
-	// [ "alarguemos", "alarg" ],
-	// // Input a word that looks like a verb form byt it's not.
-	// [ "cabalgada", "cabalgad" ],
-	// [ "abacerías", "abaceri" ],
-	// // Input a word that looks like a verb form and is on the list of stems that belong together.
-	// [ "san", "san" ],
-	// [ "virgen", "virgen" ],
-	// // Input a word that ends in -í, either a verb or a noun.
-	// [ "entendí", "entend" ],
-	// [ "marroquí", "marroqu" ],
-	// // Input an adverb that ends in -mente preceded by a consonant.
-	// [ "actualmente", "actual" ],
-	// [ "hábilmente", "habil" ],
-	// // Input an adverb that ends in -mente preceded by a vowel.
-	// [ "rápidamente", "rapid" ],
-	// [ "aparentemente", "aparent" ],
-	// // Input a word that ends in -mente but is not an adverb.
-	// [ "mentes", "ment" ],
-	// [ "fundamente", "fundament" ],
-	// // Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by bil.
-	// [ "notabilísimo", "notabl" ],
-	// [ "respetabilísimas", "respetabl" ],
-	// // Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by qu, gu.
-	// [ "riquísimo", "ric" ],
-	// [ "amiguísimas", "amig" ],
-	// // Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by c.
-	// [ "felicísimo", "feliz" ],
-	// [ "velocísimas", "veloz" ],
-	// // Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by i.
-	// [ "friísimo", "fri" ],
-	// [ "impiísima", "impi" ],
-	// // Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by -b, -d, -f, -g, -h, -i, -l, -m, -n, -p, -q, -r, -s, -t, -v, -z, -x, -y, -w, -k, -j, -u.
-	// [ "rapidísimo", "rapid" ],
-	// [ "generalísimas", "general" ],
-	// // Input a word that ends in -érrimo, -érrima, -érrimos, érrimas.
-	// [ "genialérrima", "genial" ],
-	// [ "tristérrimo", "trist" ],
-	// // Exceptions in superlatives.
-	// [ "habilísima", "habil" ],
-	// [ "majérrimo", "majerrim" ],
-	// [ "cérrimo", "cerrim" ],
-	// [ "gérrimo", "gerrim" ],
-	// [ "torísimo", "torisim" ],
-	// [ "físima", "fisim" ],
-	// [ "dísima", "disim" ],
-	// // Input a word whose stem ends in ij ∧ suffix = {o, a, as, amos, áis, an}. [verbs in -igir]
-	// [ "dirijo","dirig" ],
-	// [ "exijamos","exig" ],
-	// // Input a word whose stem ends in ij ∧ suffix = {o, a, as, amos, áis, an}. [verbs in -egir]
-	// [ "elija","eleg" ],
-	// [ "corrijáis","correg" ],
-	// // Input a word whose stem ends in ig ∧ suffix = {es, e, en, ió, ieron, iendo, [imp. & fut. subj suffixes]}. [verbs in -igir]
-	// [ "infligieras", "inflig" ],
-	// [ "transigió", "transig" ],
-	// // Input a word whose stem ends in ig ∧ suffix = {es, e, en, ió, ieron, iendo, [imp. & fut. subj suffixes]}. [verbs in -egir]
-	// [ "colige", "coleg" ],
-	// [ "rigiera", "reg" ],
-	// // Input a word whose stem ends in zc ∧ suffix = {o, [pres. subj suffixes], a, as, amos, áis, an}.
-	// [ "conozco", "conoc" ],
-	// [ "traduzcamos", "traduc" ],
-	// // Input a word whose stem ends in -c ∧ suffix = {é}.
-	// [ "lancé", "lanz" ],
-	// [ "visualicé", "visualiz" ],
-	// // Input a word whose stem ends in x: X = CVC(C) ∧ V = {i} ∧ suffix = {í, iste, ió, imos, isteis, ieron, amos, áis, iendo, [imp. & fut. subj suffixes], [pres. subj suffixes], e, o}.
-	// [ "sintió", "sent" ],
-	// [ "sugiriese", "suger" ],
-	// // Input a word whose stem ends in x: X = CVC(C) ∧ V = {u} ∧ suffix = {í, iste, ió, imos, isteis, ieron, amos, áis, iendo, [imp. & fut. subj suffixes], [pres. subj suffixes], e, o}.
-	// [ "murieron", "mor" ],
-	// [ "durmió", "dorm" ],
-	// // Input a word whose stem contains ie (but not in the infinitive) ∧ suffix = {o, es, as, e, a, en, an}.
-	// [ "cierno", "cern" ],
-	// [ "aciertas", "acert" ],
-	// // Input a word whose stem contains ue (but not in the infinitive) ∧ suffix = {o, es, as, e, a, en, an}.
-	// [ "recuerdan", "record" ],
-	// [ "resuelves", "resolv" ],
-	// // Input a word whose stem contains ue in the infinitive.
-	// [ "quejan", "quej" ],
-	// [ "quemas", "quem" ],
-	// // Input a verb where stem ends on -í-, ú- and precedes -o, -as, -a, -an, -e, -es, -en.
-	// [ "espían", "espi" ],
-	// [ "envías", "envi" ],
-	// [ "consensúas", "consensu" ],
-	// [ "licúa", "licu" ],
-	// // Input a verb where stem ends on -qu-, -gu- and precedes -é, -e, -es, -emos, -éis, -en
-	// [ "apliques", "aplic" ],
-	// [ "ataquemos", "atac" ],
-	// [ "conjuguen", "conjug" ],
-	// [ "juzguéis", "juzg" ],
-	// // Exceptions for rules on stem-modifying verbs.
-	// [ "aguaste", "agu" ]
+	// Input a word that ends in -s but is not a plural.
+	[ "caos", "caos" ],
+	[ "gas", "gas" ],
+	// Input a word that ends with a clitic pronoun and is on the list of words that end like pronouns suffixes but are not verbs.
+	[ "anime", "anim" ],
+	[ "abuela", "abuel" ],
+	// Input a word that ends with a clitic pronoun and is a verb.
+	[ "abofarse", "abof" ],
+	//[ "mírame", "mir" ],
+	// Input a word that does not ends with a clitic pronoun and is on the exceptions full forms list.
+	//[ "sacratísimo", "sagrad" ],
+	//[ "veamos", "ver" ],
+	// Input a word that looks like a diminutive but is not.
+	[ "acólito", "acolit" ],
+	[ "amalecitas", "amalecit" ],
+	// Input a word that is on the diminutive exceptions list.
+	//[ "reicito", "rey" ],
+	//[ "lucecita", "luz" ],
+	// Input a word that is a canonical diminutive.
+	//[ "puertecita", "puert" ],
+	//[ "ventita", "vent" ],
+	// Input a word that ends in a suffix preceded by uy.
+	[ "excluyendo", "exclu" ],
+	[ "atribuyes", "atribu" ],
+	// Input a word that undergoes stem modification changes.
+	//[ "recuerdan", "record" ],
+	//[ "comienzo", "comenz" ],
+	// Input a word that ends in a common verb suffix.
+	[ "saltaron", "salt" ],
+	//[ "revocares", "revoc" ],
+	// Input a word that ends in -os, -s, -a, -o, -á, -í,-ó, -é, -e.
+	[ "agostinas", "agostin" ],
+	[ "boboré", "bobor" ],
+	// Input a word that is on the stems that belong together list.
+	//[ "dollar", "dolar" ],
+	//[ "chalets", "chale" ],
+	//[ "sé", "sab" ],
+	//[ "quepa", "cab" ],
+	// Input a word that ends in -en, -es, -éis, -emos and is not preceded by gu.
+	[ "valéis", "val" ],
+	[ "dirigen", "dirig" ],
+	// Input a word that ends in -en, -es, -éis, -emos and is preceded by gu.
+	//[ "distinguen", "distingu" ],
+	[ "alarguemos", "alarg" ],
+	// Input a word that looks like a verb form but it's not.
+	//[ "cabalgada", "cabalgad" ],
+	//[ "abacerías", "abaceri" ],
+	// Input a word that looks like a verb form and is on the list of stems that belong together.
+	[ "san", "san" ],
+	//[ "virgen", "virgen" ],
+	// Input a word that ends in -í, either a verb or a noun.
+	[ "entendí", "entend" ],
+	[ "marroquí", "marroqu" ],
+	// Input an adverb that ends in -mente preceded by a consonant.
+	[ "actualmente", "actual" ],
+	[ "hábilmente", "habil" ],
+	// Input an adverb that ends in -mente preceded by a vowel.
+	[ "rápidamente", "rapid" ],
+	[ "aparentemente", "aparent" ],
+	// Input a word that ends in -mente but is not an adverb.
+	[ "mentes", "ment" ],
+	//[ "fundamente", "fundament" ],
+	// Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by bil.
+	//[ "notabilísimo", "notabl" ],
+	//[ "respetabilísimas", "respetabl" ],
+	// Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by qu, gu.
+	//[ "riquísimo", "ric" ],
+	//[ "amiguísimas", "amig" ],
+	// Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by c.
+	//[ "felicísimo", "feliz" ],
+	//[ "velocísimas", "veloz" ],
+	// Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by i.
+	//[ "friísimo", "fri" ],
+	//[ "impiísima", "impi" ],
+	// Input a word that ends in -ísimo, -ísima, ísimos, -ísimas and is preceded by -b, -d, -f, -g, -h, -i, -l, -m, -n, -p, -q, -r, -s, -t, -v, -z, -x, -y, -w, -k, -j, -u.
+	//[ "rapidísimo", "rapid" ],
+	//[ "generalísimas", "general" ],
+	// Input a word that ends in -érrimo, -érrima, -érrimos, érrimas.
+	//[ "genialérrima", "genial" ],
+	//[ "tristérrimo", "trist" ],
+	// Exceptions in superlatives.
+	//[ "habilísima", "habil" ],
+	[ "majérrimo", "majerrim" ],
+	[ "cérrimo", "cerrim" ],
+	[ "gérrimo", "gerrim" ],
+	[ "torísimo", "torisim" ],
+	[ "físima", "fisim" ],
+	[ "dísima", "disim" ],
+	// Input a word whose stem ends in ij ∧ suffix = {o, a, as, amos, áis, an}. [verbs in -igir]
+	//[ "dirijo","dirig" ],
+	//[ "exijamos","exig" ],
+	// Input a word whose stem ends in ij ∧ suffix = {o, a, as, amos, áis, an}. [verbs in -egir]
+	//[ "elija","eleg" ],
+	//[ "corrijáis","correg" ],
+	// Input a word whose stem ends in ig ∧ suffix = {es, e, en, ió, ieron, iendo, [imp. & fut. subj suffixes]}. [verbs in -igir]
+	[ "infligieras", "inflig" ],
+	[ "transigió", "transig" ],
+	// Input a word whose stem ends in ig ∧ suffix = {es, e, en, ió, ieron, iendo, [imp. & fut. subj suffixes]}. [verbs in -egir]
+	//[ "colige", "coleg" ],
+	//[ "rigiera", "reg" ],
+	// Input a word whose stem ends in zc ∧ suffix = {o, [pres. subj suffixes], a, as, amos, áis, an}.
+	//[ "conozco", "conoc" ],
+	//[ "traduzcamos", "traduc" ],
+	// Input a word whose stem ends in -c ∧ suffix = {é}.
+	//[ "lancé", "lanz" ],
+	//[ "visualicé", "visualiz" ],
+	// Input a word whose stem ends in x: X = CVC(C) ∧ V = {i} ∧ suffix = {í, iste, ió, imos, isteis, ieron, amos, áis, iendo, [imp. & fut. subj suffixes], [pres. subj suffixes], e, o}.
+	//[ "sintió", "sent" ],
+	//[ "sugiriese", "suger" ],
+	// Input a word whose stem ends in x: X = CVC(C) ∧ V = {u} ∧ suffix = {í, iste, ió, imos, isteis, ieron, amos, áis, iendo, [imp. & fut. subj suffixes], [pres. subj suffixes], e, o}.
+	//[ "murieron", "mor" ],
+	//[ "durmió", "dorm" ],
+	// Input a word whose stem contains ie (but not in the infinitive) ∧ suffix = {o, es, as, e, a, en, an}.
+	//[ "cierno", "cern" ],
+	//[ "aciertas", "acert" ],
+	// Input a word whose stem contains ue (but not in the infinitive) ∧ suffix = {o, es, as, e, a, en, an}.
+	//[ "recuerdan", "record" ],
+	//[ "resuelves", "resolv" ],
+	// Input a word whose stem contains ue in the infinitive.
+	[ "quejan", "quej" ],
+	[ "quemas", "quem" ],
+	// Input a verb where stem ends on -í-, ú- and precedes -o, -as, -a, -an, -e, -es, -en.
+	[ "espían", "espi" ],
+	[ "envías", "envi" ],
+	[ "consensúas", "consensu" ],
+	[ "licúa", "licu" ],
+	// Input a verb where stem ends on -qu-, -gu- and precedes -é, -e, -es, -emos, -éis, -en
+	//[ "apliques", "aplic" ],
+	//[ "ataquemos", "atac" ],
+	[ "conjuguen", "conjug" ],
+	[ "juzguéis", "juzg" ],
+	// Exceptions for rules on stem-modifying verbs.
+	[ "aguaste", "agu" ]
 ];
 
 describe( "Test for stemming Spanish words", () => {

--- a/packages/yoastseo/src/morphology/spanish/stem.js
+++ b/packages/yoastseo/src/morphology/spanish/stem.js
@@ -1,3 +1,88 @@
+/* eslint-disable max-statements, require-jsdoc, complexity */
+// The function will be further adjected anyways, so it makes no sense to randomly split it in smaller functions now.
+/**
+ * Copyright (C) 2018 Domingo Martín Mancera
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ */
+
+
+const isVowel = function( c ) {
+	const regex = /[aeiouáéíóú]/gi;
+
+	return regex.test( c );
+};
+
+const nextVowelPosition = function( word, start = 0 ) {
+	const length = word.length;
+
+	for ( let position = start; position < length; position++ ) {
+		if ( isVowel( word[ position ] ) ) {
+			return position;
+		}
+	}
+
+	return length;
+};
+
+const nextConsonantPosition = function( word, start = 0 ) {
+	const length = word.length;
+
+	for ( let position = start; position < length; position++ ) {
+		if ( ! isVowel( word[ position ] ) ) {
+			return position;
+		}
+	}
+
+	return length;
+};
+
+const endsIn = function( word, suffix ) {
+	if ( word.length < suffix.length ) {
+		return false;
+	}
+
+	return ( word.slice( -suffix.length ) === suffix );
+};
+
+const endsInArr = function( word, suffixes ) {
+	const matches = [];
+	for ( const i in suffixes ) {
+		if ( endsIn( word, suffixes[ i ] ) ) {
+			matches.push( suffixes[ i ] );
+		}
+	}
+
+	const longest = matches.sort( function( a, b ) {
+		return b.length - a.length;
+	} )[ 0 ];
+
+	if ( longest ) {
+		return longest;
+	}
+	return "";
+};
+
+const removeAccent = function( word ) {
+	const accentedVowels = [ "á", "é", "í", "ó", "ú" ];
+	const vowels = [ "a", "e", "i", "o", "u" ];
+
+	for ( let i = 0; i < accentedVowels.length; i++ ) {
+		word = word.replace( accentedVowels[ i ], vowels[ i ] );
+	}
+
+	return word;
+};
+
+
 /**
  * Stems Spanish words.
  *
@@ -7,5 +92,176 @@
  * @returns {string} The stemmed word.
  */
 export default function stem( morphologyData, word ) {
-	return word;
+	const length = word.length;
+
+	word.toLowerCase();
+
+	if ( length < 2 ) {
+		return this.removeAccent( word );
+	}
+
+	let r1 = length;
+	let r2 = length;
+	let rv = length;
+
+	/**
+	 * R1 is the region after the first non-vowel following a vowel, or is the null region at the end of the word if
+	 * there is no such non-vowel.
+	 */
+	for ( let i = 0; i < ( length - 1 ) && r1 === length; i++ ) {
+		if ( isVowel( word[ i ] ) && ! isVowel( word[ i + 1 ] ) ) {
+			r1 = i + 2;
+		}
+	}
+
+	/**
+	 * R2 is the region after the first non-vowel following a vowel in R1, or is the null region at the end of the
+	 * word if there is no such non-vowel.
+	 */
+	for ( let i = r1; i < ( length - 1 ) && r2 === length; i++ ) {
+		if ( isVowel( word[ i ] ) && ! isVowel( word[ i + 1 ] ) ) {
+			r2 = i + 2;
+		}
+	}
+
+	if ( length > 3 ) {
+		if ( ! isVowel( word[ 1 ] ) ) {
+			rv = nextVowelPosition( word, 2 ) + 1;
+		} else if ( isVowel( word[ 0 ] ) && isVowel( word[ 1 ] ) ) {
+			rv = nextConsonantPosition( word, 2 ) + 1;
+		} else {
+			rv = 3;
+		}
+	}
+
+	let r1Text = word.slice( r1 );
+	let r2Text = word.slice( r2 );
+	let rvText = word.slice( rv );
+	const originalWord = word;
+
+	// Step 0: Attached pronoun
+	const pronounSuffix = [ "me", "se", "sela", "selo", "selas", "selos", "la", "le", "lo", "las", "les", "los", "nos" ];
+	const pronounSuffixPre1 = [ "iéndo", "ándo", "ár", "ér", "ír" ];
+	const pronounSuffixPre2 = [ "iendo", "ando", "ar", "er", "ir" ];
+
+	const suffix = endsInArr( word, pronounSuffix );
+
+	if ( suffix !== "" ) {
+		let preSuffix = endsInArr( rvText.slice( 0, -suffix.length ), pronounSuffixPre1 );
+
+		if ( preSuffix === "" ) {
+			preSuffix = endsInArr( rvText.slice( 0, -suffix.length ), pronounSuffixPre2 );
+
+			if ( preSuffix !== "" || ( endsIn( word.slice( 0, -suffix.length ), "uyendo" ) ) ) {
+				word = word.slice( 0, -suffix.length );
+			}
+		} else {
+			word = removeAccent( word.slice( 0, -suffix.length ) );
+		}
+	}
+
+	if ( word !== originalWord ) {
+		r1Text = word.slice( r1 );
+		r2Text = word.slice( r2 );
+		rvText = word.slice( rv );
+	}
+
+	const wordAfter0 = word;
+
+	const suf1 = endsInArr( r2Text, [ "anza", "anzas", "ico", "ica", "icos", "icas", "ismo", "ismos",
+		"able", "ables", "ible", "ibles", "ista", "istas", "oso", "osa",
+		"osos", "osas", "amiento", "amientos", "imiento", "imientos" ] );
+	const suf2 = endsInArr( r2Text, [ "icadora", "icador", "icación", "icadoras", "icadores", "icaciones",
+		"icante", "icantes", "icancia", "icancias", "adora", "ador", "ación",
+		"adoras", "adores", "aciones", "ante", "antes", "ancia", "ancias" ] );
+	const suf3 = endsInArr( r2Text, [ "logía", "logías" ] );
+	const suf4 = endsInArr( r2Text, [ "ución", "uciones" ] );
+	const suf5 = endsInArr( r2Text, [ "encia", "encias" ] );
+	const suf6 = endsInArr( r2Text, [ "ativamente", "ivamente", "osamente", "icamente", "adamente" ] );
+	const suf7 = endsInArr( r1Text, [ "amente" ] );
+	const suf8 = endsInArr( r2Text, [ "antemente", "ablemente", "iblemente", "mente" ] );
+	const suf9 = endsInArr( r2Text, [ "abilidad", "abilidades", "icidad", "icidades", "ividad", "ividades", "idad", "idades" ] );
+	const suf10 = endsInArr( r2Text, [ "ativa", "ativo", "ativas", "ativos", "iva", "ivo", "ivas", "ivos" ] );
+
+
+	if ( suf1 !== "" ) {
+		word = word.slice( 0, -suf1.length );
+	} else if ( suf2 !== "" ) {
+		word = word.slice( 0, -suf2.length );
+	} else if ( suf3 !== "" ) {
+		word = word.slice( 0, -suf3.length ) + "log";
+	} else if ( suf4 !== "" ) {
+		word = word.slice( 0, -suf4.length ) + "u";
+	} else if ( suf5 !== "" ) {
+		word = word.slice( 0, -suf5.length ) + "ente";
+	} else if ( suf6 !== "" ) {
+		word = word.slice( 0, -suf6.length );
+	} else if ( suf7 !== "" ) {
+		word = word.slice( 0, -suf7.length );
+	} else if ( suf8 !== "" ) {
+		word = word.slice( 0, -suf8.length );
+	} else if ( suf9 !== "" ) {
+		word = word.slice( 0, -suf9.length );
+	} else if ( suf10 !== "" ) {
+		word = word.slice( 0, -suf10.length );
+	}
+
+	if ( word !== wordAfter0 ) {
+		rvText = word.slice( rv );
+	}
+
+	const wordAfter1 = word;
+
+	if ( wordAfter0 === wordAfter1 ) {
+		// Do step 2a if no ending was removed by step 1.
+		const suf = endsInArr( rvText, [ "ya", "ye", "yan", "yen", "yeron", "yendo", "yo", "yó", "yas", "yes", "yais", "yamos" ] );
+
+		if ( suf !== "" && ( word.slice( -suf.length - 1, -suf.length ) === "u" ) ) {
+			word = word.slice( 0, -suf.length );
+		}
+
+		if ( word !== wordAfter1 ) {
+			rvText = word.slice( rv );
+		}
+
+		// Do Step 2b if step 2a was done, but failed to remove a suffix.
+		if ( word === wordAfter1 ) {
+			const suf11 = endsInArr( rvText, [ "arían", "arías", "arán", "arás", "aríais", "aría", "aréis",
+				"aríamos", "aremos", "ará", "aré", "erían", "erías", "erán",
+				"erás", "eríais", "ería", "eréis", "eríamos", "eremos", "erá",
+				"eré", "irían", "irías", "irán", "irás", "iríais", "iría", "iréis",
+				"iríamos", "iremos", "irá", "iré", "aba", "ada", "ida", "ía", "ara",
+				"iera", "ad", "ed", "id", "ase", "iese", "aste", "iste", "an",
+				"aban", "ían", "aran", "ieran", "asen", "iesen", "aron", "ieron",
+				"ado", "ido", "ando", "iendo", "ió", "ar", "er", "ir", "as", "abas",
+				"adas", "idas", "ías", "aras", "ieras", "ases", "ieses", "ís", "áis",
+				"abais", "íais", "arais", "ierais", "  aseis", "ieseis", "asteis",
+				"isteis", "ados", "idos", "amos", "ábamos", "íamos", "imos", "áramos",
+				"iéramos", "iésemos", "ásemos" ] );
+			const suf12 = endsInArr( rvText, [ "en", "es", "éis", "emos" ] );
+			if ( suf11 !== "" ) {
+				word = word.slice( 0, -suf11.length );
+			} else if ( suf12 !== "" ) {
+				word = word.slice( 0, -suf12.length );
+				if ( endsIn( word, "gu" ) ) {
+					word = word.slice( 0, -1 );
+				}
+			}
+		}
+	}
+
+	rvText = word.slice( rv );
+
+	const suf13 = endsInArr( rvText, [ "os", "a", "o", "á", "í", "ó" ] );
+	if ( suf13 !== "" ) {
+		word = word.slice( 0, -suf13.length );
+	} else if ( ( endsInArr( rvText, [ "e", "é" ] ) ) !== "" ) {
+		word = word.slice( 0, -1 );
+		rvText = word.slice( rv );
+		if ( endsIn( rvText, "u" ) && endsIn( word, "gu" ) ) {
+			word = word.slice( 0, -1 );
+		}
+	}
+
+	return removeAccent( word );
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds an adapted version of the stemmer https://github.com/dmarman/lorca/blob/master/src/stemmer.js to the Spanish stemming function.

## Relevant technical choices:

* I added `/* eslint-disable max-statements, require-jsdoc, complexity */` at the beginning of the `stem.js` file, because this external stemmer will be subject to refactoring anyways and it makes no sense to fix it now.
* Not all specs were covered by this stemmer, for an overview of usecases that are not covered by the stemmer, see the issue https://yoast.atlassian.net/browse/LIN-293.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `yarn test` and see that all tests pass.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Spanish morphological support

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-293
