### PR TITLE
Add rules for processing present participles starting with inseparable prefixes

### DIFF
--- a/packages/yoastseo/spec/morphology/dutch/detectAndStemRegularParticipleSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/detectAndStemRegularParticipleSpec.js
@@ -67,6 +67,13 @@ describe( "Detects and stems participles", () => {
 		"Condition: compound matched by doNotStemD exception list", () => {
 		expect( detectAndStemRegularParticiple( morphologyDataNL, "aangemeld" ) ).toEqual( "aanmeld" );
 	} );
+	it( "correctly stems a past participle that ends in -end." +
+		"Condition: word is on pastParticiplesEndingOnEnd exception list", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "erkend" ) ).toEqual( "erken" );
+	} );
+	it( "correctly stems a present participle that ends in -end.", () => {
+		expect( detectAndStemRegularParticiple( morphologyDataNL, "bedelvend" ) ).toEqual( "bedelf" );
+	} );
 	it( "correctly stems a regular participle without prefixes if it starts on ë", () => {
 		expect( detectAndStemRegularParticiple( morphologyDataNL, "geëmigreerd" ) ).toEqual( "emigreer" );
 	} );

--- a/packages/yoastseo/spec/morphology/dutch/determineStemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/determineStemSpec.js
@@ -200,6 +200,11 @@ const wordsToStem = [
 	// Word that gets suffix -end/-ende and gets stem modification after suffix deletion and is in an verb exception list (9j-11)
 	[ "wegend", "weeg" ],
 	[ "wegende", "weeg" ],
+	// Past participle that starts with an inseparable prefix and ends in -end.
+	[ "erkend", "erken" ],
+	// Present participle that starts with an inseparable prefix and ends in -end(e).
+	[ "bedelvend", "bedelf" ],
+	[ "bedelvende", "bedelf" ],
 	// Word that ends in -t end gets -end suffix (4h-13)
 	[ "plantend", "plant" ],
 	/*

--- a/packages/yoastseo/src/morphology/dutch/detectAndStemSuffixes.js
+++ b/packages/yoastseo/src/morphology/dutch/detectAndStemSuffixes.js
@@ -9,7 +9,7 @@
  * Redistribution and use in source and binary forms, with or without modification, is covered by the standard BSD license.
  */
 
-import { isVowelDoublingAllowed } from "./stemModificationHelpers";
+import { isVowelDoublingAllowed, modifyStem } from "./stemModificationHelpers";
 
 /**
  * Determines the start index of the R1 region.
@@ -63,20 +63,6 @@ const findSuffix = function( word, suffixStep, r1Index ) {
 			}
 		}
 	}
-};
-
-/**
- * Modifies the stem of the word according to the specified modification type.
- *
- * @param {string} word The stem that needs to be modified.
- * @param {string[]} modificationGroup The type of modification that needs to be done.
- * @returns {string} The modified stem, or the same stem if no modification was made.
- */
-const modifyStem = function( word, modificationGroup ) {
-	const neededReplacement = modificationGroup.find( replacement => word.search( new RegExp( replacement[ 0 ] ) ) !== -1 );
-	if ( typeof neededReplacement !== "undefined" ) {
-		word = word.replace( new RegExp( neededReplacement[ 0 ] ), neededReplacement[ 1 ] );
-	} return word;
 };
 
 /**

--- a/packages/yoastseo/src/morphology/dutch/stemModificationHelpers.js
+++ b/packages/yoastseo/src/morphology/dutch/stemModificationHelpers.js
@@ -55,6 +55,20 @@ const doesPrecedingSyllableContainDiphthong = function( word, noVowelDoublingReg
 };
 
 /**
+ * Modifies the stem of the word according to the specified modification type.
+ *
+ * @param {string} word The stem that needs to be modified.
+ * @param {string[]} modificationGroup The type of modification that needs to be done.
+ * @returns {string} The modified stem, or the same stem if no modification was made.
+ */
+export function modifyStem( word, modificationGroup ) {
+	const neededReplacement = modificationGroup.find( replacement => word.search( new RegExp( replacement[ 0 ] ) ) !== -1 );
+	if ( typeof neededReplacement !== "undefined" ) {
+		word = word.replace( new RegExp( neededReplacement[ 0 ] ), neededReplacement[ 1 ] );
+	} return word;
+}
+
+/**
  * Checks whether the final vowel of the stem should be doubled by going through four checks.
  *
  * @param {string}  word                               The stemmed word that the check should be executed on.


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds rules to correctly stem present participles that start with an inseparable verbal suffix.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Try adding more present participles to the spec and check that `yarn test` passes.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-304