### PR TITLE
Add test entries for words that look like verbs with personal pronouns but are not

### DIFF
--- a/packages/yoastseo/spec/morphology/spanish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/spanish/stemSpec.js
@@ -373,6 +373,19 @@ const wordsToStem = [
 	// Non-verb ending in -ido
 	[ "antióxido", "antioxid" ],
 	[ "antióxidos", "antioxid" ],
+	// Input a word that looks like it ends on a personal pronoun but is not.
+	// Word with no personal pronoun ending on -me
+	[ "uniforme", "uniform" ],
+	// Word with no personal pronoun ending on -se
+	[ "concordiense", "concordiens" ],
+	// Word with no personal pronoun ending on -le
+	[ "doble", "dobl" ],
+	// Word with no personal pronoun ending on -la
+	[ "acerola", "acerol" ],
+	// Word with no personal pronoun ending on -lo
+	[ "estrello", "estrell" ],
+	// Word with no personal pronoun ending on -no
+	[ "inferno", "infern" ],
 ];
 
 const paradigms = [


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [yoastseo] Adds test specs for words on -lo, -la, -le, -me, -se, -no that must skip the step of removing pronoun suffixes in the stemmer.

## Test instructions

This PR can be tested by following these steps:

* run `yarn test` and make sure it passes 

Fixes #https://yoast.atlassian.net/jira/software/projects/LIN/boards/4?selectedIssue=LIN-328