### PR TITLE
Add specs for adjectives ending in -e

### DIFF
--- a/packages/yoastseo/spec/morphology/dutch/determineStemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/determineStemSpec.js
@@ -224,6 +224,9 @@ const wordsToStem = [
 	 */
 	[ "schone", "schoon" ],
 	[ "hoge", "hoog" ],
+	// Adjectives ending in -e in their base form
+	[ "luxe", "luxe" ],
+	[ "luxer", "luxe" ],
 	/*
 	 * Word that gets suffix -etje and gets stem modification after suffix deletion
 	 * and is neither in an exception list nor ends in t/d (9go-12)


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds specs to the Dutch determineStem function.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Try other words from the https://github.com/Yoast/YoastSEO.js-premium-configuration/pull/112 and see that they get stemmed correctly.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-279
