### PR TITLE
Check verbs with multiple stems

### DIFF
--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -153,6 +153,21 @@ const wordsToStem = [
 	// Input a verb that ends in guar.
 	[ "menguamos", "mengu" ],
 	[ "mengüé", "mengu" ],
+	// Input a verb that ends in ducir.
+	[ "abducir", "abduc" ],
+	[ "abduzco", "abduc" ],
+	[ "abdujo", "abduc" ],
+	[ "abdujerás", "abduc" ],
+	[ "abdujeses", "abduc" ],
+	// Input a verb that ends in seguir.
+	[ "autoseguir", "autosegu" ],
+	[ "autosiga", "autosegu" ],
+	[ "autosiguemos", "autosegu" ],
+	[ "autoseguid", "autosegu" ],
+	// Input a verb that ends in sentir.
+	[ "desconsentir", "desconsent" ],
+	[ "desconsiento", "desconsent" ],
+	[ "desconsintió", "desconsent" ],
 ];
 
 describe( "Test for stemming Spanish words", () => {

--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -48,7 +48,7 @@ const wordsToStem = [
 	[ "valéis", "val" ],
 	[ "dirigen", "dirig" ],
 	// Input a word that ends in -en, -es, -éis, -emos and is preceded by gu.
-	// [ "distinguen", "distingu" ],
+	[ "distinguen", "distingu" ],
 	[ "alarguemos", "alarg" ],
 	// Input a word that looks like a verb form but it's not.
 	// [ "cabalgada", "cabalgad" ],
@@ -144,6 +144,15 @@ const wordsToStem = [
 	[ "compuesta", "compon" ],
 	[ "compongo", "compon" ],
 	[ "componer", "compon" ],
+	// Input a verb that ends in quir.
+	[ "desagua", "desagu" ],
+	[ "desagüé", "desagu" ],
+	// Input a verb that ends in guir.
+	[ "autoextingo", "autoextingu" ],
+	[ "autoextinguimos", "autoextingu" ],
+	// Input a verb that ends in guar.
+	[ "menguamos", "mengu" ],
+	[ "mengüé", "mengu" ],
 ];
 
 describe( "Test for stemming Spanish words", () => {

--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -140,6 +140,10 @@ const wordsToStem = [
 	[ "aguaste", "agu" ],
 	// [ "engreíais", "engre" ],
 	// [ "interdijese", "interdec" ],
+	// Input a verb that has multiple stems.
+	[ "compuesta", "compon" ],
+	[ "compongo", "compon" ],
+	[ "componer", "compon" ],
 ];
 
 describe( "Test for stemming Spanish words", () => {

--- a/packages/yoastseo/src/morphology/spanish/stem.js
+++ b/packages/yoastseo/src/morphology/spanish/stem.js
@@ -127,6 +127,14 @@ const tryStemAsSuperlative = function( word, r1Text, superlativesStemming ) {
 	return buildOneFormFromRegex( word, createRulesFromMorphologyData( superlativesStemming.superlativeToStem ) ) || word;
 };
 
+/**
+ * Checks whether a stem is in an exception list of verbs with multiple stems and if so returns the canonical stem.
+ *
+ * @param {string} stemmedWord	   The stemmed word to be checked.
+ * @param {Object} morphologyData  The Spanish morphology data.
+ *
+ * @returns {null|string} The canonical stem or null if nothing was found.
+ */
 const checkVerbsWithMultipleStems = function( stemmedWord, morphologyData ) {
 	const verbsWithMultipleStems = morphologyData.stemsThatBelongToOneWord.verbs;
 
@@ -137,7 +145,6 @@ const checkVerbsWithMultipleStems = function( stemmedWord, morphologyData ) {
 	}
 	return null;
 };
-
 
 /**
  * Stems Spanish words.

--- a/packages/yoastseo/src/morphology/spanish/stem.js
+++ b/packages/yoastseo/src/morphology/spanish/stem.js
@@ -127,6 +127,18 @@ const tryStemAsSuperlative = function( word, r1Text, superlativesStemming ) {
 	return buildOneFormFromRegex( word, createRulesFromMorphologyData( superlativesStemming.superlativeToStem ) ) || word;
 };
 
+const checkVerbsWithMultipleStems = function( stemmedWord, morphologyData ) {
+	const verbsWithMultipleStems = morphologyData.stemsThatBelongToOneWord.verbs;
+
+	for ( const paradigm of verbsWithMultipleStems ) {
+		if ( paradigm.includes( stemmedWord ) ) {
+			return paradigm[ 0 ];
+		}
+	}
+	return null;
+};
+
+
 /**
  * Stems Spanish words.
  *
@@ -310,6 +322,11 @@ export default function stem( word, morphologyData ) {
 		if ( endsIn( rvText, "u" ) && endsIn( word, "gu" ) ) {
 			word = word.slice( 0, -1 );
 		}
+	}
+
+	const canonicalStem = checkVerbsWithMultipleStems( word, morphologyData );
+	if ( canonicalStem ) {
+		return canonicalStem;
 	}
 
 	return removeAccent( word );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds a check for verbs with multiple stems in Spanish 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* run yarn test and add more examples from stemsThatBelongToOneWord.verbs

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-326