### PR TITLE
Add past plural of verbs in zen and ven

### DIFF
--- a/packages/yoastseo/spec/morphology/dutch/determineStemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/determineStemSpec.js
@@ -121,6 +121,9 @@ const wordsToStem = [
 	 * and undergoes vowel doubling after suffix deletion and the stem ends in t/d (4d-13)
 	 */
 	[ "potloden", "potlood" ],
+	// Past-tense forms of verbs ending in fden/sden
+	[ "aanblaasden", "aanblaas" ],
+	[ "aandurfden", "aandurf" ],
 	/*
 	 * Word that ends in -de with -d being part of the stem and undergoes vowel doubling after suffix deletion
 	 * and the stem ends in t/d (4f-13)

--- a/packages/yoastseo/spec/morphology/dutch/getStemWordsWithTAndDEndingSpecs.js
+++ b/packages/yoastseo/spec/morphology/dutch/getStemWordsWithTAndDEndingSpecs.js
@@ -39,6 +39,12 @@ describe( "Creates stem from words with ambiguous endings", () => {
 		expect( generateCorrectStemWithTAndDEnding( morphologyDataNL,  "bieden" ) ).toEqual(
 			"bied" );
 	} );
+	it( "Creates the stem of a past-tense verb that ends in -den and that should have -den stemmed.", () => {
+		expect( generateCorrectStemWithTAndDEnding( morphologyDataNL, "aanblaasden" ) ).toEqual(
+			"aanblaas" );
+		expect( generateCorrectStemWithTAndDEnding( morphologyDataNL, "aandurfden" ) ).toEqual(
+			"aandurf" );
+	} );
 	it( "Creates the stem of a compound word which ends with a word from the verbs sub-list of the exception list of words ending in -en" +
 		"which should only have -en stemmed.", () => {
 		expect( generateCorrectStemWithTAndDEnding( morphologyDataNL,  "ontbieden" ) ).toEqual(

--- a/packages/yoastseo/src/morphology/dutch/getStemWordsWithTAndDEnding.js
+++ b/packages/yoastseo/src/morphology/dutch/getStemWordsWithTAndDEnding.js
@@ -50,7 +50,10 @@ const checkWhetherTOrDIsPartOfStem = function( word, morphologyDataNL ) {
 
 	/*
 	 * Step 2:
+	 * 2a)
 	 * - Checks whether the word is in the exception list of verbal forms ending in long vowel + -fden/sden. If so, stems -den off.
+	 * - Example: "hoefden" (-den should be stemmed, leaving "hoef").
+	 * 2b)
 	 * - Check whether the word has the suffix -en preceded by -d, where the -d is part of the stem. If it is, stem only -en.
 	 * - Example: "eenden" (-en should be stemmed, leaving "eend").
 	 */

--- a/packages/yoastseo/src/morphology/dutch/getStemWordsWithTAndDEnding.js
+++ b/packages/yoastseo/src/morphology/dutch/getStemWordsWithTAndDEnding.js
@@ -50,9 +50,14 @@ const checkWhetherTOrDIsPartOfStem = function( word, morphologyDataNL ) {
 
 	/*
 	 * Step 2:
+	 * - Checks whether the word is in the exception list of verbal forms ending in long vowel + -fden/sden. If so, stems -den off.
 	 * - Check whether the word has the suffix -en preceded by -d, where the -d is part of the stem. If it is, stem only -en.
 	 * - Example: "eenden" (-en should be stemmed, leaving "eend").
 	 */
+	if ( tAndDPartOfStemData.verbsDenShouldBeStemmed.includes( word ) ) {
+		return word.slice( 0, -3 );
+	}
+
 	if ( checkIfWordEndingIsOnExceptionList( word, tAndDPartOfStemData.wordsStemOnlyEnEnding.endingMatch ) ||
 		checkIfWordIsOnVerbExceptionList( word, tAndDPartOfStemData.wordsStemOnlyEnEnding.verbs, morphologyDataNL.verbs.compoundVerbsPrefixes ) ||
 		doesWordMatchRegex( word, tAndDPartOfStemData.denEnding ) ) {
@@ -77,6 +82,7 @@ const checkWhetherTOrDIsPartOfStem = function( word, morphologyDataNL ) {
 	if ( stemmedWord ) {
 		return stemmedWord;
 	}
+
 	/*
 	 * Step 4:
 	 * - Checks whether the word matches the regex for words ending in -te or -ten with -t being part of the stem. If it is


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Improves stemming of verbs that end in -fden/-sden in the past tense.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-288
