### PR TITLE
LIN 321 Add specs for plural nouns ending in -ors 

### DIFF
--- a/packages/yoastseo/spec/morphology/dutch/determineStemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/determineStemSpec.js
@@ -446,6 +446,9 @@ const wordsToStem = [
 	[ "precieste", "precies" ],
 	[ "preciest", "precies" ],
 	[ "trotste", "trots" ],
+	// plural nouns ending in -ors which should have -or stemmed
+	[ "alligators", "alligator" ],
+	[ "tenors", "tenor" ]
 ];
 
 describe( "Test for determining unique stem for Dutch words", () => {

--- a/packages/yoastseo/spec/morphology/dutch/determineStemSpec.js
+++ b/packages/yoastseo/spec/morphology/dutch/determineStemSpec.js
@@ -446,9 +446,9 @@ const wordsToStem = [
 	[ "precieste", "precies" ],
 	[ "preciest", "precies" ],
 	[ "trotste", "trots" ],
-	// plural nouns ending in -ors which should have -or stemmed
+	// Plural nouns ending in -ors which should have -or stemmed
 	[ "alligators", "alligator" ],
-	[ "tenors", "tenor" ]
+	[ "tenors", "tenor" ],
 ];
 
 describe( "Test for determining unique stem for Dutch words", () => {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Adds specs for plural nouns ending in -ors that were incorrectly stemmed before moving _tors_ and _nors_ to the endingMatch sub-list of wordsNotToBeStemmed

## Test instructions
This PR can be tested by following these steps:

* Add more plural nouns ending in -tors or -nors to determineStemSpec and make sure that the -s gets stemmed.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-321
