### PR TITLE
Create RadioButtonGroup component

### DIFF
--- a/apps/components/ReactifiedComponentsWrapper.js
+++ b/apps/components/ReactifiedComponentsWrapper.js
@@ -43,8 +43,8 @@ const ReactifiedComponentsWrapper = () => {
 			<RadioButtonGroup
 				options={ [
 					{
-						value: "hoi",
-						label: "hoi",
+						value: "hey",
+						label: "hey",
 						checked: false,
 					},
 					{
@@ -54,7 +54,7 @@ const ReactifiedComponentsWrapper = () => {
 					}
 				] }
 				label="Horizontal radiobutton group"
-				groupName="groep2"
+				groupName="group1"
 			/>
 			<RadioButtonGroup
 				options={ [
@@ -71,7 +71,7 @@ const ReactifiedComponentsWrapper = () => {
 				] }
 				label="Vertical radiobutton group"
 				vertical={ true }
-				groupName="groep1"
+				groupName="group2"
 			/>
 		</div>
 	);

--- a/apps/components/ReactifiedComponentsWrapper.js
+++ b/apps/components/ReactifiedComponentsWrapper.js
@@ -45,28 +45,25 @@ const ReactifiedComponentsWrapper = () => {
 					{
 						value: "hey",
 						label: "hey",
-						checked: false,
 					},
 					{
 						value: "hi",
 						label: "hi",
-						checked: true,
 					}
 				] }
 				label="Horizontal radiobutton group"
 				groupName="group1"
+				selected="hi"
 			/>
 			<RadioButtonGroup
 				options={ [
 					{
 						value: "haha",
 						label: "haha",
-						checked: false,
 					},
 					{
 						value: "hoho",
 						label: "hoho",
-						checked: true,
 					}
 				] }
 				label="Vertical radiobutton group"

--- a/apps/components/ReactifiedComponentsWrapper.js
+++ b/apps/components/ReactifiedComponentsWrapper.js
@@ -1,6 +1,7 @@
 import React from "react";
 import TextInput from "@yoast/components/src/inputs/TextInput";
 import TextArea from "@yoast/components/src/inputs/TextArea";
+import RadioButtonGroup from "@yoast/components/src/radiobutton/RadioButtonGroup";
 
 const ReactifiedComponentsWrapper = () => {
 	return (
@@ -38,6 +39,41 @@ const ReactifiedComponentsWrapper = () => {
 				placeholder="Ugly placeholder"
 				value="Wow, what happens now??"
 				description="The greatest textarea ever!!1!"
+			/>
+			<RadioButtonGroup
+				options={ [
+					{
+						groupName: "groep2",
+						value: "hoi",
+						label: "hoi",
+						checked: false,
+					},
+					{
+						groupName: "groep2",
+						value: "hi",
+						label: "hi",
+						checked: true,
+					}
+				] }
+				label="Horizontal radiobutton group"
+			/>
+			<RadioButtonGroup
+				options={ [
+					{
+						groupName: "groep1",
+						value: "haha",
+						label: "haha",
+						checked: false,
+					},
+					{
+						groupName: "groep1",
+						value: "hoho",
+						label: "hoho",
+						checked: true,
+					}
+				] }
+				label="Vertical radiobutton group"
+				vertical={ true }
 			/>
 		</div>
 	);

--- a/apps/components/ReactifiedComponentsWrapper.js
+++ b/apps/components/ReactifiedComponentsWrapper.js
@@ -41,14 +41,15 @@ const ReactifiedComponentsWrapper = () => {
 				description="The greatest textarea ever!!1!"
 			/>
 			<RadioButtonGroup
+				onChange={ console.log }
 				options={ [
 					{
-						value: "hey",
-						label: "hey",
+						value: "hey-value",
+						label: "Hey there!",
 					},
 					{
-						value: "hi",
-						label: "hi",
+						value: "hi-value",
+						label: "Hi there!",
 					}
 				] }
 				label="Horizontal radiobutton group"
@@ -56,14 +57,15 @@ const ReactifiedComponentsWrapper = () => {
 				selected="hi"
 			/>
 			<RadioButtonGroup
+				onChange={ console.log }
 				options={ [
 					{
-						value: "haha",
-						label: "haha",
+						value: "haha-value",
+						label: "Haha, that's funny!",
 					},
 					{
-						value: "hoho",
-						label: "hoho",
+						value: "hoho-value",
+						label: "Hohoho, I'm santa!",
 					}
 				] }
 				label="Vertical radiobutton group"

--- a/apps/components/ReactifiedComponentsWrapper.js
+++ b/apps/components/ReactifiedComponentsWrapper.js
@@ -43,30 +43,27 @@ const ReactifiedComponentsWrapper = () => {
 			<RadioButtonGroup
 				options={ [
 					{
-						groupName: "groep2",
 						value: "hoi",
 						label: "hoi",
 						checked: false,
 					},
 					{
-						groupName: "groep2",
 						value: "hi",
 						label: "hi",
 						checked: true,
 					}
 				] }
 				label="Horizontal radiobutton group"
+				groupName="groep2"
 			/>
 			<RadioButtonGroup
 				options={ [
 					{
-						groupName: "groep1",
 						value: "haha",
 						label: "haha",
 						checked: false,
 					},
 					{
-						groupName: "groep1",
 						value: "hoho",
 						label: "hoho",
 						checked: true,
@@ -74,6 +71,7 @@ const ReactifiedComponentsWrapper = () => {
 				] }
 				label="Vertical radiobutton group"
 				vertical={ true }
+				groupName="groep1"
 			/>
 		</div>
 	);

--- a/packages/components/src/radiobutton/RadioButtonGroup.js
+++ b/packages/components/src/radiobutton/RadioButtonGroup.js
@@ -1,0 +1,110 @@
+import React, { Fragment } from "react";
+import PropTypes from "prop-types";
+import FieldGroup, { FieldGroupDefaultProps, FieldGroupProps } from "../field-group/FieldGroup";
+import { getId } from "../GenerateId";
+
+import "./radiobutton.css";
+
+
+/**
+ * Component that generates a group of radio buttons.
+ *
+ * @param {object} props The props for this component.
+ *
+ * @returns {React.Component} A RadioButtonGroup.
+ */
+const RadioButtonGroup = ( props ) => {
+	/**
+	 * Function that returns a radiobutton with accompanying label.
+	 *
+	 * @param {string} groupName The name of the group to which the radiobutton belongs.
+	 * @param {string} value The value of the radiobutton.
+	 * @param {string} label The label that accompanies the radiobutton.
+	 * @param {boolean} checked Whether the radiobutton is checked.
+	 *
+	 * @returns {React.Component} A single radiobutton field with label.
+	 */
+	const RadioButtonWithLabel = ( { groupName, value, label, checked } ) => <Fragment>
+		<input
+			type="radio"
+			name={ groupName }
+			id={ value }
+			value={ value }
+			defaultChecked={ checked }
+			onChange={ props.onChange }
+		/>
+		<label
+			htmlFor={ value }
+		>
+			{ label }
+		</label>
+	</Fragment>;
+
+	RadioButtonWithLabel.propTypes = {
+		groupName: PropTypes.string.isRequired,
+		value: PropTypes.string.isRequired,
+		label: PropTypes.string.isRequired,
+		checked: PropTypes.bool.isRequired,
+	};
+
+	/**
+	 * Returns a set of radiobuttons that are on the same line.
+	 *
+	 * @returns {React.Component} A div with radiobuttons in it.
+	 */
+	const HorizontalRadioButtons = () =>
+		<div className="yoast-field-group__radiobutton">
+			{ props.options.map( option => <RadioButtonWithLabel key={ option.value }{ ...option } /> ) }
+		</div>;
+
+	/**
+	 * Returns a set of radiobuttons that are vertically aligned.
+	 *
+	 * @returns {React.Component} A lot of divs with one radiobutton in it.
+	 */
+	const VerticalRadioButtons = () =>
+		<Fragment>
+			{ props.options.map( option => <div
+				className="yoast-field-group__radiobutton yoast-field-group__radiobutton--vertical"
+				key={ option.value }
+			>
+				<RadioButtonWithLabel { ...option } />
+			</div>,
+			) }
+		</Fragment>;
+
+	const id = getId( props.id );
+	const fieldGroupProps = {
+		htmlFor: id,
+		...props,
+	};
+	return (
+		<FieldGroup
+			{ ...fieldGroupProps }
+		>
+			{ props.vertical ? <VerticalRadioButtons /> : <HorizontalRadioButtons /> }
+		</FieldGroup>
+	);
+};
+
+RadioButtonGroup.propTypes = {
+	id: PropTypes.string,
+	options: PropTypes.arrayOf( PropTypes.shape( {
+		groupName: PropTypes.string.isRequired,
+		value: PropTypes.string.isRequired,
+		label: PropTypes.string.isRequired,
+		checked: PropTypes.bool.isRequired,
+	} ) ).isRequired,
+	onChange: PropTypes.func,
+	vertical: PropTypes.bool,
+	...FieldGroupProps,
+};
+
+RadioButtonGroup.defaultProps = {
+	id: "",
+	vertical: false,
+	onChange: () => {},
+	...FieldGroupDefaultProps,
+};
+
+export default RadioButtonGroup;

--- a/packages/components/src/radiobutton/RadioButtonGroup.js
+++ b/packages/components/src/radiobutton/RadioButtonGroup.js
@@ -5,6 +5,108 @@ import { getId } from "../GenerateId";
 
 import "./radiobutton.css";
 
+/**
+ * Function that returns a radiobutton with accompanying label.
+ *
+ * @param {string} value The value of the radiobutton.
+ * @param {string} label The label that accompanies the radiobutton.
+ * @param {boolean} checked Whether the radiobutton is checked.
+ * @param {string} groupName The name of the group of radio buttons.
+ * @param {string} id The id of the radio button.
+ *
+ * @returns {React.Component} A single radiobutton field with label.
+ */
+const LabeledRadioButton = ( { value, label, checked, groupName, id } ) => <Fragment>
+	<input
+		type="radio"
+		name={ groupName }
+		id={ id }
+		value={ value }
+		defaultChecked={ checked }
+	/>
+	<label
+		htmlFor={ id }
+	>
+		{ label }
+	</label>
+</Fragment>;
+
+LabeledRadioButton.propTypes = {
+	value: PropTypes.string.isRequired,
+	label: PropTypes.string.isRequired,
+	checked: PropTypes.bool.isRequired,
+	groupName: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+};
+
+/**
+ * Returns a set of radiobuttons that are on the same line.
+ *
+ * @param {array} options An array of options for the radio buttons.
+ * @param {function} onChange The onChange function.
+ * @param {string} groupName The name of the radio button group.
+ * @param {string} id The id of the component.
+ * @param {string} selected Optional: the selected radio button.
+ *
+ * @returns {React.Component} A div with radiobuttons in it.
+ */
+const HorizontalRadioButtons = ( { options, onChange, groupName, id, selected } ) => (
+	<div className="yoast-field-group__radiobutton" onChange={ onChange }>
+		{ options.map( option =>
+			<LabeledRadioButton
+				key={ option.value }
+				groupName={ groupName }
+				checked={ selected === option.value }
+				id={ `${ id }_${ option.value }` }
+				{ ...option }
+			/>,
+		) }
+	</div>
+);
+
+HorizontalRadioButtons.propTypes = {
+	options: PropTypes.array.isRequired,
+	onChange: PropTypes.func.isRequired,
+	groupName: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+	selected: PropTypes.string.isRequired,
+};
+
+/**
+ * Returns a set of radiobuttons that are vertically aligned.
+ *
+ * @param {array} options An array of options for the radio buttons.
+ * @param {function} onChange The onChange function.
+ * @param {string} groupName The name of the radio button group.
+ * @param {string} id The id of the component.
+ * @param {string} selected Optional: the selected radio button.
+ *
+ * @returns {React.Component} A lot of divs with one radiobutton in it.
+ */
+const VerticalRadioButtons = ( { options, onChange, groupName, id, selected } ) => (
+	<div onChange={ onChange }>
+		{ options.map( option => <div
+			className="yoast-field-group__radiobutton yoast-field-group__radiobutton--vertical"
+			key={ option.value }
+		>
+			<LabeledRadioButton
+				groupName={ groupName }
+				checked={ selected === option.value }
+				id={ `${ id }_${ option.value }` }
+				{ ...option }
+			/>
+		</div>,
+		) }
+	</div>
+);
+
+VerticalRadioButtons.propTypes = {
+	options: PropTypes.array.isRequired,
+	onChange: PropTypes.func.isRequired,
+	groupName: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+	selected: PropTypes.string.isRequired,
+};
 
 /**
  * Component that generates a group of radio buttons.
@@ -13,74 +115,35 @@ import "./radiobutton.css";
  *
  * @returns {React.Component} A RadioButtonGroup.
  */
-const RadioButtonGroup = ( props ) => {
-	/**
-	 * Function that returns a radiobutton with accompanying label.
-	 *
-	 * @param {string} value The value of the radiobutton.
-	 * @param {string} label The label that accompanies the radiobutton.
-	 * @param {boolean} checked Whether the radiobutton is checked.
-	 *
-	 * @returns {React.Component} A single radiobutton field with label.
-	 */
-	const RadioButtonWithLabel = ( { value, label, checked } ) => <Fragment>
-		<input
-			type="radio"
-			name={ props.groupName }
-			id={ value }
-			value={ value }
-			defaultChecked={ checked }
-			onChange={ props.onChange }
-		/>
-		<label
-			htmlFor={ value }
-		>
-			{ label }
-		</label>
-	</Fragment>;
+const RadioButtonGroup = props => {
+	const {
+		id,
+		options,
+		groupName,
+		onChange,
+		vertical,
+		selected,
+		...fieldGroupProps
+	} = props;
+	const componentId = getId( id );
 
-	RadioButtonWithLabel.propTypes = {
-		value: PropTypes.string.isRequired,
-		label: PropTypes.string.isRequired,
-		checked: PropTypes.bool.isRequired,
+	const radioButtonProps = {
+		options,
+		groupName,
+		selected,
+		onChange: event => onChange( event.target.value ),
+		id: componentId,
 	};
 
-	/**
-	 * Returns a set of radiobuttons that are on the same line.
-	 *
-	 * @returns {React.Component} A div with radiobuttons in it.
-	 */
-	const HorizontalRadioButtons = () =>
-		<div className="yoast-field-group__radiobutton">
-			{ props.options.map( option => <RadioButtonWithLabel key={ option.value }{ ...option } /> ) }
-		</div>;
-
-	/**
-	 * Returns a set of radiobuttons that are vertically aligned.
-	 *
-	 * @returns {React.Component} A lot of divs with one radiobutton in it.
-	 */
-	const VerticalRadioButtons = () =>
-		<Fragment>
-			{ props.options.map( option => <div
-				className="yoast-field-group__radiobutton yoast-field-group__radiobutton--vertical"
-				key={ option.value }
-			>
-				<RadioButtonWithLabel { ...option } />
-			</div>,
-			) }
-		</Fragment>;
-
-	const id = getId( props.id );
-	const fieldGroupProps = {
-		htmlFor: id,
-		...props,
-	};
 	return (
 		<FieldGroup
+			htmlFor={ componentId }
 			{ ...fieldGroupProps }
 		>
-			{ props.vertical ? <VerticalRadioButtons /> : <HorizontalRadioButtons /> }
+			{ vertical
+				? <VerticalRadioButtons { ...radioButtonProps } />
+				: <HorizontalRadioButtons { ...radioButtonProps } />
+			}
 		</FieldGroup>
 	);
 };
@@ -91,8 +154,8 @@ RadioButtonGroup.propTypes = {
 	options: PropTypes.arrayOf( PropTypes.shape( {
 		value: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,
-		checked: PropTypes.bool.isRequired,
 	} ) ).isRequired,
+	selected: PropTypes.string,
 	onChange: PropTypes.func,
 	vertical: PropTypes.bool,
 	...FieldGroupProps,
@@ -101,6 +164,7 @@ RadioButtonGroup.propTypes = {
 RadioButtonGroup.defaultProps = {
 	id: "",
 	vertical: false,
+	selected: null,
 	onChange: () => {},
 	...FieldGroupDefaultProps,
 };

--- a/packages/components/src/radiobutton/RadioButtonGroup.js
+++ b/packages/components/src/radiobutton/RadioButtonGroup.js
@@ -17,17 +17,16 @@ const RadioButtonGroup = ( props ) => {
 	/**
 	 * Function that returns a radiobutton with accompanying label.
 	 *
-	 * @param {string} groupName The name of the group to which the radiobutton belongs.
 	 * @param {string} value The value of the radiobutton.
 	 * @param {string} label The label that accompanies the radiobutton.
 	 * @param {boolean} checked Whether the radiobutton is checked.
 	 *
 	 * @returns {React.Component} A single radiobutton field with label.
 	 */
-	const RadioButtonWithLabel = ( { groupName, value, label, checked } ) => <Fragment>
+	const RadioButtonWithLabel = ( { value, label, checked } ) => <Fragment>
 		<input
 			type="radio"
-			name={ groupName }
+			name={ props.groupName }
 			id={ value }
 			value={ value }
 			defaultChecked={ checked }
@@ -41,7 +40,6 @@ const RadioButtonGroup = ( props ) => {
 	</Fragment>;
 
 	RadioButtonWithLabel.propTypes = {
-		groupName: PropTypes.string.isRequired,
 		value: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,
 		checked: PropTypes.bool.isRequired,
@@ -89,8 +87,8 @@ const RadioButtonGroup = ( props ) => {
 
 RadioButtonGroup.propTypes = {
 	id: PropTypes.string,
+	groupName: PropTypes.string.isRequired,
 	options: PropTypes.arrayOf( PropTypes.shape( {
-		groupName: PropTypes.string.isRequired,
 		value: PropTypes.string.isRequired,
 		label: PropTypes.string.isRequired,
 		checked: PropTypes.bool.isRequired,

--- a/packages/components/src/radiobutton/RadioButtonGroup.js
+++ b/packages/components/src/radiobutton/RadioButtonGroup.js
@@ -5,6 +5,18 @@ import { getId } from "../GenerateId";
 
 import "./radiobutton.css";
 
+const radioButtonsProps = {
+	options: PropTypes.array.isRequired,
+	onChange: PropTypes.func.isRequired,
+	groupName: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+	selected: PropTypes.string,
+};
+
+const radioButtonsDefaultProps = {
+	selected: null,
+};
+
 /**
  * Function that returns a radiobutton with accompanying label.
  *
@@ -64,13 +76,8 @@ const HorizontalRadioButtons = ( { options, onChange, groupName, id, selected } 
 	</div>
 );
 
-HorizontalRadioButtons.propTypes = {
-	options: PropTypes.array.isRequired,
-	onChange: PropTypes.func.isRequired,
-	groupName: PropTypes.string.isRequired,
-	id: PropTypes.string.isRequired,
-	selected: PropTypes.string.isRequired,
-};
+HorizontalRadioButtons.propTypes = radioButtonsProps;
+HorizontalRadioButtons.defaultProps = radioButtonsDefaultProps;
 
 /**
  * Returns a set of radiobuttons that are vertically aligned.
@@ -100,13 +107,8 @@ const VerticalRadioButtons = ( { options, onChange, groupName, id, selected } ) 
 	</div>
 );
 
-VerticalRadioButtons.propTypes = {
-	options: PropTypes.array.isRequired,
-	onChange: PropTypes.func.isRequired,
-	groupName: PropTypes.string.isRequired,
-	id: PropTypes.string.isRequired,
-	selected: PropTypes.string.isRequired,
-};
+VerticalRadioButtons.propTypes = radioButtonsProps;
+VerticalRadioButtons.defaultProps = radioButtonsDefaultProps;
 
 /**
  * Component that generates a group of radio buttons.

--- a/packages/components/tests/RadioButtonGroupTest.js
+++ b/packages/components/tests/RadioButtonGroupTest.js
@@ -1,0 +1,34 @@
+import React from "react";
+import ReactShallowRenderer from "react-test-renderer/shallow";
+
+import RadioButtonGroup from "../src/radiobutton/RadioButtonGroup";
+
+describe( "RadioButtonGroup", () => {
+	const renderer = new ReactShallowRenderer();
+	it( "should render with only the required props", () => {
+		renderer.render(
+			<RadioButtonGroup
+				label="Nice label"
+				groupName="best-group"
+				options={ [
+					{
+						value: "1",
+						label: "hi",
+						checked: false,
+					},
+					{
+						value: "2",
+						label: "ho",
+						checked: true,
+					},
+				] }
+			/>,
+		);
+
+		const result = renderer.getRenderOutput();
+
+		expect( result ).toBeDefined();
+		expect( result.props.label ).toBe( "Nice label" );
+		expect( result.props.groupName ).toBe( "best-group" );
+	} );
+} );

--- a/packages/components/tests/RadioButtonGroupTest.js
+++ b/packages/components/tests/RadioButtonGroupTest.js
@@ -29,6 +29,6 @@ describe( "RadioButtonGroup", () => {
 
 		expect( result ).toBeDefined();
 		expect( result.props.label ).toBe( "Nice label" );
-		expect( result.props.groupName ).toBe( "best-group" );
+		expect( result.props.children.props.groupName ).toBe( "best-group" );
 	} );
 } );


### PR DESCRIPTION
## Summary
This PR creates a `RadioButtonGroup` component based on the HTML provided by Team Front-end.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoast-components] Adds a new `RadioButtonGroup` component.

## Relevant technical choices:
* I have named the component `RadioButtonGroup` since it is used for rendering a group of radiobuttons (it does not make sense to render a single radiobutton imho).
* The options for the `RadioButtonGroup` can be passed via the `options` prop. I have decided to use the following object for the data: 
```js
{
	value: string,
	label: string,
	checked: bool,
}
```
A short explanation about the usage of the props:
- `value`: the value that will be submitted when this radiobutton is selected
- `label`: a label accompanying the radiobutton
- `checked`: an indicator whether this radiobutton is checked, optimally only one of the options should have this property set to `true`.
Furthermore, the `groupName` of every radiobutton can be passed to the `RadioButtonGroup` since it should be equal for every radiobutton in a group.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
1. Check that the implementation of the `RadioButtonGroup` in the example app works as expected.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #559 
