### PR TITLE
Update some Spanish stem specs

### DIFF
--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -77,7 +77,6 @@ const wordsToStem = [
 	// Input a word that is on the stems that belong together list.
 	// [ "dollar", "dolar" ],
 	// [ "chalets", "chale" ],
-	// [ "sé", "sab" ],
 	[ "quepa", "cab" ],
 	// Input a word that ends in -en, -es, -éis, -emos and is not preceded by gu.
 	[ "valéis", "val" ],
@@ -85,9 +84,10 @@ const wordsToStem = [
 	// Input a word that ends in -en, -es, -éis, -emos and is preceded by gu.
 	[ "distinguen", "distingu" ],
 	[ "alarguemos", "alarg" ],
+	// Input a participle of a verb that is also a noun (should be stemmed as a verb)
+	[ "cabalgadas", "cabalg" ],
 	// Input a word that looks like a verb form but it's not.
-	// [ "cabalgada", "cabalgad" ],
-	// [ "abacerías", "abaceri" ],
+	[ "abacerías", "abaceri" ],
 	// Input a word that looks like a verb form and is on the list of stems that belong together.
 	[ "san", "san" ],
 	[ "virgen", "virgen" ],


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [yoastseo] In Spanish stem specs: Uncomments passing spec, deletes a spec for a word that is a function word; and changes an expected stem for one word and uncomments the spec

## Relevant technical choices:

* The expected stem for _cabalgada_ was _cabalgad_ - it was expected to be stemmed as a noun. However, the word can be both a noun and a verb form (participle), with related meanings. If the word is stemmed as a verb, all the noun forms and verb forms will get the same stem _(cabalg_). This is okay since their meanings are related. Therefore, the expected stem was changed to _cabalg_ and the spec was uncommented since it now passes.

## Test instructions

This PR can be tested by following these steps:

* Make sure that all specs in the Spanish stemSpec pass.


## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-351
