### PR TITLE
Avoids verbal stemming of Spanish non-verbs that look like verbs

### DIFF
--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -174,6 +174,146 @@ const wordsToStem = [
 	[ "desconsentir", "desconsent" ],
 	[ "desconsiento", "desconsent" ],
 	[ "desconsintió", "desconsent" ],
+	// Words that look like verb forms but aren't verbs.
+	// Non-verb ending in -ió
+	[ "chevió", "chevi" ],
+	// [ "cheviós", "chevi" ],
+	// Non-verb ending in -irán
+	[ "caguairán", "caguairan" ],
+	[ "caguairanes", "caguairan" ],
+	// Non-verb ending in -ái
+	[ "samurái", "samurai" ],
+	// [ "samuráis", "samurai" ],
+	// Non-verb ending in -ei
+	[ "chatolei", "chatolei" ],
+	// Non-verb ending in -éi
+	[ "upéi", "upei" ],
+	// Non-verb ending in -ir
+	[ "mártir", "martir" ],
+	[ "mártires", "martir" ],
+	// Non-verb ending in -ír
+	[ "hazmerreír", "hazmerreir" ],
+	// Non-verb ending in -ada
+	[ "abada", "abad" ],
+	[ "abadas", "abad" ],
+	// Non-verb ending in -ado
+	[ "mercado", "mercad" ],
+	// [ "mercados", "mercad" ],
+	// Non-verb ending in -imo
+	[ "mínimo", "minim" ],
+	// [ "mínimos", "minim" ],
+	// Non-verb ending in -emo
+	[ "extremo", "extrem" ],
+	[ "extremos", "extrem" ],
+	// Non-verb ending in -ad
+	[ "ciudad", "ciudad" ],
+	[ "ciudades", "ciudad" ],
+	// Non-verb ending in -ed
+	[ "pared", "pared" ],
+	[ "paredes", "pared" ],
+	// Non-verb ending in -ie
+	[ "serie", "seri" ],
+	[ "series", "seri" ],
+	// Non-verb ending in -ié
+	[ "hincapié", "hincapi" ],
+	// [ "hincapiés", "hincapi" ],
+	// Non-verb ending in -ando
+	[ "contrabando", "contraband" ],
+	[ "contrabandos", "contraband" ],
+	// Non-verb ending in -ándo
+	[ "cuándo", "cuand" ],
+	// Non-verb ending in -aré
+	[ "pagaré", "pagar" ],
+	// [ "pagarés", "pagar" ],
+	// Non-verb ending in -eré
+	[ "tereré", "terer" ],
+	// [ "tererés", "terer" ],
+	// Non-verb ending in -ará
+	[ "yarará", "yarar" ],
+	// [ "yararás", "yarar" ],
+	// Non-verb ending in -erá
+	[ "camerá", "camer" ],
+	// [ "camerás", "camer" ],
+	// Non-verb ending in -irá
+	[ "aragüirá", "aragüir" ],
+	// [ "aragüirás", "aragüir" ],
+	// Non-verb ending in -ia
+	[ "historia", "histori" ],
+	[ "historias", "histori" ],
+	// Non-verb ending in -id
+	[ "apartheid", "apartheid" ],
+	// Non-verb ending in -aba
+	[ "guayaba", "guayab" ],
+	// [ "guayabas", "guayab" ],
+	// Non-verb ending in -asta
+	[ "canasta", "canast" ],
+	[ "canastas", "canast" ],
+	// Non-verb ending in -iste
+	[ "quiste", "quist" ],
+	[ "quistes", "quist" ],
+	// Non-verb ending in -aste
+	// [ "contraste", "contrast" ],
+	[ "contrastes", "contrast" ],
+	// Non-verb ending in -ía
+	[ "policía", "polici" ],
+	// [ "policías", "polici" ],
+	// [ "policías", "polic" ],
+	// Non-verb ending in -an
+	[ "eslogan", "eslogan" ],
+	[ "eslóganes", "eslogan" ],
+	// Non-verb ending in -en
+	[ "imagen", "imagen" ],
+	[ "imágenes", "imagen" ],
+	// Non-verb ending in -er
+	[ "mujer", "mujer" ],
+	[ "mujeres", "mujer" ],
+	// Non-verb ending in -iendo
+	[ "arriendo", "arriend" ],
+	[ "arriendos", "arriend" ],
+	// Non-verb ending in -ieron
+	[ "gobieron", "gobieron" ],
+	// Non-verb ending in -iera
+	[ "ingeniera", "ingenier" ],
+	// [ "ingenieras", "ingenier" ],
+	// Non-verb ending in -aron
+	[ "gatillaron", "gatillaron" ],
+	// Non-verb ending in -ida
+	[ "vida", "vid" ],
+	[ "vidas", "vid" ],
+	// Non-verb ending in -ido
+	[ "partido", "part" ],
+	[ "partidos", "part" ],
+	// Non-verb ending in -amo
+	[ "reclamo", "reclam" ],
+	// [ "reclamos", "reclam" ],
+	// Non-verb ending in -ara
+	[ "máscara", "mascar" ],
+	// [ "máscaras", "mascar" ],
+	// Non-verb ending in -ere
+	[ "títere", "titer" ],
+	[ "títeres", "titer" ],
+	// Non-verb ending in -ase
+	[ "base", "bas" ],
+	[ "bases", "bas" ],
+	// Non-verb ending in -ar
+	[ "hogar", "hogar" ],
+	[ "hogares", "hogar" ],
+	// Non-verb ending in -ya
+	[ "playa", "play" ],
+	[ "playas", "play" ],
+	// Non-verb ending in -ye
+	[ "rallye", "rally" ],
+	// Non-verb ending in -yo
+	[ "apoyo", "apoy" ],
+	[ "apoyos", "apoy" ],
+	// Non-verb ending in -yera
+	[ "playera", "player" ],
+	[ "playeras", "player" ],
+	// Non-verb ending in -arán
+	[ "catamarán", "catamaran" ],
+	[ "catamaranes", "catamaran" ],
+	// Non-verb ending in -erán
+	[ "bumerán", "bumeran" ],
 ];
 
 describe( "Test for stemming Spanish words", () => {

--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -257,7 +257,6 @@ const wordsToStem = [
 	// Non-verb ending in -ía
 	[ "policía", "polici" ],
 	// [ "policías", "polici" ],
-	// [ "policías", "polic" ],
 	// Non-verb ending in -an
 	[ "eslogan", "eslogan" ],
 	[ "eslóganes", "eslogan" ],

--- a/packages/yoastseo/src/morphology/spanish/stem.js
+++ b/packages/yoastseo/src/morphology/spanish/stem.js
@@ -147,6 +147,60 @@ const checkVerbsWithMultipleStems = function( stemmedWord, morphologyData ) {
 };
 
 /**
+ * Stems verb suffixes.
+ *
+ * @param {string}  word                The original word.
+ * @param {string}  wordAfter1          The word after step 1.
+ * @param {string}  rvText              The text of the RV.
+ * @param {number}  rv                  The start position of the RV.
+ * @param {Object}  morphologyData      The Spanish morphology data.
+ *
+ * @returns {string} The word with the verb suffixes removed (if applicable).
+ */
+const stemVerbSuffixes = function( word, wordAfter1, rvText, rv, morphologyData ) {
+// Do step 2a if no ending was removed by step 1.
+	const suf = endsInArr( rvText, [ "ya", "ye", "yan", "yen", "yeron", "yendo", "yo", "yó", "yas", "yes", "yais", "yamos" ] );
+
+	if ( suf !== "" && ( word.slice( -suf.length - 1, -suf.length ) === "u" ) &&
+		! morphologyData.wordsThatLookLikeButAreNot.notVerbForms.includes( word ) ) {
+		word = word.slice( 0, -suf.length );
+	}
+
+	if ( word !== wordAfter1 ) {
+		rvText = word.slice( rv );
+	}
+
+	// Do Step 2b if step 2a was done, but failed to remove a suffix.
+	if ( word === wordAfter1 ) {
+		const suf11 = endsInArr( rvText, [ "arían", "arías", "arán", "arás", "aríais", "aría", "aréis",
+			"aríamos", "aremos", "ará", "aré", "erían", "erías", "erán",
+			"erás", "eríais", "ería", "eréis", "eríamos", "eremos", "erá",
+			"eré", "irían", "irías", "irán", "irás", "iríais", "iría", "iréis",
+			"iríamos", "iremos", "irá", "iré", "aba", "ada", "ida", "ía", "ara",
+			"iera", "ad", "ed", "id", "ase", "iese", "aste", "iste", "an",
+			"aban", "ían", "aran", "ieran", "asen", "iesen", "aron", "ieron",
+			"ado", "ido", "ando", "iendo", "ió", "ar", "er", "ir", "as", "abas",
+			"adas", "idas", "ías", "aras", "ieras", "ases", "ieses", "ís", "áis",
+			"abais", "íais", "arais", "ierais", "  aseis", "ieseis", "asteis",
+			"isteis", "ados", "idos", "amos", "ábamos", "íamos", "imos", "áramos",
+			"iéramos", "iésemos", "ásemos" ] );
+		const suf12 = endsInArr( rvText, [ "en", "es", "éis", "emos" ] );
+		if ( suf11 !== "" && ! morphologyData.wordsThatLookLikeButAreNot.nonPluralsOnS.includes( word ) &&
+			! morphologyData.wordsThatLookLikeButAreNot.notVerbForms.includes( word ) ) {
+			word = word.slice( 0, -suf11.length );
+		} else if ( suf12 !== "" && ! morphologyData.wordsThatLookLikeButAreNot.nonPluralsOnS.includes( word ) &&
+			! morphologyData.wordsThatLookLikeButAreNot.notVerbForms.includes( word ) ) {
+			word = word.slice( 0, -suf12.length );
+			if ( endsIn( word, "gu" ) ) {
+				word = word.slice( 0, -1 );
+			}
+		}
+	}
+
+	return word;
+};
+
+/**
  * Stems Spanish words.
  *
  * @param {string} word            The word to stem.
@@ -277,45 +331,11 @@ export default function stem( word, morphologyData ) {
 
 	const wordAfter1 = word;
 
-	if ( wordAfter0 === wordAfter1 ) {
-		// Do step 2a if no ending was removed by step 1.
-		const suf = endsInArr( rvText, [ "ya", "ye", "yan", "yen", "yeron", "yendo", "yo", "yó", "yas", "yes", "yais", "yamos" ] );
 
-		if ( suf !== "" && ( word.slice( -suf.length - 1, -suf.length ) === "u" ) &&
-			! morphologyData.wordsThatLookLikeButAreNot.notVerbForms.includes( word ) ) {
-			word = word.slice( 0, -suf.length );
-		}
-
-		if ( word !== wordAfter1 ) {
-			rvText = word.slice( rv );
-		}
-
-		// Do Step 2b if step 2a was done, but failed to remove a suffix.
-		if ( word === wordAfter1 ) {
-			const suf11 = endsInArr( rvText, [ "arían", "arías", "arán", "arás", "aríais", "aría", "aréis",
-				"aríamos", "aremos", "ará", "aré", "erían", "erías", "erán",
-				"erás", "eríais", "ería", "eréis", "eríamos", "eremos", "erá",
-				"eré", "irían", "irías", "irán", "irás", "iríais", "iría", "iréis",
-				"iríamos", "iremos", "irá", "iré", "aba", "ada", "ida", "ía", "ara",
-				"iera", "ad", "ed", "id", "ase", "iese", "aste", "iste", "an",
-				"aban", "ían", "aran", "ieran", "asen", "iesen", "aron", "ieron",
-				"ado", "ido", "ando", "iendo", "ió", "ar", "er", "ir", "as", "abas",
-				"adas", "idas", "ías", "aras", "ieras", "ases", "ieses", "ís", "áis",
-				"abais", "íais", "arais", "ierais", "  aseis", "ieseis", "asteis",
-				"isteis", "ados", "idos", "amos", "ábamos", "íamos", "imos", "áramos",
-				"iéramos", "iésemos", "ásemos" ] );
-			const suf12 = endsInArr( rvText, [ "en", "es", "éis", "emos" ] );
-			if ( suf11 !== "" && ! morphologyData.wordsThatLookLikeButAreNot.nonPluralsOnS.includes( word ) &&
-				! morphologyData.wordsThatLookLikeButAreNot.notVerbForms.includes( word ) ) {
-				word = word.slice( 0, -suf11.length );
-			} else if ( suf12 !== "" && ! morphologyData.wordsThatLookLikeButAreNot.nonPluralsOnS.includes( word ) &&
-				! morphologyData.wordsThatLookLikeButAreNot.notVerbForms.includes( word ) ) {
-				word = word.slice( 0, -suf12.length );
-				if ( endsIn( word, "gu" ) ) {
-					word = word.slice( 0, -1 );
-				}
-			}
-		}
+	// Step 2a and 2b stem verb suffixes.
+	const notVerbForms = morphologyData.wordsThatLookLikeButAreNot.notVerbForms;
+	if ( wordAfter0 === wordAfter1 && ! notVerbForms.includes( word ) ) {
+		word = stemVerbSuffixes( word, wordAfter1, rvText, rv, morphologyData );
 	}
 
 	rvText = word.slice( rv );

--- a/packages/yoastseo/src/morphology/spanish/stem.js
+++ b/packages/yoastseo/src/morphology/spanish/stem.js
@@ -158,11 +158,14 @@ const checkVerbsWithMultipleStems = function( stemmedWord, morphologyData ) {
  * @returns {string} The word with the verb suffixes removed (if applicable).
  */
 const stemVerbSuffixes = function( word, wordAfter1, rvText, rv, morphologyData ) {
-// Do step 2a if no ending was removed by step 1.
+	const notVerbForms = morphologyData.wordsThatLookLikeButAreNot.notVerbForms;
+	const nonPluralsOnS = morphologyData.wordsThatLookLikeButAreNot.nonPluralsOnS;
+
+	// Do step 2a if no ending was removed by step 1.
 	const suf = endsInArr( rvText, [ "ya", "ye", "yan", "yen", "yeron", "yendo", "yo", "yó", "yas", "yes", "yais", "yamos" ] );
 
 	if ( suf !== "" && ( word.slice( -suf.length - 1, -suf.length ) === "u" ) &&
-		! morphologyData.wordsThatLookLikeButAreNot.notVerbForms.includes( word ) ) {
+		! notVerbForms.includes( word ) ) {
 		word = word.slice( 0, -suf.length );
 	}
 
@@ -185,11 +188,11 @@ const stemVerbSuffixes = function( word, wordAfter1, rvText, rv, morphologyData 
 			"isteis", "ados", "idos", "amos", "ábamos", "íamos", "imos", "áramos",
 			"iéramos", "iésemos", "ásemos" ] );
 		const suf12 = endsInArr( rvText, [ "en", "es", "éis", "emos" ] );
-		if ( suf11 !== "" && ! morphologyData.wordsThatLookLikeButAreNot.nonPluralsOnS.includes( word ) &&
-			! morphologyData.wordsThatLookLikeButAreNot.notVerbForms.includes( word ) ) {
+		if ( suf11 !== "" && ! nonPluralsOnS.includes( word ) &&
+			! notVerbForms.includes( word ) ) {
 			word = word.slice( 0, -suf11.length );
-		} else if ( suf12 !== "" && ! morphologyData.wordsThatLookLikeButAreNot.nonPluralsOnS.includes( word ) &&
-			! morphologyData.wordsThatLookLikeButAreNot.notVerbForms.includes( word ) ) {
+		} else if ( suf12 !== "" && ! nonPluralsOnS.includes( word ) &&
+			! notVerbForms.includes( word ) ) {
 			word = word.slice( 0, -suf12.length );
 			if ( endsIn( word, "gu" ) ) {
 				word = word.slice( 0, -1 );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Avoids verbal stemming of Spanish non-verbs that look like verbs.

## Relevant technical choices:

* I've added the exception check before the stemming for verbs. I didn't check, however, if the check actually applies in all cases. For example, we have a lot of words ending in `idad` in the exception list, but the stemmer stems `idad` as a derivational noun suffix before we get to the exception check. For this, we could have clean-up later, so that we don't have unnecessarily long exception lists. That's only a performance consideration, however. It should not negatively affect the accuracy of the stemmer.
* For specs I left all forms commented out that don't get correctly stemmed. This affects a number of plurals of forms included in the lists. 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- Run `yarn test` and check that all tests pass.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-310
