### PR TITLE
Fix the text analysis breaking on ying

### DIFF
--- a/packages/yoastseo/spec/morphology/english/determineStemEnglishSpec.js
+++ b/packages/yoastseo/spec/morphology/english/determineStemEnglishSpec.js
@@ -286,6 +286,7 @@ describe( "determineStem", function() {
 		expect( determineStem( "anaesthesias'", morphologyDataEN ) ).toEqual( "anaesthesia" );
 
 		expect( determineStem( "traffic", morphologyDataEN ) ).toEqual( "traffic" );
+		expect( determineStem( "ying", morphologyDataEN ) ).toEqual( "ying" );
 	} );
 
 	it( "returns the stem of an irregular verb/noun", function() {

--- a/packages/yoastseo/src/morphology/english/getVerbStem.js
+++ b/packages/yoastseo/src/morphology/english/getVerbStem.js
@@ -167,7 +167,7 @@ const endsWithIng = function( word ) {
 	const vowelCount = ( word.match( vowelRegex ) || [] ).length;
 
 	// Consider only words that have at least one more vowel besides "i" in "ing" (otherwise, words like "ping" are being treated as verb forms).
-	if ( vowelCount > 1 ) {
+	if ( vowelCount > 1 && word.length > 4 ) {
 		return word.substring( word.length - 3, word.length ) === "ing";
 	}
 	return false;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the text analysis would break if the text contains the word "Ying".

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* To reproduce
  * Check out `develop` in `javascript` and in `premium-configuration`
  * Start your `content-analysis` app
  * Create a text that contains the word `Ying` and add a keyphrase, set your locale to English
  * See that a number of keyphrase-based assessments break
* Check that it is fixed now
  * Check out `fix-ying-stemming` in `javascript`
  * Refresh your `content-analysis` app
  * See that the text analysis returns good results and the console error disappeared

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/bugreports/issues/932