### PR TITLE
Stem plurals of Spanish words from the non-verbs list correctly

### DIFF
--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -289,7 +289,7 @@ const wordsToStem = [
 	[ "gobieron", "gobieron" ],
 	// Non-verb ending in -iera
 	[ "ingeniera", "ingenier" ],
-	// [ "ingenieras", "ingenier" ],
+	[ "ingenieras", "ingenier" ],
 	// Non-verb ending in -aron
 	[ "gatillaron", "gatillaron" ],
 	// Non-verb ending in -ida
@@ -333,10 +333,12 @@ const wordsToStem = [
 	[ "empaste", "empast" ],
 	// Non-verb ending in -iste
 	[ "quiste", "quist" ],
-	// Non-verb ending in -ido
-	[ "sólida", "solid" ],
 	// Non-verb ending in -ida
+	[ "sólida", "solid" ],
+	//[ "sólidas", "solid" ],
+	// Non-verb ending in -ido
 	[ "antióxido", "antioxid" ],
+	//[ "antióxidos", "antioxid" ],
 ];
 
 describe( "Test for stemming Spanish words", () => {

--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -193,13 +193,13 @@ const wordsToStem = [
 	// Words that look like verb forms but aren't verbs.
 	// Non-verb ending in -ió
 	[ "chevió", "chevi" ],
-	// [ "cheviós", "chevi" ],
+	[ "cheviós", "chevi" ],
 	// Non-verb ending in -irán
 	[ "caguairán", "caguairan" ],
 	[ "caguairanes", "caguairan" ],
 	// Non-verb ending in -ái
 	[ "samurái", "samurai" ],
-	// [ "samuráis", "samurai" ],
+	[ "samuráis", "samurai" ],
 	// Non-verb ending in -ei
 	[ "chatolei", "chatolei" ],
 	// Non-verb ending in -éi
@@ -214,10 +214,10 @@ const wordsToStem = [
 	[ "abadas", "abad" ],
 	// Non-verb ending in -ado
 	[ "mercado", "mercad" ],
-	// [ "mercados", "mercad" ],
+	[ "mercados", "mercad" ],
 	// Non-verb ending in -imo
 	[ "mínimo", "minim" ],
-	// [ "mínimos", "minim" ],
+	[ "mínimos", "minim" ],
 	// Non-verb ending in -emo
 	[ "extremo", "extrem" ],
 	[ "extremos", "extrem" ],
@@ -232,7 +232,7 @@ const wordsToStem = [
 	[ "series", "seri" ],
 	// Non-verb ending in -ié
 	[ "hincapié", "hincapi" ],
-	// [ "hincapiés", "hincapi" ],
+	[ "hincapiés", "hincapi" ],
 	// Non-verb ending in -ando
 	[ "contrabando", "contraband" ],
 	[ "contrabandos", "contraband" ],
@@ -240,19 +240,19 @@ const wordsToStem = [
 	[ "cuándo", "cuand" ],
 	// Non-verb ending in -aré
 	[ "pagaré", "pagar" ],
-	// [ "pagarés", "pagar" ],
+	[ "pagarés", "pagar" ],
 	// Non-verb ending in -eré
 	[ "tereré", "terer" ],
-	// [ "tererés", "terer" ],
+	[ "tererés", "terer" ],
 	// Non-verb ending in -ará
 	[ "yarará", "yarar" ],
-	// [ "yararás", "yarar" ],
+	[ "yararás", "yarar" ],
 	// Non-verb ending in -erá
 	[ "camerá", "camer" ],
-	// [ "camerás", "camer" ],
+	[ "camerás", "camer" ],
 	// Non-verb ending in -irá
 	[ "aragüirá", "aragüir" ],
-	// [ "aragüirás", "aragüir" ],
+	[ "aragüirás", "aragüir" ],
 	// Non-verb ending in -ia
 	[ "historia", "histori" ],
 	[ "historias", "histori" ],
@@ -260,7 +260,7 @@ const wordsToStem = [
 	[ "apartheid", "apartheid" ],
 	// Non-verb ending in -aba
 	[ "guayaba", "guayab" ],
-	// [ "guayabas", "guayab" ],
+	[ "guayabas", "guayab" ],
 	// Non-verb ending in -asta
 	[ "canasta", "canast" ],
 	[ "canastas", "canast" ],
@@ -268,11 +268,11 @@ const wordsToStem = [
 	[ "quiste", "quist" ],
 	[ "quistes", "quist" ],
 	// Non-verb ending in -aste
-	// [ "contraste", "contrast" ],
+	[ "contraste", "contrast" ],
 	[ "contrastes", "contrast" ],
 	// Non-verb ending in -ía
 	[ "policía", "polici" ],
-	// [ "policías", "polici" ],
+	[ "policías", "polici" ],
 	// Non-verb ending in -an
 	[ "eslogan", "eslogan" ],
 	[ "eslóganes", "eslogan" ],
@@ -300,10 +300,10 @@ const wordsToStem = [
 	[ "partidos", "part" ],
 	// Non-verb ending in -amo
 	[ "reclamo", "reclam" ],
-	// [ "reclamos", "reclam" ],
+	[ "reclamos", "reclam" ],
 	// Non-verb ending in -ara
 	[ "máscara", "mascar" ],
-	// [ "máscaras", "mascar" ],
+	[ "máscaras", "mascar" ],
 	// Non-verb ending in -ere
 	[ "títere", "titer" ],
 	[ "títeres", "titer" ],
@@ -331,14 +331,16 @@ const wordsToStem = [
 	[ "bumerán", "bumeran" ],
 	// Non-verb ending in -asta
 	[ "empaste", "empast" ],
+	[ "empastes", "empast" ],
 	// Non-verb ending in -iste
 	[ "quiste", "quist" ],
+	[ "quistes", "quist" ],
 	// Non-verb ending in -ida
 	[ "sólida", "solid" ],
-	//[ "sólidas", "solid" ],
+	[ "sólidas", "solid" ],
 	// Non-verb ending in -ido
 	[ "antióxido", "antioxid" ],
-	//[ "antióxidos", "antioxid" ],
+	[ "antióxidos", "antioxid" ],
 ];
 
 describe( "Test for stemming Spanish words", () => {

--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -9,6 +9,7 @@ const wordsToStem = [
 	[ "gas", "gas" ],
 	[ "martes", "martes" ],
 	[ "microondas", "microondas" ],
+	[ "jesús", "jesus" ],
 	// Input a word that ends with a clitic pronoun and is on the list of words that end like pronouns suffixes but are not verbs.
 	[ "anime", "anim" ],
 	[ "abuela", "abuel" ],

--- a/packages/yoastseo/src/morphology/spanish/stem.js
+++ b/packages/yoastseo/src/morphology/spanish/stem.js
@@ -208,14 +208,12 @@ const canonicalizeStem = function( stemmedWord, stemsThatBelongToOneWord ) {
  * @returns {string} The word with the verb suffixes removed (if applicable).
  */
 const stemVerbSuffixes = function( word, wordAfter1, rvText, rv, morphologyData ) {
-	const notVerbForms = morphologyData.wordsThatLookLikeButAreNot.notVerbForms;
 	const nonPluralsOnS = morphologyData.wordsThatLookLikeButAreNot.nonPluralsOnS;
 
 	// Do step 2a if no ending was removed by step 1.
 	const suf = endsInArr( rvText, [ "ya", "ye", "yan", "yen", "yeron", "yendo", "yo", "yó", "yas", "yes", "yais", "yamos" ] );
 
-	if ( suf !== "" && ( word.slice( -suf.length - 1, -suf.length ) === "u" ) &&
-		! notVerbForms.includes( word ) ) {
+	if ( suf !== "" && ( word.slice( -suf.length - 1, -suf.length ) === "u" ) ) {
 		word = word.slice( 0, -suf.length );
 	}
 
@@ -238,11 +236,9 @@ const stemVerbSuffixes = function( word, wordAfter1, rvText, rv, morphologyData 
 			"isteis", "ados", "idos", "amos", "ábamos", "íamos", "imos", "áramos",
 			"iéramos", "iésemos", "ásemos" ] );
 		const suf12 = endsInArr( rvText, [ "en", "es", "éis", "emos" ] );
-		if ( suf11 !== "" && ! nonPluralsOnS.includes( word ) &&
-			! notVerbForms.includes( word ) ) {
+		if ( suf11 !== "" && ! nonPluralsOnS.includes( word ) ) {
 			word = word.slice( 0, -suf11.length );
-		} else if ( suf12 !== "" && ! nonPluralsOnS.includes( word ) &&
-			! notVerbForms.includes( word ) ) {
+		} else if ( suf12 !== "" && ! nonPluralsOnS.includes( word ) ) {
 			word = word.slice( 0, -suf12.length );
 			if ( endsIn( word, "gu" ) ) {
 				word = word.slice( 0, -1 );
@@ -397,7 +393,18 @@ export default function stem( word, morphologyData ) {
 
 	// Step 2a and 2b stem verb suffixes.
 	const notVerbForms = morphologyData.wordsThatLookLikeButAreNot.notVerbForms;
-	if ( wordAfter0 === wordAfter1 && ! notVerbForms.includes( word ) ) {
+
+	/**
+	 * The list of non-verbs is checked after removing the possible -s from the end of the word, in case the word was a
+	 * plural of a word on the non-verb list.
+	 */
+	let wordWithoutS = word;
+
+	if ( word.endsWith( "s" ) ) {
+		wordWithoutS = word.slice( 0, -1 );
+	}
+
+	if ( wordAfter0 === wordAfter1 && ! notVerbForms.includes( wordWithoutS ) ) {
 		word = stemVerbSuffixes( word, wordAfter1, rvText, rv, morphologyData );
 	}
 

--- a/packages/yoastseo/src/morphology/spanish/stem.js
+++ b/packages/yoastseo/src/morphology/spanish/stem.js
@@ -262,9 +262,10 @@ export default function stem( word, morphologyData ) {
 	if ( ifException ) {
 		return ifException;
 	}
+
 	const nonPluralsOnS = morphologyData.wordsThatLookLikeButAreNot.nonPluralsOnS;
 	if ( nonPluralsOnS.includes( word ) ) {
-		return word;
+		return removeAccent( word );
 	}
 
 	const length = word.length;
@@ -405,10 +406,10 @@ export default function stem( word, morphologyData ) {
 
 		if ( notVerbForms.includes( wordWithoutS ) ) {
 			/*
-			* If the word without -s is matched on the non-verbs list, we can perform the next (non-verb) stemming steps
-			* with the -s removed. This is because all possible non-verb suffixes ending in -s also have an equivalent
-			* without the -s (e.g. -as/a; -es/e), so will be stemmed after stripping the -s.
-			*/
+			 * If the word without -s is matched on the non-verbs list, we can perform the next (non-verb) stemming steps
+			 * with the -s removed. This is because all possible non-verb suffixes ending in -s also have an equivalent
+			 * without the -s (e.g. -as/a; -es/e), so will be stemmed after stripping the -s.
+			 */
 			word = wordWithoutS;
 		} else {
 			word = stemVerbSuffixes( word, wordAfter1, rvText, rv, morphologyData );


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Makes sure that plurals of Spanish words on the notVerbForms list are stemmed correctly

## Test instructions

This PR can be tested by following these steps:

* Take some words from the notVerbForms list
* Add -s at the end of the words
* Add them to stemSpec and make sure they are stemmed correctly (-s should always be stemmed)

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/jira/software/projects/LIN/boards/4?selectedIssue=LIN-341
