### PR TITLE
Add specs for verb form looking words ending in -asta, -ista, -ida, and -ido

### DIFF
--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -329,6 +329,14 @@ const wordsToStem = [
 	[ "catamaranes", "catamaran" ],
 	// Non-verb ending in -erán
 	[ "bumerán", "bumeran" ],
+	// Non-verb ending in -asta
+	[ "empaste", "empast" ],
+	// Non-verb ending in -iste
+	[ "quiste", "quist" ],
+	// Non-verb ending in -ido
+	[ "sólida", "solid" ],
+	// Non-verb ending in -ida
+	[ "antióxido", "antioxid" ],
 ];
 
 describe( "Test for stemming Spanish words", () => {


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [yoastseo] Add specs for verb form looking words ending in -asta, -ista, -ida, and -ido

## Relevant technical choices:

*

## Test instructions

This PR can be tested by following these steps:

* Run yarn test and check that all tests pass.

## Impact check

* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #https://yoast.atlassian.net/browse/LIN-342
