### PR TITLE
Adapt Dutch morphology code to a new structure of the data file

### DIFF
--- a/packages/yoastseo/spec/morphology/morphoHelpers/exceptionListHelpersSpec.js
+++ b/packages/yoastseo/spec/morphology/morphoHelpers/exceptionListHelpersSpec.js
@@ -16,16 +16,16 @@ describe( "Returns true if a word has the same ending as one of the entries in a
 		expect( checkIfWordEndingIsOnExceptionList( "huisarts", [ "huis", "keuken" ] ) ).toEqual( false );
 	} );
 	it( "Returns true if a word is on the verb exception list", () => {
-		expect( checkIfWordIsOnVerbExceptionList( "zien", [ "zien", "doen" ], morphologyDataNL.verbs.compoundVerbsPrefixes ) ).toEqual( true );
+		expect( checkIfWordIsOnVerbExceptionList( "zien", [ "zien", "doen" ], morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ).toEqual( true );
 	} );
 	it( "Returns true if a word has an inseparable verb prefix, and after removing the prefix the word is found on the verb exception list", () => {
-		expect( checkIfWordIsOnVerbExceptionList( "bezien", [ "zien", "doen" ], morphologyDataNL.verbs.compoundVerbsPrefixes ) ).toEqual( true );
+		expect( checkIfWordIsOnVerbExceptionList( "bezien", [ "zien", "doen" ], morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ).toEqual( true );
 	} );
 	it( "Returns true if a word has an separable verb prefix, and after removing the prefix the word is found on the verb exception list", () => {
-		expect( checkIfWordIsOnVerbExceptionList( "uitzien", [ "zien", "doen" ], morphologyDataNL.verbs.compoundVerbsPrefixes ) ).toEqual( true );
+		expect( checkIfWordIsOnVerbExceptionList( "uitzien", [ "zien", "doen" ], morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ).toEqual( true );
 	} );
 	it( "Returns false if a word ends with an entry from the verb exception list, but the rest of the word is not a verb prefix", () => {
-		expect( checkIfWordIsOnVerbExceptionList( "onvoorzien", [ "zien", "doen" ], morphologyDataNL.verbs.compoundVerbsPrefixes ) ).toEqual( false );
+		expect( checkIfWordIsOnVerbExceptionList( "onvoorzien", [ "zien", "doen" ], morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ).toEqual( false );
 	} );
 	it( "Returns the canonical stem if a word is in the array list with two stems", () => {
 		expect( checkExceptionListWithTwoStems( [ [ "glas", "glaas" ], [ "vat", "vaat" ] ], "glaas" ) ).toEqual( "glas" );

--- a/packages/yoastseo/src/morphology/dutch/detectAndStemRegularParticiple.js
+++ b/packages/yoastseo/src/morphology/dutch/detectAndStemRegularParticiple.js
@@ -37,23 +37,23 @@ const checkAndStemIfExceptionWithoutGePrefix = function( dataExceptionListToChec
 const shouldSuffixBeStemmed = function( wordWithoutPrefix, morphologyDataNL ) {
 	if ( wordWithoutPrefix.endsWith( "t" ) ) {
 		// Return true (suffix should be stemmed) if word was found on the exception list of verbs which should have the final -t stemmed.
-		const exceptionsTShouldBeStemmed = morphologyDataNL.stemming.stemExceptions.ambiguousTAndDEndings.wordsTShouldBeStemmed;
+		const exceptionsTShouldBeStemmed = morphologyDataNL.ambiguousTAndDEndings.wordsTShouldBeStemmed;
 		if ( exceptionsTShouldBeStemmed.includes( wordWithoutPrefix ) ) {
 			return true;
 		}
 		// Return false (suffix should not be stemmed) if word matches the regex for stems ending in -t.
-		if ( doesWordMatchRegex( wordWithoutPrefix, morphologyDataNL.stemming.stemExceptions.ambiguousTAndDEndings.tOrDArePartOfStem.tEnding ) ) {
+		if ( doesWordMatchRegex( wordWithoutPrefix, morphologyDataNL.ambiguousTAndDEndings.tOrDArePartOfStem.tEnding ) ) {
 			return false;
 		}
 		/*
 		 * Return false (suffix should not be stemmed) if the word was found on the list of verbs with stem ending in -t (e.g. haast)
 		 * Otherwise, return true (if no checks are matched, the default condition is for -t to be stemmed).
 		 */
-		const exceptionsTShouldNotBeStemmed = morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions.verbs;
+		const exceptionsTShouldNotBeStemmed = morphologyDataNL.stemExceptions.wordsNotToBeStemmedExceptions.verbs;
 		return ! exceptionsTShouldNotBeStemmed.includes( wordWithoutPrefix );
 	}
 	if ( wordWithoutPrefix.endsWith( "d" ) ) {
-		const exceptionsDShouldNotBeStemmed = morphologyDataNL.verbs.doNotStemD;
+		const exceptionsDShouldNotBeStemmed = morphologyDataNL.pastParticipleStemmer.doNotStemD;
 		return ! exceptionsDShouldNotBeStemmed.includes( wordWithoutPrefix );
 	}
 };
@@ -69,12 +69,12 @@ const shouldSuffixBeStemmed = function( wordWithoutPrefix, morphologyDataNL ) {
  * @returns {string|null} The stem or null if no participle was matched.
  */
 const detectAndStemParticiplesWithoutPrefixes = function( morphologyDataNL, word ) {
-	const geStemTParticipleRegex = new RegExp( "^" + morphologyDataNL.verbs.participleStemmingClasses[ 0 ].regex );
+	const geStemTParticipleRegex = new RegExp( "^" + morphologyDataNL.pastParticipleStemmer.participleStemmingClasses[ 0 ].regex );
 
 	// Check if it's a ge + stem + t/d participle.
 	if ( geStemTParticipleRegex.test( word ) ) {
 		// Check if the ge- is actually part of the stem. If yes, stem only the suffix.
-		const exception = ( checkAndStemIfExceptionWithoutGePrefix( morphologyDataNL.verbs.doNotStemGe, word ) );
+		const exception = ( checkAndStemIfExceptionWithoutGePrefix( morphologyDataNL.pastParticipleStemmer.doNotStemGe, word ) );
 		if ( exception ) {
 			return exception;
 		}
@@ -120,7 +120,7 @@ const detectAndStemParticiplePerPrefixClass = function( morphologyDataNL, word, 
 			 * If it does, stem only the suffix.
 			 */
 			if ( separable ) {
-				const exception = ( checkAndStemIfExceptionWithoutGePrefix( morphologyDataNL.verbs.doNotStemGe, wordWithoutPrefix ) );
+				const exception = ( checkAndStemIfExceptionWithoutGePrefix( morphologyDataNL.pastParticipleStemmer.doNotStemGe, wordWithoutPrefix ) );
 				if ( exception ) {
 					return  ( currentPrefix + exception );
 				}
@@ -156,13 +156,13 @@ const detectAndStemParticiplesWithPrefixes = function( morphologyDataNL, word ) 
 	 * It's important to preserve order here, since the ge + stem ending in -t regex is more specific than
 	 * the stem + t regex, and therefore must be checked first.
 	 */
-	for ( const participleClass of morphologyDataNL.verbs.participleStemmingClasses ) {
+	for ( const participleClass of morphologyDataNL.pastParticipleStemmer.participleStemmingClasses ) {
 		const regex = participleClass.regex;
 		const separable = participleClass.separable;
 
 		const prefixes = separable
-			? morphologyDataNL.verbs.compoundVerbsPrefixes.separable
-			: morphologyDataNL.verbs.compoundVerbsPrefixes.inseparable;
+			? morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes.separable
+			: morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes.inseparable;
 
 		const stem = detectAndStemParticiplePerPrefixClass( morphologyDataNL, word, separable, prefixes, regex );
 
@@ -224,7 +224,7 @@ export function detectAndStemRegularParticiple( morphologyDataNL, word ) {
 	 * Check whether the word is on an exception list of verbs whose participle is the same as the stem. If the word is found
 	 * on the list, return the stem.
 	 */
-	if ( checkIfParticipleIsSameAsStem( morphologyDataNL.verbs.inseparableCompoundVerbsNotToBeStemmed, word ) ) {
+	if ( checkIfParticipleIsSameAsStem( morphologyDataNL.pastParticipleStemmer.inseparableCompoundVerbsNotToBeStemmed, word ) ) {
 		return word;
 	}
 
@@ -239,7 +239,7 @@ export function detectAndStemRegularParticiple( morphologyDataNL, word ) {
 	 * Check whether the word is on an exception list of inseparable compound verbs with a prefix that is usually separable.
 	 * If it is, remove just the suffix and return the stem.
 	 */
-	stem = checkAndStemIfExceptionWithoutGePrefix( morphologyDataNL.verbs.inseparableCompoundVerbs, word );
+	stem = checkAndStemIfExceptionWithoutGePrefix( morphologyDataNL.pastParticipleStemmer.inseparableCompoundVerbs, word );
 
 	if ( stem ) {
 		return stem;
@@ -250,9 +250,9 @@ export function detectAndStemRegularParticiple( morphologyDataNL, word ) {
 	 * If not, stem the word that starts with an inseparable verb prefix and ends in -end as a present participle.
 	 */
 	stem = checkAndStemIfInseparablePrefixWithEndEnding(
-		morphologyDataNL.verbs.compoundVerbsPrefixes.inseparable,
-		morphologyDataNL.verbs.pastParticiplesEndingOnEnd,
-		morphologyDataNL.stemming.stemModifications.finalChanges,
+		morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes.inseparable,
+		morphologyDataNL.pastParticipleStemmer.pastParticiplesEndingOnEnd,
+		morphologyDataNL.regularStemmer.stemModifications.finalChanges,
 		word
 	);
 

--- a/packages/yoastseo/src/morphology/dutch/detectAndStemSuffixes.js
+++ b/packages/yoastseo/src/morphology/dutch/detectAndStemSuffixes.js
@@ -84,8 +84,14 @@ const deleteSuffixAndModifyStem = function( word, suffixStep, suffixIndex, stemM
 		return modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.iedToId );
 	} else if ( stemModification === "changeInktoIng" && word.endsWith( "ink" ) ) {
 		return modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.inkToIng );
-	} else if ( stemModification === "vowelDoubling" && isVowelDoublingAllowed( word, morphologyDataNL.regularStemmer.stemModifications.exceptionsStemModifications,
-		morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ) {
+	} else if (
+		stemModification === "vowelDoubling" &&
+		isVowelDoublingAllowed(
+			word,
+			morphologyDataNL.regularStemmer.stemModifications.exceptionsStemModifications,
+			morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes
+		)
+	) {
 		return modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.doubleVowel );
 	}
 	return word;

--- a/packages/yoastseo/src/morphology/dutch/detectAndStemSuffixes.js
+++ b/packages/yoastseo/src/morphology/dutch/detectAndStemSuffixes.js
@@ -77,16 +77,16 @@ const findSuffix = function( word, suffixStep, r1Index ) {
  */
 const deleteSuffixAndModifyStem = function( word, suffixStep, suffixIndex, stemModification, morphologyDataNL ) {
 	if ( stemModification === "hedenToHeid" ) {
-		return modifyStem( word, morphologyDataNL.stemming.stemModifications.hedenToHeid );
+		return modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.hedenToHeid );
 	}
 	word = word.substring( 0, suffixIndex );
 	if ( stemModification === "changeIedtoId" ) {
-		return modifyStem( word, morphologyDataNL.stemming.stemModifications.iedToId );
+		return modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.iedToId );
 	} else if ( stemModification === "changeInktoIng" && word.endsWith( "ink" ) ) {
-		return modifyStem( word, morphologyDataNL.stemming.stemModifications.inkToIng );
-	} else if ( stemModification === "vowelDoubling" && isVowelDoublingAllowed( word, morphologyDataNL.stemming.stemExceptions,
-		morphologyDataNL.verbs.compoundVerbsPrefixes ) ) {
-		return modifyStem( word, morphologyDataNL.stemming.stemModifications.doubleVowel );
+		return modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.inkToIng );
+	} else if ( stemModification === "vowelDoubling" && isVowelDoublingAllowed( word, morphologyDataNL.exceptionsStemModifications,
+		morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ) {
+		return modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.doubleVowel );
 	}
 	return word;
 };
@@ -143,17 +143,17 @@ export default function detectAndStemSuffixes( word, morphologyDataNL ) {
 	 * Put i and y in between vowels, initial y, and y after a vowel into upper case. This is because they should
 	 * be treated as consonants so we want to differentiate them from other i's and y's when matching regexes.
 	 */
-	word = modifyStem( word, morphologyDataNL.stemming.stemModifications.IAndYToUppercase );
+	word = modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.IAndYToUppercase );
 
 	// Find the start index of the R1 region.
 	const r1Index = determineR1( word );
 
 	// Import the suffixes from all three steps.
-	const suffixSteps = morphologyDataNL.stemming.suffixes;
+	const suffixSteps = morphologyDataNL.regularStemmer.suffixes;
 
 	// Run through the three steps of possible de-suffixation.
 	word = findAndDeleteSuffixes( word, suffixSteps, r1Index, morphologyDataNL );
 
 	// Do final modifications to the stem.
-	return modifyStem( word, morphologyDataNL.stemming.stemModifications.finalChanges );
+	return modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.finalChanges );
 }

--- a/packages/yoastseo/src/morphology/dutch/detectAndStemSuffixes.js
+++ b/packages/yoastseo/src/morphology/dutch/detectAndStemSuffixes.js
@@ -84,7 +84,7 @@ const deleteSuffixAndModifyStem = function( word, suffixStep, suffixIndex, stemM
 		return modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.iedToId );
 	} else if ( stemModification === "changeInktoIng" && word.endsWith( "ink" ) ) {
 		return modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.inkToIng );
-	} else if ( stemModification === "vowelDoubling" && isVowelDoublingAllowed( word, morphologyDataNL.exceptionsStemModifications,
+	} else if ( stemModification === "vowelDoubling" && isVowelDoublingAllowed( word, morphologyDataNL.regularStemmer.stemModifications.exceptionsStemModifications,
 		morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ) {
 		return modifyStem( word, morphologyDataNL.regularStemmer.stemModifications.doubleVowel );
 	}

--- a/packages/yoastseo/src/morphology/dutch/determineStem.js
+++ b/packages/yoastseo/src/morphology/dutch/determineStem.js
@@ -28,16 +28,16 @@ const checkStrongVerbExceptionList = function( strongVerbsLists, stemmedWord ) {
  * If the stem after prefix deletion is in the verb exception list, only return the first stem from the stem set and attach back the prefix.
  * E.g. words to check: verhielp, stem set: help, hielp, geholp -> the stem returned would be "verhelp".
  *
- * @param  {Object} morphologyDataVerbs The Dutch verbs data.
- * @param  {string} stemmedWord The word to check.
+ * @param  {Object} morphologyDataNL 	The Dutch morphology data file.
+ * @param  {string} stemmedWord 		The word to check.
  *
  * @returns {string} The unique stem.
  */
-const findStemOnVerbExceptionList = function( morphologyDataVerbs, stemmedWord ) {
-	const prefixes = flattenSortLength( morphologyDataVerbs.compoundVerbsPrefixes );
+const findStemOnVerbExceptionList = function( morphologyDataNL, stemmedWord ) {
+	const prefixes = flattenSortLength( morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes );
 	// Check whether the inputted stem is started with one of the separable compound prefixes
 	let foundPrefix = prefixes.find( prefix => stemmedWord.startsWith( prefix ) );
-	const doNotStemPrefix = morphologyDataVerbs.strongAndIrregularVerbs.doNotStemPrefix;
+	const doNotStemPrefix = morphologyDataNL.stemExceptions.stemmingExceptionsWithMultipleStems.strongAndIrregularVerbs.doNotStemPrefix;
 	const doNotStemPrefixException = doNotStemPrefix.find( exception => stemmedWord.endsWith( exception ) );
 	let stemmedWordWithoutPrefix = "";
 
@@ -57,10 +57,11 @@ const findStemOnVerbExceptionList = function( morphologyDataVerbs, stemmedWord )
 			foundPrefix = null;
 		}
 	}
+
+	const strongVerbExceptions = morphologyDataNL.stemExceptions.stemmingExceptionsWithMultipleStems.strongAndIrregularVerbs.strongVerbStems;
 	// Find stem strong verbs lists.
-	const strongVerbsExceptionLists = [ morphologyDataVerbs.strongAndIrregularVerbs.strongVerbStems.irregularStrongVerbs,
-		morphologyDataVerbs.strongAndIrregularVerbs.strongVerbStems.regularStrongVerbs,
-		morphologyDataVerbs.strongAndIrregularVerbs.strongVerbStems.bothRegularAndIrregularStrongVerbs,
+	const strongVerbsExceptionLists = [ strongVerbExceptions.irregularStrongVerbs, strongVerbExceptions.regularStrongVerbs,
+		strongVerbExceptions.bothRegularAndIrregularStrongVerbs,
 	];
 	for ( let i = 0; i < strongVerbsExceptionLists.length; i++ ) {
 		const checkIfWordIsException =  checkStrongVerbExceptionList( strongVerbsExceptionLists[ i ], stemmedWord );
@@ -87,17 +88,18 @@ export function determineStem( word, morphologyDataNL ) {
 	const stemmedWord = stem( word, morphologyDataNL );
 
 	// Check whether the stemmed word is on an exception list of words with multiple stems. If it is, return the canonical stem.
-	let stemFromExceptionList = checkExceptionListWithTwoStems( morphologyDataNL.stemming.stemmingExceptionsWithTwoStems, stemmedWord );
+	let stemFromExceptionList = checkExceptionListWithTwoStems(
+		morphologyDataNL.stemExceptions.stemmingExceptionsWithMultipleStems.stemmingExceptionsWithTwoStems, stemmedWord );
 	if ( stemFromExceptionList ) {
 		return stemFromExceptionList;
 	}
-	stemFromExceptionList = findStemOnVerbExceptionList( morphologyDataNL.verbs, stemmedWord );
+	stemFromExceptionList = findStemOnVerbExceptionList( morphologyDataNL, stemmedWord );
 	if ( stemFromExceptionList ) {
 		return stemFromExceptionList;
 	}
 
 	// If the stemmed word ends in -t or -d, check whether it should be stemmed further, and return the stem with or without the -t/d.
-	const ambiguousEndings = morphologyDataNL.stemming.stemExceptions.ambiguousTAndDEndings.tAndDEndings;
+	const ambiguousEndings = morphologyDataNL.ambiguousTAndDEndings.tAndDEndings;
 	for ( const ending of ambiguousEndings ) {
 		if ( stemmedWord.endsWith( ending ) ) {
 			const stemmedWordWithoutTOrD = stemTOrDFromEndOfWord( morphologyDataNL, stemmedWord, word );

--- a/packages/yoastseo/src/morphology/dutch/getStemWordsWithTAndDEnding.js
+++ b/packages/yoastseo/src/morphology/dutch/getStemWordsWithTAndDEnding.js
@@ -16,8 +16,9 @@ import { isVowelDoublingAllowed } from "./stemModificationHelpers";
 const stemWordsWithEOrEnSuffix = function( morphologyDataNL, regexAndReplacement, word ) {
 	if ( doesWordMatchRegex( word, regexAndReplacement[ 0 ] ) ) {
 		const stemmedWord = word.replace( new RegExp( regexAndReplacement[ 0 ] ), regexAndReplacement[ 1 ] );
-		if ( isVowelDoublingAllowed( stemmedWord, morphologyDataNL.stemming.stemExceptions, morphologyDataNL.verbs.compoundVerbsPrefixes ) ) {
-			const replacement = searchAndReplaceWithRegex( stemmedWord, morphologyDataNL.stemming.stemModifications.doubleVowel );
+		if ( isVowelDoublingAllowed( stemmedWord,
+			morphologyDataNL.exceptionsStemModifications, morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ) {
+			const replacement = searchAndReplaceWithRegex( stemmedWord, morphologyDataNL.regularStemmer.stemModifications.doubleVowel );
 			return replacement ? replacement : stemmedWord;
 		}
 		return stemmedWord;
@@ -36,7 +37,7 @@ const stemWordsWithEOrEnSuffix = function( morphologyDataNL, regexAndReplacement
  * @returns {?string} 							The stemmed word, if matched in one of the checks, or null if not matched.
  */
 const checkWhetherTOrDIsPartOfStem = function( word, morphologyDataNL ) {
-	const tAndDPartOfStemData = morphologyDataNL.stemming.stemExceptions.ambiguousTAndDEndings.tOrDArePartOfStem;
+	const tAndDPartOfStemData = morphologyDataNL.ambiguousTAndDEndings.tOrDArePartOfStem;
 	/*
 	 * Step 1:
 	 * - If the stem ends in -tte, -tten, -dde or -dden leave the first -t/-d and stem the remaining ending.
@@ -62,12 +63,14 @@ const checkWhetherTOrDIsPartOfStem = function( word, morphologyDataNL ) {
 	}
 
 	if ( checkIfWordEndingIsOnExceptionList( word, tAndDPartOfStemData.wordsStemOnlyEnEnding.endingMatch ) ||
-		checkIfWordIsOnVerbExceptionList( word, tAndDPartOfStemData.wordsStemOnlyEnEnding.verbs, morphologyDataNL.verbs.compoundVerbsPrefixes ) ||
+		checkIfWordIsOnVerbExceptionList( word,
+			tAndDPartOfStemData.wordsStemOnlyEnEnding.verbs, morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ||
 		doesWordMatchRegex( word, tAndDPartOfStemData.denEnding ) ) {
 		stemmedWord = word.slice( 0, -2 );
 		//	Check if the vowel needs to be doubled after deleting suffix -en.
-		if ( isVowelDoublingAllowed( stemmedWord, morphologyDataNL.stemming.stemExceptions, morphologyDataNL.verbs.compoundVerbsPrefixes ) ) {
-			const replacement = searchAndReplaceWithRegex( stemmedWord, morphologyDataNL.stemming.stemModifications.doubleVowel );
+		if ( isVowelDoublingAllowed( stemmedWord,
+			morphologyDataNL.exceptionsStemModifications, morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ) {
+			const replacement = searchAndReplaceWithRegex( stemmedWord, morphologyDataNL.regularStemmer.stemModifications.doubleVowel );
 			return replacement ? replacement : stemmedWord;
 		}
 		return stemmedWord;
@@ -117,7 +120,7 @@ export function generateCorrectStemWithTAndDEnding( morphologyDataNL, word ) {
 	 * - Example: "squasht".
 	 * - This is an exception to one of the rule in step 2.
 	 */
-	if ( checkIfWordEndingIsOnExceptionList( word, morphologyDataNL.stemming.stemExceptions.ambiguousTAndDEndings.wordsTShouldBeStemmed ) ) {
+	if ( checkIfWordEndingIsOnExceptionList( word, morphologyDataNL.ambiguousTAndDEndings.wordsTShouldBeStemmed ) ) {
 		return word.slice( 0, -1 );
 	}
 
@@ -126,7 +129,7 @@ export function generateCorrectStemWithTAndDEnding( morphologyDataNL, word ) {
 	 * - Check if word is matched by a regex for a t that shouldn't be stemmed.
 	 * - Example: "boot".
 	 */
-	if ( doesWordMatchRegex( word, morphologyDataNL.stemming.stemExceptions.ambiguousTAndDEndings.tOrDArePartOfStem.tEnding ) ) {
+	if ( doesWordMatchRegex( word, morphologyDataNL.ambiguousTAndDEndings.tOrDArePartOfStem.tEnding ) ) {
 		return word;
 	}
 

--- a/packages/yoastseo/src/morphology/dutch/getStemWordsWithTAndDEnding.js
+++ b/packages/yoastseo/src/morphology/dutch/getStemWordsWithTAndDEnding.js
@@ -17,7 +17,8 @@ const stemWordsWithEOrEnSuffix = function( morphologyDataNL, regexAndReplacement
 	if ( doesWordMatchRegex( word, regexAndReplacement[ 0 ] ) ) {
 		const stemmedWord = word.replace( new RegExp( regexAndReplacement[ 0 ] ), regexAndReplacement[ 1 ] );
 		if ( isVowelDoublingAllowed( stemmedWord,
-			morphologyDataNL.exceptionsStemModifications, morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ) {
+			morphologyDataNL.regularStemmer.stemModifications.exceptionsStemModifications,
+			morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ) {
 			const replacement = searchAndReplaceWithRegex( stemmedWord, morphologyDataNL.regularStemmer.stemModifications.doubleVowel );
 			return replacement ? replacement : stemmedWord;
 		}
@@ -69,7 +70,8 @@ const checkWhetherTOrDIsPartOfStem = function( word, morphologyDataNL ) {
 		stemmedWord = word.slice( 0, -2 );
 		//	Check if the vowel needs to be doubled after deleting suffix -en.
 		if ( isVowelDoublingAllowed( stemmedWord,
-			morphologyDataNL.exceptionsStemModifications, morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ) {
+			morphologyDataNL.regularStemmer.stemModifications.exceptionsStemModifications,
+			morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ) {
 			const replacement = searchAndReplaceWithRegex( stemmedWord, morphologyDataNL.regularStemmer.stemModifications.doubleVowel );
 			return replacement ? replacement : stemmedWord;
 		}

--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -7,25 +7,6 @@ import { detectAndStemRegularParticiple } from "./detectAndStemRegularParticiple
 import { modifyStem, isVowelDoublingAllowed } from "./stemModificationHelpers";
 
 /**
- * Check whether the word is a comparative adjective with a stem ending in -rd. If yes, stem it (the regular stemmer
- * would incorrectly stem the d).
- * @param {string} word The word to check.
- * @param {Object} adjectivesEndingInRd The exception list of adjectives with stem ending in -rd.
- * @returns {string} The stemmed word or the original word if it was not matched with the exception list.
- */
-const stemAdjectiveEndingInRd = function( word, adjectivesEndingInRd ) {
-	for ( const adjective of adjectivesEndingInRd ) {
-		const regex = new RegExp( adjective + "er[se]?$" );
-		if ( word.search( regex ) !== -1 ) {
-			if ( word.endsWith( "er" ) ) {
-				return word.slice( 0, -2 );
-			}
-			return word.slice( 0, -3 );
-		}
-	} return word;
-};
-
-/**
  * Get the stem from noun diminutives and plurals exceptions.
  *
  * @param {Object}    morphologyDataNL The data for stemming exception.
@@ -39,7 +20,7 @@ const removeSuffixFromFullForms = function( morphologyDataNL,  word ) {
 	 * If it is, remove the corresponding suffix.
 	 * e.g. lekkere -> lekker, bitters -> bitter
 	*/
-	for ( const exceptionClass of morphologyDataNL.stemming.stemExceptions.removeSuffixesFromFullForms ) {
+	for ( const exceptionClass of morphologyDataNL.stemExceptions.removeSuffixesFromFullForms ) {
 		const stemmedWord = removeSuffixesFromFullForm( exceptionClass.forms, exceptionClass.suffixes, word );
 		if ( stemmedWord ) {
 			return stemmedWord;
@@ -50,7 +31,7 @@ const removeSuffixFromFullForms = function( morphologyDataNL,  word ) {
 	 * for which a specific suffix needs to be stemmed (e.g. -s, -es, -eren, -er etc.)
 	 * e.g. kuddes -> kud, modes -> mod, revenuen -> revenu
 	 */
-	for ( const exceptionClass of morphologyDataNL.stemming.stemExceptions.removeSuffixFromFullForms ) {
+	for ( const exceptionClass of morphologyDataNL.stemExceptions.removeSuffixFromFullForms ) {
 		const stemmedWord = removeSuffixFromFullForm( exceptionClass.forms, exceptionClass.suffix, word );
 		if ( stemmedWord ) {
 			return stemmedWord;
@@ -67,25 +48,17 @@ const removeSuffixFromFullForms = function( morphologyDataNL,  word ) {
  */
 const checkOtherStemmingExceptions = function( word, morphologyDataNL ) {
 	/*
-	 * Check whether the word is on an exception list of adjectives with stem ending in -rd. If it is, stem and
-	 * return the word here, instead of going through the regular stemmer.
- 	 */
-	const wordAfterRdExceptionCheck = stemAdjectiveEndingInRd( word, morphologyDataNL.stemming.stemExceptions.adjectivesEndInRD );
-	if ( wordAfterRdExceptionCheck !== word ) {
-		return wordAfterRdExceptionCheck;
-	}
-	/*
 	 * Checks whether the word is in the exception list of nouns or adjectives with specific suffixes that needs to be stemmed.
 	 * If it is return the stem here and run possible stem modification if it is required. e.g. modes -> mod -> mood
 	 */
 	let stemFromFullForm = removeSuffixFromFullForms( morphologyDataNL, word );
 	if ( stemFromFullForm ) {
-		if ( isVowelDoublingAllowed( stemFromFullForm, morphologyDataNL.stemming.stemExceptions,
-			morphologyDataNL.verbs.compoundVerbsPrefixes ) ) {
-			stemFromFullForm = modifyStem( stemFromFullForm, morphologyDataNL.stemming.stemModifications.doubleVowel );
-			return modifyStem( stemFromFullForm, morphologyDataNL.stemming.stemModifications.finalChanges );
+		if ( isVowelDoublingAllowed( stemFromFullForm, morphologyDataNL.exceptionsStemModifications,
+			morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ) {
+			stemFromFullForm = modifyStem( stemFromFullForm, morphologyDataNL.regularStemmer.stemModifications.doubleVowel );
+			return modifyStem( stemFromFullForm, morphologyDataNL.regularStemmer.stemModifications.finalChanges );
 		}
-		return modifyStem( stemFromFullForm, morphologyDataNL.stemming.stemModifications.finalChanges );
+		return modifyStem( stemFromFullForm, morphologyDataNL.regularStemmer.stemModifications.finalChanges );
 	}
 	return null;
 };
@@ -112,8 +85,8 @@ export default function stem( word, morphologyDataNL ) {
 	}
 
 	// Check whether the word is on the list of words that should not be stemmed, and if yes, return the word. Example: gans -> gans
-	const wordsNotToBeStemmed = morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions;
-	if ( checkIfWordIsOnVerbExceptionList( word, wordsNotToBeStemmed.verbs, morphologyDataNL.verbs.compoundVerbsPrefixes ) ||
+	const wordsNotToBeStemmed = morphologyDataNL.stemExceptions.wordsNotToBeStemmedExceptions;
+	if ( checkIfWordIsOnVerbExceptionList( word, wordsNotToBeStemmed.verbs, morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ||
 		 checkIfWordEndingIsOnExceptionList( word, wordsNotToBeStemmed.endingMatch ) ||
 		 wordsNotToBeStemmed.exactMatch.includes( word ) ) {
 		return word;
@@ -124,7 +97,7 @@ export default function stem( word, morphologyDataNL ) {
 	 * predicting whether the -t/d is part of the stem or the suffix. If the word was matched in one of the checks, stem it
 	 * accordingly and return the stem. Example: boot -> boot, squasht -> squash
 	 */
-	const tAndDEndings = morphologyDataNL.stemming.stemExceptions.ambiguousTAndDEndings.otherTAndDEndings;
+	const tAndDEndings = morphologyDataNL.ambiguousTAndDEndings.otherTAndDEndings;
 	for ( const ending of tAndDEndings ) {
 		if ( word.endsWith( ending ) ) {
 			stemmedWord = generateCorrectStemWithTAndDEnding( morphologyDataNL, word );

--- a/packages/yoastseo/src/morphology/dutch/stem.js
+++ b/packages/yoastseo/src/morphology/dutch/stem.js
@@ -53,7 +53,7 @@ const checkOtherStemmingExceptions = function( word, morphologyDataNL ) {
 	 */
 	let stemFromFullForm = removeSuffixFromFullForms( morphologyDataNL, word );
 	if ( stemFromFullForm ) {
-		if ( isVowelDoublingAllowed( stemFromFullForm, morphologyDataNL.exceptionsStemModifications,
+		if ( isVowelDoublingAllowed( stemFromFullForm, morphologyDataNL.regularStemmer.stemModifications.exceptionsStemModifications,
 			morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ) {
 			stemFromFullForm = modifyStem( stemFromFullForm, morphologyDataNL.regularStemmer.stemModifications.doubleVowel );
 			return modifyStem( stemFromFullForm, morphologyDataNL.regularStemmer.stemModifications.finalChanges );

--- a/packages/yoastseo/src/morphology/dutch/stemTOrDFromEndOfWord.js
+++ b/packages/yoastseo/src/morphology/dutch/stemTOrDFromEndOfWord.js
@@ -1,5 +1,4 @@
-import { checkIfWordEndingIsOnExceptionList, checkExceptionListWithTwoStems,
-	checkIfWordIsOnVerbExceptionList } from "../morphoHelpers/exceptionListHelpers";
+import { checkIfWordEndingIsOnExceptionList, checkIfWordIsOnVerbExceptionList } from "../morphoHelpers/exceptionListHelpers";
 import { detectAndStemRegularParticiple } from "./detectAndStemRegularParticiple";
 import { generateCorrectStemWithTAndDEnding } from "./getStemWordsWithTAndDEnding";
 import checkExceptionsWithFullForms from "../morphoHelpers/checkExceptionsWithFullForms";
@@ -15,14 +14,14 @@ import checkExceptionsWithFullForms from "../morphoHelpers/checkExceptionsWithFu
  * @returns {boolean}	Whether one of the conditions returns true or not.
  */
 const checkIfTorDIsUnambiguous = function( morphologyDataNL, stemmedWord, word ) {
-	const wordsNotToBeStemmed = morphologyDataNL.stemming.stemExceptions.wordsNotToBeStemmedExceptions;
-	const adjectivesEndingInRd = morphologyDataNL.stemming.stemExceptions.adjectivesEndInRD;
-	const wordsEndingInTOrDExceptionList = morphologyDataNL.stemming.stemExceptions.ambiguousTAndDEndings.tOrDArePartOfStem.doNotStemTOrD;
+	const wordsNotToBeStemmed = morphologyDataNL.stemExceptions.wordsNotToBeStemmedExceptions;
+	const adjectivesEndingInRd = morphologyDataNL.stemExceptions.removeSuffixesFromFullForms[ 1 ].forms;
+	const wordsEndingInTOrDExceptionList = morphologyDataNL.ambiguousTAndDEndings.tOrDArePartOfStem.doNotStemTOrD;
 
 	// Run the checks below. If one of the conditions returns true, return the stem.
 	if ( detectAndStemRegularParticiple( morphologyDataNL, word ) ||
 		 generateCorrectStemWithTAndDEnding( morphologyDataNL, word ) ||
-		 checkIfWordIsOnVerbExceptionList( word, wordsNotToBeStemmed.verbs, morphologyDataNL.verbs.compoundVerbsPrefixes ) ||
+		 checkIfWordIsOnVerbExceptionList( word, wordsNotToBeStemmed.verbs, morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes ) ||
 		 checkIfWordEndingIsOnExceptionList( word, wordsNotToBeStemmed.endingMatch ) ||
 		 wordsNotToBeStemmed.exactMatch.includes( word ) ||
 		 adjectivesEndingInRd.includes( stemmedWord ) ||
@@ -31,23 +30,6 @@ const checkIfTorDIsUnambiguous = function( morphologyDataNL, stemmedWord, word )
 		 checkIfWordEndingIsOnExceptionList( stemmedWord, wordsEndingInTOrDExceptionList )
 	) {
 		return true;
-	}
-};
-
-/**
- * Checks if the word after t/d deletion is in the noun exception list. If it is, return the correct stem.
- *
- * @param {Object}  morphologyDataNL	The Dutch morphology data.
- * @param {string}	stemmedWord			The stemmed word.
- * @returns {string} The correct stem from noun exception list.
- */
-const checkIfWordIsInNounException = function( morphologyDataNL, stemmedWord ) {
-	// Check if after t/d deletion, the word is in noun exception list.
-	const nounExceptionList = morphologyDataNL.nouns.exceptions.nounExceptionWithTwoStems;
-	const checkIfWordIsInNounExceptionList = checkExceptionListWithTwoStems( nounExceptionList, stemmedWord );
-	// If it is, return the correct stem.
-	if ( checkIfWordIsInNounExceptionList ) {
-		return checkIfWordIsInNounExceptionList;
 	}
 };
 
@@ -69,10 +51,5 @@ export function stemTOrDFromEndOfWord( morphologyDataNL, stemmedWord, word ) {
 		return null;
 	}
 	// If none of the conditions above is true, stem the t/d from the word.
-	stemmedWord = stemmedWord.slice( 0, -1 );
-	if ( checkIfWordIsInNounException( morphologyDataNL, stemmedWord ) ) {
-		return checkIfWordIsInNounException( morphologyDataNL, stemmedWord );
-	}
-	// If it was not in the noun exception list, return the stem without t/d.
-	return stemmedWord;
+	return stemmedWord.slice( 0, -1 );
 }

--- a/packages/yoastseo/src/morphology/morphoHelpers/checkExceptionsWithFullForms.js
+++ b/packages/yoastseo/src/morphology/morphoHelpers/checkExceptionsWithFullForms.js
@@ -101,9 +101,9 @@ const checkExactMatchFullFormsList = function( word, exactMatchFullFormsList ) {
  * @returns {string/null} The created word forms.
  */
 export default function( morphologyDataNL, word ) {
-	const exceptionListWithFullForms = morphologyDataNL.stemming.stemmingExceptionStemsWithFullForms;
+	const exceptionListWithFullForms = morphologyDataNL.stemExceptions.stemmingExceptionStemsWithFullForms;
 
-	let stem = checkVerbFullFormsList( word, exceptionListWithFullForms.verbs, morphologyDataNL.verbs.compoundVerbsPrefixes );
+	let stem = checkVerbFullFormsList( word, exceptionListWithFullForms.verbs, morphologyDataNL.pastParticipleStemmer.compoundVerbsPrefixes );
 	if ( stem ) {
 		return stem;
 	}


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adapts the code of Dutch morphology functions to a new structure of the morphology data file

## Relevant technical choices:

* The stemAdjectiveEndingInRd  function was removed, as the list checked by that function was moved to the set of lists checked by the removeSuffixesFromFullForm function
* The checkIfWordIsInNounException function was also removed, because I had noticed that all the words from those lists were already in a different list in the data file, so the check that this function does is already performed elsewhere

## Test instructions

This PR can be tested by following these steps:

* Make sure that the specs for all the Dutch morphology functions still pass

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/jira/software/projects/LIN/boards/4?selectedIssue=LIN-314
