### PR TITLE
Create Social Preview Editor component

### DIFF
--- a/apps/components/App.js
+++ b/apps/components/App.js
@@ -119,7 +119,7 @@ const components = [
 		component: <SocialPreviewFormWrapper />,
 	},
 	{
-		id: "social-preview-",
+		id: "social-preview",
 		name: "Social Preview",
 		component: <SocialPreviewEditorWrapper />,
 	},
@@ -145,7 +145,7 @@ class App extends React.Component {
 		super();
 
 		this.state = {
-			activeComponent: "buttons",
+			activeComponent: ( localStorage.getItem( "active-component" ) || "buttons" ),
 			isRtl: false,
 		};
 		this.changeLanguageDirection = this.changeLanguageDirection.bind( this );
@@ -175,6 +175,8 @@ class App extends React.Component {
 	navigate( activeComponent ) {
 		this.setState( {
 			activeComponent: activeComponent,
+		}, () => {
+			localStorage.setItem( "active-component", activeComponent );
 		} );
 	}
 

--- a/apps/components/App.js
+++ b/apps/components/App.js
@@ -21,6 +21,7 @@ import WordOccurrencesWrapper from "./WordOccurrencesWrapper";
 import MultiStepProgressWrapper from "./MultiStepProgressWrapper";
 import SocialPreviewFormWrapper from "./SocialPreviewFormWrapper";
 import ReactifiedComponentsWrapper from "./ReactifiedComponentsWrapper";
+import SocialPreviewEditorWrapper from "./SocialPreviewEditorWrapper";
 
 
 // Setup empty translations to prevent Jed error.
@@ -116,6 +117,11 @@ const components = [
 		id: "social-preview-data-form",
 		name: "Social Preview data form",
 		component: <SocialPreviewFormWrapper />,
+	},
+	{
+		id: "social-preview-",
+		name: "Social Preview",
+		component: <SocialPreviewEditorWrapper />,
 	},
 	{
 		id: "reactified-components",

--- a/apps/components/ReactifiedComponentsWrapper.js
+++ b/apps/components/ReactifiedComponentsWrapper.js
@@ -3,6 +3,11 @@ import TextInput from "@yoast/components/src/inputs/TextInput";
 import TextArea from "@yoast/components/src/inputs/TextArea";
 import RadioButtonGroup from "@yoast/components/src/radiobutton/RadioButtonGroup";
 
+/**
+ * Wraps all components in a div.
+ *
+ * @returns {*} A div with all reactified components.
+ */
 const ReactifiedComponentsWrapper = () => {
 	return (
 		<div className="yoast">

--- a/apps/components/SocialPreviewEditorWrapper.js
+++ b/apps/components/SocialPreviewEditorWrapper.js
@@ -21,8 +21,8 @@ class SocialPreviewEditorWrapper extends React.Component {
 		super( props );
 
 		this.state = {
-			title: "",
-			description: "",
+			title: "Initial title state",
+			description: "Initial description state",
 			image: "",
 		};
 

--- a/apps/components/SocialPreviewEditorWrapper.js
+++ b/apps/components/SocialPreviewEditorWrapper.js
@@ -1,6 +1,12 @@
 import React  from "react";
+import styled from "styled-components";
 
 import SocialPreviewEditor from "@yoast/social-metadata-previews/src/editor/SocialPreviewEditor";
+const Container = styled.div`
+	background-color: white;
+	margin: 20px;
+`;
+
 
 class SocialPreviewEditorWrapper extends React.Component {
 	constructor( props ) {
@@ -15,6 +21,7 @@ class SocialPreviewEditorWrapper extends React.Component {
 		this.setTitle = this.setStateAttribute.bind( this, "title" );
 		this.setDescription = this.setStateAttribute.bind( this, "description" );
 		this.setImage = this.setStateAttribute.bind( this, "image" );
+		this.removeImage = this.setStateAttribute.bind( this, "image", "" );
 	}
 
 	setStateAttribute( attr, value ) {
@@ -27,17 +34,19 @@ class SocialPreviewEditorWrapper extends React.Component {
 	render() {
 		console.log( this.state );
 		return (
-			<SocialPreviewEditor
-				title={ this.state.title }
-				onTitleChange={ this.setTitle }
-				description={ this.state.description }
-				onDescriptionChange={ this.setDescription }
-				siteName="Site name"
-				onRemoveImageClick={ () => this.setImage( "" ) }
-				alt="Alt text"
-				image={ this.state.image }
-				onSelectImageClick={ () => this.setImage( "https://www.yarrah.com/en/wp-content/uploads/sites/10/2019/01/Puppy-aanschaffen-header-800x600.png" ) }
-			/>
+			<Container>
+				<SocialPreviewEditor
+					title={ this.state.title }
+					onTitleChange={ this.setTitle }
+					description={ this.state.description }
+					onDescriptionChange={ this.setDescription }
+					siteName="Site name"
+					onRemoveImageClick={ this.removeImage }
+					alt="Alt text"
+					image={ this.state.image }
+					onSelectImageClick={ () => this.setImage( "https://www.yarrah.com/en/wp-content/uploads/sites/10/2019/01/Puppy-aanschaffen-header-800x600.png" ) }
+				/>
+			</Container>
 		);
 	}
 

--- a/apps/components/SocialPreviewEditorWrapper.js
+++ b/apps/components/SocialPreviewEditorWrapper.js
@@ -24,12 +24,14 @@ class SocialPreviewEditorWrapper extends React.Component {
 			title: "Initial title state",
 			description: "Initial description state",
 			image: "",
+			isLarge: true,
 		};
 
 		this.setTitle = this.setStateAttribute.bind( this, "title" );
 		this.setDescription = this.setStateAttribute.bind( this, "description" );
 		this.setImage = this.setStateAttribute.bind( this, "image" );
 		this.removeImage = this.setStateAttribute.bind( this, "image", "" );
+		this.toggleLarge = this.setStateAttribute.bind( this, "isLarge" );
 	}
 
 	/**
@@ -71,6 +73,7 @@ class SocialPreviewEditorWrapper extends React.Component {
 				/>
 				<br />
 				<h2>Twitter</h2>
+				<button onClick={ () => this.toggleLarge( ! this.state.isLarge ) }>Toggle Large Summary Card</button>
 				<SocialPreviewEditor
 					title={ this.state.title }
 					onTitleChange={ this.setTitle }
@@ -79,6 +82,7 @@ class SocialPreviewEditorWrapper extends React.Component {
 					siteName="Site name"
 					onRemoveImageClick={ this.removeImage }
 					alt="Alt text"
+					isLarge={ this.state.isLarge }
 					image={ this.state.image }
 					socialMediumName={ "Twitter" }
 					// eslint-disable-next-line react/jsx-no-bind

--- a/apps/components/SocialPreviewEditorWrapper.js
+++ b/apps/components/SocialPreviewEditorWrapper.js
@@ -1,0 +1,45 @@
+import React  from "react";
+
+import SocialPreviewEditor from "@yoast/social-metadata-previews/src/editor/SocialPreviewEditor";
+
+class SocialPreviewEditorWrapper extends React.Component {
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			title: "",
+			description: "",
+			image: "",
+		};
+
+		this.setTitle = this.setStateAttribute.bind( this, "title" );
+		this.setDescription = this.setStateAttribute.bind( this, "description" );
+		this.setImage = this.setStateAttribute.bind( this, "image" );
+	}
+
+	setStateAttribute( attr, value ) {
+		this.setState( state => ( {
+			...state,
+			[ attr ]: value,
+		} ) );
+	}
+
+	render() {
+		console.log( this.state );
+		return (
+			<SocialPreviewEditor
+				title={ this.state.title }
+				onTitleChange={ this.setTitle }
+				description={ this.state.description }
+				onDescriptionChange={ this.setDescription }
+				siteName="Site name"
+				onRemoveImageClick={ () => this.setImage( "" ) }
+				alt="Alt text"
+				image={ this.state.image }
+				onSelectImageClick={ () => this.setImage( "https://www.yarrah.com/en/wp-content/uploads/sites/10/2019/01/Puppy-aanschaffen-header-800x600.png" ) }
+			/>
+		);
+	}
+
+}
+export default SocialPreviewEditorWrapper;

--- a/apps/components/SocialPreviewEditorWrapper.js
+++ b/apps/components/SocialPreviewEditorWrapper.js
@@ -4,11 +4,19 @@ import styled from "styled-components";
 import SocialPreviewEditor from "@yoast/social-metadata-previews/src/editor/SocialPreviewEditor";
 const Container = styled.div`
 	background-color: white;
+	padding: 16px;
 	margin: 20px;
 `;
 
-
+/**
+ * @returns {void} Void
+ */
 class SocialPreviewEditorWrapper extends React.Component {
+	/**
+	* The constructor
+	*
+	@param {Object} props The properties of this component.
+	*/
 	constructor( props ) {
 		super( props );
 
@@ -24,15 +32,24 @@ class SocialPreviewEditorWrapper extends React.Component {
 		this.removeImage = this.setStateAttribute.bind( this, "image", "" );
 	}
 
+	/**
+	* @returns {void} Void
+	*
+	* @param {Object} attr Attributes
+	* @param {string} value Value
+	*/
 	setStateAttribute( attr, value ) {
 		this.setState( state => ( {
 			...state,
 			[ attr ]: value,
 		} ) );
 	}
-
+	/**
+	* @returns {void} Void
+	*
+	@param {Object} props The properties of this component.
+	*/
 	render() {
-		console.log( this.state );
 		return (
 			<Container>
 				<SocialPreviewEditor
@@ -44,11 +61,13 @@ class SocialPreviewEditorWrapper extends React.Component {
 					onRemoveImageClick={ this.removeImage }
 					alt="Alt text"
 					image={ this.state.image }
-					onSelectImageClick={ () => this.setImage( "https://www.yarrah.com/en/wp-content/uploads/sites/10/2019/01/Puppy-aanschaffen-header-800x600.png" ) }
+					// eslint-disable-next-line react/jsx-no-bind
+					onSelectImageClick={ () => this.setImage(
+						"https://www.yarrah.com/en/wp-content/uploads/sites/10/2019/01/Puppy-aanschaffen-header-800x600.png"
+					) }
 				/>
 			</Container>
 		);
 	}
-
 }
 export default SocialPreviewEditorWrapper;

--- a/apps/components/SocialPreviewEditorWrapper.js
+++ b/apps/components/SocialPreviewEditorWrapper.js
@@ -52,6 +52,7 @@ class SocialPreviewEditorWrapper extends React.Component {
 	render() {
 		return (
 			<Container>
+				<h2>Facebook</h2>
 				<SocialPreviewEditor
 					title={ this.state.title }
 					onTitleChange={ this.setTitle }
@@ -61,6 +62,25 @@ class SocialPreviewEditorWrapper extends React.Component {
 					onRemoveImageClick={ this.removeImage }
 					alt="Alt text"
 					image={ this.state.image }
+					socialMediumName={ "Facebook" }
+					// eslint-disable-next-line react/jsx-no-bind
+					onSelectImageClick={ () => this.setImage(
+						"https://www.yarrah.com/en/wp-content/uploads/sites/10/2019/01/Puppy-aanschaffen-header-800x600.png"
+					) }
+					isPremium={ true }
+				/>
+				<br />
+				<h2>Twitter</h2>
+				<SocialPreviewEditor
+					title={ this.state.title }
+					onTitleChange={ this.setTitle }
+					description={ this.state.description }
+					onDescriptionChange={ this.setDescription }
+					siteName="Site name"
+					onRemoveImageClick={ this.removeImage }
+					alt="Alt text"
+					image={ this.state.image }
+					socialMediumName={ "Twitter" }
 					// eslint-disable-next-line react/jsx-no-bind
 					onSelectImageClick={ () => this.setImage(
 						"https://www.yarrah.com/en/wp-content/uploads/sites/10/2019/01/Puppy-aanschaffen-header-800x600.png"

--- a/apps/components/SocialPreviewEditorWrapper.js
+++ b/apps/components/SocialPreviewEditorWrapper.js
@@ -65,6 +65,7 @@ class SocialPreviewEditorWrapper extends React.Component {
 					onSelectImageClick={ () => this.setImage(
 						"https://www.yarrah.com/en/wp-content/uploads/sites/10/2019/01/Puppy-aanschaffen-header-800x600.png"
 					) }
+					isPremium={ true }
 				/>
 			</Container>
 		);

--- a/apps/components/package.json
+++ b/apps/components/package.json
@@ -60,7 +60,8 @@
   },
   "jest": {
     "testRegex": ".*Test.js$",
-    "testEnvironment": "node",
+    "testEnvironment": "jsdom",
+    "testURL": "http://localhost",
     "transform": {
       "\\.jsx?$": "babel-jest"
     },

--- a/apps/components/tests/__snapshots__/appTest.js.snap
+++ b/apps/components/tests/__snapshots__/appTest.js.snap
@@ -148,6 +148,13 @@ exports[`App renders without problems 1`] = `
       style={Object {}}
       type="button"
     >
+      Social Preview
+    </button>
+    <button
+      onClick={[Function]}
+      style={Object {}}
+      type="button"
+    >
       Reactified components
     </button>
     <p

--- a/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
@@ -80,7 +80,6 @@ class ReplacementVariableEditor extends React.Component {
 			editorRef,
 			placeholder,
 			fieldId,
-			withCaret,
 			onMouseEnter,
 			onMouseLeave,
 		} = this.props;
@@ -117,7 +116,6 @@ class ReplacementVariableEditor extends React.Component {
 						onChange={ onChange }
 						onFocus={ onFocus }
 						onBlur={ onBlur }
-						withCaret={ withCaret }
 						replacementVariables={ replacementVariables }
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						ref={ ref => {

--- a/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditor.js
@@ -80,6 +80,9 @@ class ReplacementVariableEditor extends React.Component {
 			editorRef,
 			placeholder,
 			fieldId,
+			withCaret,
+			onMouseEnter,
+			onMouseLeave,
 		} = this.props;
 
 		const InputContainer = this.InputContainer;
@@ -91,7 +94,10 @@ class ReplacementVariableEditor extends React.Component {
 		</TriggerReplacementVariableSuggestionsButton>;
 
 		return (
-			<FormSection>
+			<FormSection
+				onMouseEnter={ onMouseEnter }
+				onMouseLeave={ onMouseLeave }
+			>
 				<SimulatedLabel
 					id={ this.uniqueId }
 					onClick={ onFocus }
@@ -111,6 +117,7 @@ class ReplacementVariableEditor extends React.Component {
 						onChange={ onChange }
 						onFocus={ onFocus }
 						onBlur={ onBlur }
+						withCaret={ withCaret }
 						replacementVariables={ replacementVariables }
 						recommendedReplacementVariables={ recommendedReplacementVariables }
 						ref={ ref => {
@@ -140,6 +147,8 @@ ReplacementVariableEditor.propTypes = {
 	placeholder: PropTypes.string,
 	type: PropTypes.oneOf( [ "title", "description" ] ).isRequired,
 	fieldId: PropTypes.string,
+	onMouseEnter: PropTypes.func,
+	onMouseLeave: PropTypes.func,
 };
 
 ReplacementVariableEditor.defaultProps = {
@@ -154,6 +163,8 @@ ReplacementVariableEditor.defaultProps = {
 	isHovered: false,
 	isActive: false,
 	editorRef: () => {},
+	onMouseEnter: () => {},
+	onMouseLeave: () => {},
 };
 
 export default ReplacementVariableEditor;

--- a/packages/social-metadata-forms/src/ImageSelect.js
+++ b/packages/social-metadata-forms/src/ImageSelect.js
@@ -85,8 +85,11 @@ const renderButtons = ( onClick, imageSelected, onRemoveImageClick ) => {
  *
  * @returns {React.Component} The ImageSelect component with a title, optional warnings and an image selection button.
  */
-const ImageSelect = ( { title, warnings, onClick, imageSelected, onRemoveImageClick, imageUrl, isPremium } ) =>
-	<Fragment>
+const ImageSelect = ( { title, warnings, onClick, imageSelected, onRemoveImageClick, imageUrl, isPremium, onMouseEnter, onMouseLeave } ) =>
+	<div
+		onMouseEnter={ onMouseEnter }
+		onMouseLeave={ onMouseLeave }
+	>
 		<SimulatedLabel>
 			{ title }
 		</SimulatedLabel>
@@ -105,7 +108,7 @@ const ImageSelect = ( { title, warnings, onClick, imageSelected, onRemoveImageCl
 					</RowWrapper>
 				</ColumnWrapper>
 		}
-	</Fragment>
+	</div>
 ;
 
 ImageSelect.propTypes = {
@@ -116,6 +119,8 @@ ImageSelect.propTypes = {
 	onRemoveImageClick: PropTypes.func,
 	warnings: PropTypes.arrayOf( PropTypes.string ),
 	imageUrl: PropTypes.string,
+	onMouseEnter: PropTypes.func,
+	onMouseLeave: PropTypes.func,
 };
 
 ImageSelect.defaultProps = {
@@ -123,6 +128,8 @@ ImageSelect.defaultProps = {
 	onClick: () => {},
 	warnings: [],
 	imageUrl: "",
+	onMouseEnter: () => {},
+	onMouseLeave: () => {},
 };
 
 export default ImageSelect;

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -28,6 +28,7 @@ const Caret = styled.div`
 /**
  * Adds caret styles to a component.
  *
+ * @param {string} field The identifier for this field.
  * @param {ReactComponent} WithoutCaret The component without caret styles.
  *
  * @returns {ReactComponent} The component with caret styles.

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -11,7 +11,7 @@ const Caret = styled.div`
 	position: absolute;
 
 	::before {
-		display: block;
+		display: ${ props => ( props.isActive || props.isHovered ) ? "block" : "none" };
 		position: absolute;
 		top: 0;
 		${ getDirectionalStyle( "left", "right" ) === "left" ? "left: 5px" : "right: 5px" };
@@ -29,21 +29,31 @@ const Caret = styled.div`
  * Adds caret styles to a component.
  *
  * @param {ReactComponent} WithoutCaret The component without caret styles.
- * @param {string} color The color to render the caret in.
- * @param {string} mode The mode the snippet preview is in.
  *
  * @returns {ReactComponent} The component with caret styles.
  */
-function addCaretStyle( WithoutCaret ) {
+function addCaretStyle( field, WithoutCaret ) {
 	return (
-		<Fragment>
-			<Caret />
-			<WithoutCaret />
-		</Fragment>
+		function WithCaret( props ) {
+			return (
+				<Fragment>
+					<Caret
+						// eslint-disable-next-line react/prop-types
+						isActive={ props.activeField === field }
+						// eslint-disable-next-line react/prop-types
+						isHovered={ props.hoveredField === field }
+					/>
+					<WithoutCaret { ...props } />
+				</Fragment>
+			);
+		}
 	);
 }
 
-const CaretContainer = addCaretStyle( styled.div`` );
+
+const TitleWithCaret = addCaretStyle( "title", ReplacementVariableEditor );
+const DescriptionWithCaret = addCaretStyle( "description", ReplacementVariableEditor );
+const ImageSelectWithCaret = addCaretStyle( "image", ImageSelect );
 
 /**
  * A form with an image selection button, a title input field and a description field.
@@ -66,28 +76,30 @@ const SocialMetadataPreviewForm = ( props ) => {
 		props.socialMediumName
 	);
 
+	const focusTitle = () => props.onSelect( "title" );
+	const focusDescription = () => props.onSelect( "description" );
+
 	return (
 		<Fragment>
-			<ImageSelect
+			<ImageSelectWithCaret
 				title={ imageSelectTitle }
 				onClick={ props.onSelectImageClick }
 				onRemoveImageClick={ props.onRemoveImageClick }
 				warnings={ props.imageWarnings }
 				imageSelected={ props.imageSelected }
 			/>
-			<div>
-				<Caret />
-				<ReplacementVariableEditor
-					onChange={ props.onTitleChange }
-					content={ props.title }
-					replacementVariables={ props.replacementVariables }
-					recommendedReplacementVariables={ props.recommendedReplacementVariables }
-					type="title"
-					label={ titleEditorTitle }
-				/>
-			</div>
-			<Caret />
-			<ReplacementVariableEditor
+			<TitleWithCaret
+				onChange={ props.onTitleChange }
+				content={ props.title }
+				replacementVariables={ props.replacementVariables }
+				recommendedReplacementVariables={ props.recommendedReplacementVariables }
+				type="title"
+				label={ titleEditorTitle }
+				activeField={ props.activeField }
+				hoveredField={ props.hoveredField }
+				onFocus={ focusTitle }
+			/>
+			<DescriptionWithCaret
 				onChange={ props.onDescriptionChange }
 				content={ props.description }
 				placeholder={ descEditorPlaceholder }
@@ -95,6 +107,9 @@ const SocialMetadataPreviewForm = ( props ) => {
 				recommendedReplacementVariables={ props.recommendedReplacementVariables }
 				type="description"
 				label={ descEditorTitle }
+				activeField={ props.activeField }
+				hoveredField={ props.hoveredField }
+				onFocus={ focusDescription }
 			/>
 		</Fragment>
 	);
@@ -113,6 +128,8 @@ SocialMetadataPreviewForm.propTypes = {
 	onDescriptionChange: PropTypes.func.isRequired,
 	imageWarnings: PropTypes.array,
 	imageSelected: PropTypes.bool.isRequired,
+	hoveredField: PropTypes.string,
+	activeField: PropTypes.string,
 };
 
 SocialMetadataPreviewForm.defaultProps = {

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React, { Fragment, Component } from "react";
 import ImageSelect from "./ImageSelect";
 import PropTypes from "prop-types";
 import { ReplacementVariableEditor, replacementVariablesShape } from "@yoast/replacement-variable-editor";
@@ -16,7 +16,7 @@ import { angleLeft, angleRight, colors } from "@yoast/style-guide";
  * @returns {string} The color of the caret. Black if active, grey otherwise.
  */
 const getCaretColor = ( active ) => {
-	return active ? colors.$color_black : colors.$palette_grey;
+	return active ? colors.$color_snippet_focus : colors.$color_snippet_hover;
 };
 
 const CaretContainer = styled.div`position: relative`;
@@ -27,14 +27,15 @@ const Caret = styled.div`
 
 	::before {
 		position: absolute;
-		top: 8px;
-		${ getDirectionalStyle( "left", "right" ) }: -22px;
+		top: -2px;
+		${ getDirectionalStyle( "left", "right" ) }: -16px;
 		width: 22px;
 		height: 22px;
 		background-image: url(
 		${ props => getDirectionalStyle(
 		angleRight( getCaretColor( props.isActive ) ),
-		angleLeft( getCaretColor( props.isActive ) ) ) }
+		angleLeft( getCaretColor( props.isActive ) )
+	) }
 		);
 		color: ${ props => getCaretColor( props.isActive ) };
 		background-size: 24px;
@@ -49,31 +50,29 @@ Caret.propTypes = {
 	isHovered: PropTypes.bool,
 };
 
-Caret.propTypes = {
+Caret.defaultProps = {
 	isActive: false,
 	isHovered: false,
 };
 
 /**
  * Adds Caret to a component.
- * @param {React.Element} Component The component to add a Caret to.
+ * @param {React.Element} WithoutCaretComponent The component to add a Caret to.
  *
  * @returns {React.Element} A component with added Caret.
  */
-const withCaretStyle = ( Component ) => {
+export const withCaretStyle = ( WithoutCaretComponent ) => {
 	return function ComponentWithCaret( props ) {
 		return (
 			<CaretContainer>
 				{ /* eslint-disable-next-line react/prop-types */ }
 				<Caret isActive={ props.isActive } isHovered={ props.isHovered } />
-				<Component { ...props } />
+				<WithoutCaretComponent { ...props } />
 			</CaretContainer>
 		);
 	};
 };
 
-const TitleWithCaret = withCaretStyle( ReplacementVariableEditor );
-const DescriptionWithCaret = withCaretStyle( ReplacementVariableEditor );
 const ImageSelectWithCaret = withCaretStyle( ImageSelect );
 
 /**
@@ -83,74 +82,145 @@ const ImageSelectWithCaret = withCaretStyle( ImageSelect );
  *
  * @returns {React.Component} Returns a Fragment that contains all input fields.
  */
-const SocialMetadataPreviewForm = ( props ) => {
-	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	const imageSelectTitle = sprintf( __( "%s image", "yoast-components" ), props.socialMediumName );
-	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	const titleEditorTitle = sprintf( __( "%s title", "yoast-components" ), props.socialMediumName );
-	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	const descEditorTitle = sprintf( __( "%s desciption", "yoast-components" ), props.socialMediumName );
-	/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-	const descEditorPlaceholder  = sprintf(
+class SocialMetadataPreviewForm extends Component {
+	/**
+	 * Constructs the component.
+	 *
+	 * @param {Object} props The component's props.
+	 *
+	 * @returns {void}
+	 */
+	constructor( props ) {
+		super( props );
+
+		// Binding fields to onMouseHover to prevent arrow functions in JSX props.
+		this.onImageEnter = props.onMouseHover.bind( this, "image" );
+		this.onTitleEnter = props.onMouseHover.bind( this, "title" );
+		this.onDescriptionEnter = props.onMouseHover.bind( this, "description" );
+		this.onLeave = props.onMouseHover.bind( this, "" );
+
+		this.onSelectTitleEditor = this.onSelectEditor.bind( this, "title" );
+		this.onSelectDescriptionEditor = this.onSelectEditor.bind( this, "description" );
+		this.onDeselectEditor = this.onSelectEditor.bind( this, "" );
+
+		this.onTitleEditorRef = this.onSetEditorRef.bind( this, "title" );
+		this.onDescriptionEditorRef = this.onSetEditorRef.bind( this, "description" );
+	}
+
+	/**
+	 * Handles the onSelect function for the editors.
+	 *
+	 * @param {String} field The field name of the editor to focus.
+	 *
+	 * @returns {void}
+	 */
+	onSelectEditor( field ) {
+		this.props.onSelect( field );
+	}
+
+	/**
+	 * Handles the onSelect function for the editors.
+	 *
+	 * @param {String} field The field name of the editor to focus.
+	 * @param {String} ref The field name of the editor to focus.
+	 *
+	 * @returns {void}
+	 */
+	onSetEditorRef( field, ref ) {
+		this.props.setEditorRef( field, ref );
+	}
+
+	/**
+	 * Renders the component.
+	 *
+	 * @returns {React.Element} The rend
+	 */
+	render() {
+		const {
+			socialMediumName,
+			onSelectImageClick,
+			onRemoveImageClick,
+			title,
+			description,
+			onTitleChange,
+			onDescriptionChange,
+			imageSelected,
+			hoveredField,
+			activeField,
+			isPremium,
+			replacementVariables,
+			recommendedReplacementVariables,
+			imageWarnings,
+			imageUrl,
+		} = this.props;
+
 		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-		__( "Modify your %s description by editing it right here...", "yoast-components" ),
-		props.socialMediumName
-	);
+		const imageSelectTitle = sprintf( __( "%s image", "yoast-components" ), socialMediumName );
+		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+		const titleEditorTitle = sprintf( __( "%s title", "yoast-components" ), socialMediumName );
+		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+		const descEditorTitle = sprintf( __( "%s desciption", "yoast-components" ), socialMediumName );
+		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+		const descEditorPlaceholder  = sprintf(
+			/* Translators: %s expands to the social medium name, i.e. Faceboook. */
+			__( "Modify your %s description by editing it right here...", "yoast-components" ),
+			socialMediumName
+		);
 
-	/**
-	 * @returns {void}
-	 */
-	function focusTitle() {
-		props.onSelect( "title" );
+
+		return (
+			<Fragment>
+				<ImageSelectWithCaret
+					title={ imageSelectTitle }
+					onClick={ onSelectImageClick }
+					onRemoveImageClick={ onRemoveImageClick }
+					warnings={ imageWarnings }
+					imageSelected={ imageSelected }
+					onMouseEnter={ this.onImageEnter }
+					onMouseLeave={ this.onLeave }
+					isActive={ activeField === "image" }
+					isHovered={ hoveredField === "image" }
+					imageUrl={ imageUrl }
+					isPremium={ isPremium }
+				/>
+				<ReplacementVariableEditor
+					onChange={ onTitleChange }
+					content={ title }
+					replacementVariables={ replacementVariables }
+					recommendedReplacementVariables={ recommendedReplacementVariables }
+					type="title"
+					label={ titleEditorTitle }
+					onMouseEnter={ this.onTitleEnter }
+					onMouseLeave={ this.onLeave }
+					isActive={ activeField === "title" }
+					isHovered={ hoveredField === "title" }
+					withCaret={ true }
+					onFocus={ this.onSelectTitleEditor }
+					onBlur={ this.onDeselectEditor }
+					editorRef={ this.onTitleEditorRef }
+				/>
+				<ReplacementVariableEditor
+					onChange={ onDescriptionChange }
+					content={ description }
+					placeholder={ descEditorPlaceholder }
+					replacementVariables={ replacementVariables }
+					recommendedReplacementVariables={ recommendedReplacementVariables }
+					type="description"
+					label={ descEditorTitle }
+					onMouseEnter={ this.onDescriptionEnter }
+					onMouseLeave={ this.onLeave }
+					isActive={ activeField === "description" }
+					isHovered={ hoveredField === "description" }
+					withCaret={ true }
+					onFocus={ this.onSelectDescriptionEditor }
+					onBlur={ this.onDeselectEditor }
+					editorRef={ this.onDescriptionEditorRef }
+				/>
+			</Fragment>
+		);
 	}
-
-	/**
-	 * @returns {void}
-	 */
-	function focusDescription() {
-		props.onSelect( "description" );
-	}
-
-	return (
-		<Fragment>
-			<ImageSelectWithCaret
-				title={ imageSelectTitle }
-				onClick={ props.onSelectImageClick }
-				onRemoveImageClick={ props.onRemoveImageClick }
-				warnings={ props.imageWarnings }
-				imageSelected={ props.imageSelected }
-				isActive={ props.activeField === "image" }
-				isHovered={ props.hoveredField === "image" }
-				imageUrl={ props.imageUrl }
-				isPremium={ props.isPremium }
-			/>
-			<TitleWithCaret
-				onChange={ props.onTitleChange }
-				content={ props.title }
-				replacementVariables={ props.replacementVariables }
-				recommendedReplacementVariables={ props.recommendedReplacementVariables }
-				type="title"
-				label={ titleEditorTitle }
-				isActive={ props.activeField === "title" }
-				isHovered={ props.hoveredField === "title" }
-				onFocus={ focusTitle }
-			/>
-			<DescriptionWithCaret
-				onChange={ props.onDescriptionChange }
-				content={ props.description }
-				placeholder={ descEditorPlaceholder }
-				replacementVariables={ props.replacementVariables }
-				recommendedReplacementVariables={ props.recommendedReplacementVariables }
-				type="description"
-				label={ descEditorTitle }
-				isActive={ props.activeField === "description" }
-				isHovered={ props.hoveredField === "description" }
-				onFocus={ focusDescription }
-			/>
-		</Fragment>
-	);
 }
-;
+
 
 SocialMetadataPreviewForm.propTypes = {
 	socialMediumName: PropTypes.oneOf( [ "Twitter", "Facebook" ] ).isRequired,
@@ -169,6 +239,8 @@ SocialMetadataPreviewForm.propTypes = {
 	recommendedReplacementVariables: PropTypes.arrayOf( PropTypes.string ),
 	imageWarnings: PropTypes.array,
 	imageUrl: PropTypes.string,
+	setEditorRef: PropTypes.func,
+	onMouseHover: PropTypes.func,
 };
 
 SocialMetadataPreviewForm.defaultProps = {
@@ -180,6 +252,8 @@ SocialMetadataPreviewForm.defaultProps = {
 	onSelect: () => {},
 	imageUrl: "",
 	isPremium: false,
+	setEditorRef: () => {},
+	onMouseHover: () => {},
 };
 
 export default SocialMetadataPreviewForm;

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -164,7 +164,7 @@ SocialMetadataPreviewForm.propTypes = {
 	hoveredField: PropTypes.string,
 	activeField: PropTypes.string,
 	onSelect: PropTypes.func,
-	isPremium: PropTypes.bool.isRequired,
+	isPremium: PropTypes.bool,
 	replacementVariables: PropTypes.arrayOf( replacementVariablesShape ),
 	recommendedReplacementVariables: PropTypes.arrayOf( PropTypes.string ),
 	imageWarnings: PropTypes.array,
@@ -179,6 +179,7 @@ SocialMetadataPreviewForm.defaultProps = {
 	activeField: "",
 	onSelect: () => {},
 	imageUrl: "",
+	isPremium: false,
 };
 
 export default SocialMetadataPreviewForm;

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -27,7 +27,7 @@ const Caret = styled.div`
 	::before {
 		position: absolute;
 		top: -2px;
-		${ getDirectionalStyle( "left", "right" ) }: ${ ( props ) => props.inPreview ? "-35px" : "-25px" };
+		${ getDirectionalStyle( "left", "right" ) }: -25px;
 		width: 24px;
 		height: 24px;
 		background-image: url(
@@ -47,28 +47,25 @@ const Caret = styled.div`
 Caret.propTypes = {
 	isActive: PropTypes.bool,
 	isHovered: PropTypes.bool,
-	inPreview: PropTypes.bool,
 };
 
 Caret.defaultProps = {
 	isActive: false,
 	isHovered: false,
-	inPreview: false,
 };
 
 /**
  * Adds Caret to a component.
  * @param {React.Element} WithoutCaretComponent The component to add a Caret to.
- * @param {bool} inPreview Whether or not the component is in a social preview.
  *
  * @returns {React.Element} A component with added Caret.
  */
-export const withCaretStyle = ( WithoutCaretComponent, inPreview = false ) => {
+export const withCaretStyle = ( WithoutCaretComponent ) => {
 	return function ComponentWithCaret( props ) {
 		return (
 			<CaretContainer>
 				{ /* eslint-disable-next-line react/prop-types */ }
-				<Caret isActive={ props.isActive } isHovered={ props.isHovered } inPreview={ inPreview } />
+				<Caret isActive={ props.isActive } isHovered={ props.isHovered } />
 				<WithoutCaretComponent { ...props } />
 			</CaretContainer>
 		);

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -238,7 +238,7 @@ SocialMetadataPreviewForm.propTypes = {
 	activeField: PropTypes.string,
 	onSelect: PropTypes.func,
 	isPremium: PropTypes.bool,
-	replacementVariables: PropTypes.arrayOf( replacementVariablesShape ),
+	replacementVariables: replacementVariablesShape,
 	recommendedReplacementVariables: PropTypes.arrayOf( PropTypes.string ),
 	imageWarnings: PropTypes.array,
 	imageUrl: PropTypes.string,

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -11,19 +11,19 @@ import { angleLeft, angleRight, colors } from "@yoast/style-guide";
  * Sets the color based on whether the caret is active or not (usually hovered).
  * Display css prop sets the visibility, so this only needs to switch color.
  *
- * @param {*} showActive Whether to show the active color or the hover color.
- * 
+ * @param {*} active Whether to show the active color or the hover color.
+ *
  * @returns {string} The color of the caret. Black if active, grey otherwise.
  */
-const getCaretColor = ( showActive ) => {
-	return showActive ? colors.$color_black : colors.$palette_grey;
+const getCaretColor = ( active ) => {
+	return active ? colors.$color_black : colors.$palette_grey;
 };
 
 const CaretContainer = styled.div`position: relative`;
 
 const Caret = styled.div`
 	position: absolute;
-	display: ${ props => ( props.showActive || props.showHovered ) ? "block" : "none" };
+	display: ${ props => ( props.active || props.hovered ) ? "block" : "none" };
 
 	::before {
 		position: absolute;
@@ -33,10 +33,10 @@ const Caret = styled.div`
 		height: 22px;
 		background-image: url(
 		${ props => getDirectionalStyle(
-		angleRight( getCaretColor( props.showActive ) ),
-		angleLeft( getCaretColor( props.showActive ) ) ) }
+		angleRight( getCaretColor( props.active ) ),
+		angleLeft( getCaretColor( props.active ) ) ) }
 		);
-		color: ${ props => getCaretColor( props.showActive ) };
+		color: ${ props => getCaretColor( props.active ) };
 		background-size: 24px;
 		background-repeat: no-repeat;
 		background-position: center;
@@ -45,13 +45,13 @@ const Caret = styled.div`
 `;
 
 Caret.propTypes = {
-	showActive: PropTypes.bool,
-	showHovered: PropTypes.bool,
+	active: PropTypes.bool,
+	hovered: PropTypes.bool,
 };
 
 Caret.propTypes = {
-	showActive: false,
-	showHovered: false,
+	active: false,
+	hovered: false,
 };
 
 /**
@@ -65,7 +65,7 @@ const withCaretStyle = ( Component ) => {
 		return (
 			<CaretContainer>
 				{ /* eslint-disable-next-line react/prop-types */ }
-				<Caret showActive={ props.isActive } showHovered={ props.isHovered } />
+				<Caret active={ props.isActive } hovered={ props.isHovered } />
 				<Component { ...props } />
 			</CaretContainer>
 		);

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -8,36 +8,73 @@ import { getDirectionalStyle } from "@yoast/helpers";
 import { angleLeft, angleRight, colors } from "@yoast/style-guide";
 
 /**
- * Adds caret styles to a component.
+ * Sets the color based on whether the caret is active or not (usually hovered).
+ * Display css prop sets the visibility, so this only needs to switch color.
  *
- * @param {ReactComponent} WithoutCaret The component without caret styles.
- *
- * @returns {ReactComponent} The component with caret styles.
+ * @param {*} showActive Whether to show the active color or the hover color.
+ * 
+ * @returns {string} The color of the caret. Black if active, grey otherwise.
  */
-function addCaretStyle( WithoutCaret ) {
-	const WithCaret = styled( WithoutCaret )`
-		&::before {
-			display: ${ props => ( props.isActive || props.isHovered ) ? "block" : "none" };
-			position: absolute;
-			top: 0;
-			${ getDirectionalStyle( "left", "right" ) === "left" ? "left: -22px" : "right: 5px" };
-			width: 22px;
-			height: 22px;
-			background-image: url( ${ getDirectionalStyle( angleRight( colors.$color_black ), angleLeft( colors.$color_black ) ) } );
-			background-size: 24px;
-			background-repeat: no-repeat;
-			background-position: center;
-			content: "";
-		}
-	`;
+const getCaretColor = ( showActive ) => {
+	return showActive ? colors.$color_black : colors.$palette_grey;
+};
 
-	return WithCaret;
-}
+const CaretContainer = styled.div`position: relative`;
 
+const Caret = styled.div`
+	position: absolute;
+	display: ${ props => ( props.showActive || props.showHovered ) ? "block" : "none" };
 
-const TitleWithCaret = addCaretStyle( ReplacementVariableEditor );
-const DescriptionWithCaret = addCaretStyle( ReplacementVariableEditor );
-const ImageSelectWithCaret = addCaretStyle( ImageSelect );
+	::before {
+		position: absolute;
+		top: 8px;
+		${ getDirectionalStyle( "left", "right" ) }: -22px;
+		width: 22px;
+		height: 22px;
+		background-image: url(
+		${ props => getDirectionalStyle(
+		angleRight( getCaretColor( props.showActive ) ),
+		angleLeft( getCaretColor( props.showActive ) ) ) }
+		);
+		color: ${ props => getCaretColor( props.showActive ) };
+		background-size: 24px;
+		background-repeat: no-repeat;
+		background-position: center;
+		content: "";
+	}
+`;
+
+Caret.propTypes = {
+	showActive: PropTypes.bool,
+	showHovered: PropTypes.bool,
+};
+
+Caret.propTypes = {
+	showActive: false,
+	showHovered: false,
+};
+
+/**
+ * Adds Caret to a component.
+ * @param {React.Element} Component The component to add a Caret to.
+ *
+ * @returns {React.Element} A component with added Caret.
+ */
+const withCaretStyle = ( Component ) => {
+	return function ComponentWithCaret( props ) {
+		return (
+			<CaretContainer>
+				{ /* eslint-disable-next-line react/prop-types */ }
+				<Caret showActive={ props.isActive } showHovered={ props.isHovered } />
+				<Component { ...props } />
+			</CaretContainer>
+		);
+	};
+};
+
+const TitleWithCaret = withCaretStyle( ReplacementVariableEditor );
+const DescriptionWithCaret = withCaretStyle( ReplacementVariableEditor );
+const ImageSelectWithCaret = withCaretStyle( ImageSelect );
 
 /**
  * A form with an image selection button, a title input field and a description field.
@@ -87,19 +124,17 @@ const SocialMetadataPreviewForm = ( props ) => {
 				imageUrl={ props.imageUrl }
 				isPremium={ props.isPremium }
 			/>
-			<div>
-				<TitleWithCaret
-					onChange={ props.onTitleChange }
-					content={ props.title }
-					replacementVariables={ props.replacementVariables }
-					recommendedReplacementVariables={ props.recommendedReplacementVariables }
-					type="title"
-					label={ titleEditorTitle }
-					isActive={ props.activeField === "title" }
-					isHovered={ props.hoveredField === "title" }
-					onFocus={ focusTitle }
-				/>
-			</div>
+			<TitleWithCaret
+				onChange={ props.onTitleChange }
+				content={ props.title }
+				replacementVariables={ props.replacementVariables }
+				recommendedReplacementVariables={ props.recommendedReplacementVariables }
+				type="title"
+				label={ titleEditorTitle }
+				isActive={ props.activeField === "title" }
+				isHovered={ props.hoveredField === "title" }
+				onFocus={ focusTitle }
+			/>
 			<DescriptionWithCaret
 				onChange={ props.onDescriptionChange }
 				content={ props.description }

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -22,15 +22,14 @@ const getCaretColor = ( active ) => {
 const CaretContainer = styled.div`position: relative`;
 
 const Caret = styled.div`
-	position: absolute;
 	display: ${ props => ( props.isActive || props.isHovered ) ? "block" : "none" };
 
 	::before {
 		position: absolute;
 		top: -2px;
-		${ getDirectionalStyle( "left", "right" ) }: -16px;
-		width: 22px;
-		height: 22px;
+		${ getDirectionalStyle( "left", "right" ) }: ${ ( props ) => props.inPreview ? "-35px" : "-25px" };
+		width: 24px;
+		height: 24px;
 		background-image: url(
 		${ props => getDirectionalStyle(
 		angleRight( getCaretColor( props.isActive ) ),
@@ -48,25 +47,28 @@ const Caret = styled.div`
 Caret.propTypes = {
 	isActive: PropTypes.bool,
 	isHovered: PropTypes.bool,
+	inPreview: PropTypes.bool,
 };
 
 Caret.defaultProps = {
 	isActive: false,
 	isHovered: false,
+	inPreview: false,
 };
 
 /**
  * Adds Caret to a component.
  * @param {React.Element} WithoutCaretComponent The component to add a Caret to.
+ * @param {bool} inPreview Whether or not the component is in a social preview.
  *
  * @returns {React.Element} A component with added Caret.
  */
-export const withCaretStyle = ( WithoutCaretComponent ) => {
+export const withCaretStyle = ( WithoutCaretComponent, inPreview = false ) => {
 	return function ComponentWithCaret( props ) {
 		return (
 			<CaretContainer>
 				{ /* eslint-disable-next-line react/prop-types */ }
-				<Caret isActive={ props.isActive } isHovered={ props.isHovered } />
+				<Caret isActive={ props.isActive } isHovered={ props.isHovered } inPreview={ inPreview } />
 				<WithoutCaretComponent { ...props } />
 			</CaretContainer>
 		);
@@ -98,6 +100,7 @@ class SocialMetadataPreviewForm extends Component {
 		this.onTitleEnter = props.onMouseHover.bind( this, "title" );
 		this.onDescriptionEnter = props.onMouseHover.bind( this, "description" );
 		this.onLeave = props.onMouseHover.bind( this, "" );
+		this.onImageSelectBlur = props.onSelect.bind( this, "" );
 
 		this.onSelectTitleEditor = this.onSelectEditor.bind( this, "title" );
 		this.onSelectDescriptionEditor = this.onSelectEditor.bind( this, "description" );

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -76,8 +76,19 @@ const SocialMetadataPreviewForm = ( props ) => {
 		props.socialMediumName
 	);
 
-	const focusTitle = () => props.onSelect( "title" );
-	const focusDescription = () => props.onSelect( "description" );
+	/**
+	 * @returns {void}
+	 */
+	function focusTitle() {
+		props.onSelect( "title" );
+	}
+
+	/**
+	 * @returns {void}
+	 */
+	function focusDescription() {
+		props.onSelect( "description" );
+	}
 
 	return (
 		<Fragment>
@@ -130,12 +141,16 @@ SocialMetadataPreviewForm.propTypes = {
 	imageSelected: PropTypes.bool.isRequired,
 	hoveredField: PropTypes.string,
 	activeField: PropTypes.string,
+	onSelect: PropTypes.func,
 };
 
 SocialMetadataPreviewForm.defaultProps = {
 	replacementVariables: [],
 	recommendedReplacementVariables: [],
 	imageWarnings: [],
+	hoveredField: "",
+	activeField: "",
+	onSelect: () => {},
 };
 
 export default SocialMetadataPreviewForm;

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -23,7 +23,7 @@ const CaretContainer = styled.div`position: relative`;
 
 const Caret = styled.div`
 	position: absolute;
-	display: ${ props => ( props.active || props.hovered ) ? "block" : "none" };
+	display: ${ props => ( props.isActive || props.isHovered ) ? "block" : "none" };
 
 	::before {
 		position: absolute;
@@ -33,10 +33,10 @@ const Caret = styled.div`
 		height: 22px;
 		background-image: url(
 		${ props => getDirectionalStyle(
-		angleRight( getCaretColor( props.active ) ),
-		angleLeft( getCaretColor( props.active ) ) ) }
+		angleRight( getCaretColor( props.isActive ) ),
+		angleLeft( getCaretColor( props.isActive ) ) ) }
 		);
-		color: ${ props => getCaretColor( props.active ) };
+		color: ${ props => getCaretColor( props.isActive ) };
 		background-size: 24px;
 		background-repeat: no-repeat;
 		background-position: center;
@@ -45,13 +45,13 @@ const Caret = styled.div`
 `;
 
 Caret.propTypes = {
-	active: PropTypes.bool,
-	hovered: PropTypes.bool,
+	isActive: PropTypes.bool,
+	isHovered: PropTypes.bool,
 };
 
 Caret.propTypes = {
-	active: false,
-	hovered: false,
+	isActive: false,
+	isHovered: false,
 };
 
 /**
@@ -65,7 +65,7 @@ const withCaretStyle = ( Component ) => {
 		return (
 			<CaretContainer>
 				{ /* eslint-disable-next-line react/prop-types */ }
-				<Caret active={ props.isActive } hovered={ props.isHovered } />
+				<Caret isActive={ props.isActive } isHovered={ props.isHovered } />
 				<Component { ...props } />
 			</CaretContainer>
 		);

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -7,54 +7,37 @@ import styled from "styled-components";
 import { getDirectionalStyle } from "@yoast/helpers";
 import { angleLeft, angleRight, colors } from "@yoast/style-guide";
 
-const Caret = styled.div`
-	position: absolute;
-
-	::before {
-		display: ${ props => ( props.isActive || props.isHovered ) ? "block" : "none" };
-		position: absolute;
-		top: 0;
-		${ getDirectionalStyle( "left", "right" ) === "left" ? "left: 5px" : "right: 5px" };
-		width: 22px;
-		height: 22px;
-		background-image: url( ${ getDirectionalStyle( angleRight( colors.$color_black ), angleLeft( colors.$color_black ) ) } );
-		background-size: 24px;
-		background-repeat: no-repeat;
-		background-position: center;
-		content: "";
-	}
-`;
-
 /**
  * Adds caret styles to a component.
  *
- * @param {string} field The identifier for this field.
  * @param {ReactComponent} WithoutCaret The component without caret styles.
  *
  * @returns {ReactComponent} The component with caret styles.
  */
-function addCaretStyle( field, WithoutCaret ) {
-	return (
-		function WithCaret( props ) {
-			return (
-				<Fragment>
-					<Caret
-						// eslint-disable-next-line react/prop-types
-						isActive={ props.activeField === field }
-						// eslint-disable-next-line react/prop-types
-						isHovered={ props.hoveredField === field }
-					/>
-					<WithoutCaret { ...props } />
-				</Fragment>
-			);
+function addCaretStyle( WithoutCaret ) {
+	const WithCaret = styled( WithoutCaret )`
+		&::before {
+			display: ${ props => ( props.isActive || props.isHovered ) ? "block" : "none" };
+			position: absolute;
+			top: 0;
+			${ getDirectionalStyle( "left", "right" ) === "left" ? "left: -22px" : "right: 5px" };
+			width: 22px;
+			height: 22px;
+			background-image: url( ${ getDirectionalStyle( angleRight( colors.$color_black ), angleLeft( colors.$color_black ) ) } );
+			background-size: 24px;
+			background-repeat: no-repeat;
+			background-position: center;
+			content: "";
 		}
-	);
+	`;
+
+	return WithCaret;
 }
 
 
-const TitleWithCaret = addCaretStyle( "title", ReplacementVariableEditor );
-const DescriptionWithCaret = addCaretStyle( "description", ReplacementVariableEditor );
-const ImageSelectWithCaret = addCaretStyle( "image", ImageSelect );
+const TitleWithCaret = addCaretStyle( ReplacementVariableEditor );
+const DescriptionWithCaret = addCaretStyle( ReplacementVariableEditor );
+const ImageSelectWithCaret = addCaretStyle( ImageSelect );
 
 /**
  * A form with an image selection button, a title input field and a description field.
@@ -99,18 +82,22 @@ const SocialMetadataPreviewForm = ( props ) => {
 				onRemoveImageClick={ props.onRemoveImageClick }
 				warnings={ props.imageWarnings }
 				imageSelected={ props.imageSelected }
+				isActive={ props.activeField === "image" }
+				isHovered={ props.hoveredField === "image" }
 			/>
-			<TitleWithCaret
-				onChange={ props.onTitleChange }
-				content={ props.title }
-				replacementVariables={ props.replacementVariables }
-				recommendedReplacementVariables={ props.recommendedReplacementVariables }
-				type="title"
-				label={ titleEditorTitle }
-				activeField={ props.activeField }
-				hoveredField={ props.hoveredField }
-				onFocus={ focusTitle }
-			/>
+			<div>
+				<TitleWithCaret
+					onChange={ props.onTitleChange }
+					content={ props.title }
+					replacementVariables={ props.replacementVariables }
+					recommendedReplacementVariables={ props.recommendedReplacementVariables }
+					type="title"
+					label={ titleEditorTitle }
+					isActive={ props.activeField === "title" }
+					isHovered={ props.hoveredField === "title" }
+					onFocus={ focusTitle }
+				/>
+			</div>
 			<DescriptionWithCaret
 				onChange={ props.onDescriptionChange }
 				content={ props.description }
@@ -119,8 +106,8 @@ const SocialMetadataPreviewForm = ( props ) => {
 				recommendedReplacementVariables={ props.recommendedReplacementVariables }
 				type="description"
 				label={ descEditorTitle }
-				activeField={ props.activeField }
-				hoveredField={ props.hoveredField }
+				isActive={ props.activeField === "description" }
+				isHovered={ props.hoveredField === "description" }
 				onFocus={ focusDescription }
 			/>
 		</Fragment>

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -20,12 +20,12 @@ function addCaretStyle( WithoutCaret ) {
 	return styled( WithoutCaret )`
 		&::before {
 			display: block;
-			position: absolute;
+			position: relative;
 			top: 0;
 			${ getDirectionalStyle( "left", "right" ) }: ${ () => "-22px" };
 			width: 22px;
 			height: 22px;
-			background-image: url( ${ getDirectionalStyle( angleRight( colors.$color_white ), angleLeft( colors.$color_snippet_hover ) ) } );
+			background-image: url( ${ getDirectionalStyle( angleRight( colors.$color_black ), angleLeft( colors.$color_snippet_hover ) ) } );
 			background-size: 24px;
 			background-repeat: no-repeat;
 			background-position: center;

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -7,6 +7,24 @@ import styled from "styled-components";
 import { getDirectionalStyle } from "@yoast/helpers";
 import { angleLeft, angleRight, colors } from "@yoast/style-guide";
 
+const Caret = styled.div`
+	position: absolute;
+
+	::before {
+		display: block;
+		position: absolute;
+		top: 0;
+		${ getDirectionalStyle( "left", "right" ) === "left" ? "left: 5px" : "right: 5px" };
+		width: 22px;
+		height: 22px;
+		background-image: url( ${ getDirectionalStyle( angleRight( colors.$color_black ), angleLeft( colors.$color_black ) ) } );
+		background-size: 24px;
+		background-repeat: no-repeat;
+		background-position: center;
+		content: "";
+	}
+`;
+
 /**
  * Adds caret styles to a component.
  *
@@ -17,21 +35,12 @@ import { angleLeft, angleRight, colors } from "@yoast/style-guide";
  * @returns {ReactComponent} The component with caret styles.
  */
 function addCaretStyle( WithoutCaret ) {
-	return styled( WithoutCaret )`
-		&::before {
-			display: block;
-			position: relative;
-			top: 0;
-			${ getDirectionalStyle( "left", "right" ) }: ${ () => "-22px" };
-			width: 22px;
-			height: 22px;
-			background-image: url( ${ getDirectionalStyle( angleRight( colors.$color_black ), angleLeft( colors.$color_snippet_hover ) ) } );
-			background-size: 24px;
-			background-repeat: no-repeat;
-			background-position: center;
-			content: "";
-		}
-	`;
+	return (
+		<Fragment>
+			<Caret />
+			<WithoutCaret />
+		</Fragment>
+	);
 }
 
 const CaretContainer = addCaretStyle( styled.div`` );
@@ -66,7 +75,8 @@ const SocialMetadataPreviewForm = ( props ) => {
 				warnings={ props.imageWarnings }
 				imageSelected={ props.imageSelected }
 			/>
-			<CaretContainer>
+			<div>
+				<Caret />
 				<ReplacementVariableEditor
 					onChange={ props.onTitleChange }
 					content={ props.title }
@@ -75,18 +85,17 @@ const SocialMetadataPreviewForm = ( props ) => {
 					type="title"
 					label={ titleEditorTitle }
 				/>
-			</CaretContainer>
-			<CaretContainer>
-				<ReplacementVariableEditor
-					onChange={ props.onDescriptionChange }
-					content={ props.description }
-					placeholder={ descEditorPlaceholder }
-					replacementVariables={ props.replacementVariables }
-					recommendedReplacementVariables={ props.recommendedReplacementVariables }
-					type="description"
-					label={ descEditorTitle }
-				/>
-			</CaretContainer>
+			</div>
+			<Caret />
+			<ReplacementVariableEditor
+				onChange={ props.onDescriptionChange }
+				content={ props.description }
+				placeholder={ descEditorPlaceholder }
+				replacementVariables={ props.replacementVariables }
+				recommendedReplacementVariables={ props.recommendedReplacementVariables }
+				type="description"
+				label={ descEditorTitle }
+			/>
 		</Fragment>
 	);
 }

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -3,6 +3,38 @@ import ImageSelect from "./ImageSelect";
 import PropTypes from "prop-types";
 import { ReplacementVariableEditor, replacementVariablesShape } from "@yoast/replacement-variable-editor";
 import { __, sprintf } from "@wordpress/i18n";
+import styled from "styled-components";
+import { getDirectionalStyle } from "@yoast/helpers";
+import { angleLeft, angleRight, colors } from "@yoast/style-guide";
+
+/**
+ * Adds caret styles to a component.
+ *
+ * @param {ReactComponent} WithoutCaret The component without caret styles.
+ * @param {string} color The color to render the caret in.
+ * @param {string} mode The mode the snippet preview is in.
+ *
+ * @returns {ReactComponent} The component with caret styles.
+ */
+function addCaretStyle( WithoutCaret ) {
+	return styled( WithoutCaret )`
+		&::before {
+			display: block;
+			position: absolute;
+			top: 0;
+			${ getDirectionalStyle( "left", "right" ) }: ${ () => "-22px" };
+			width: 22px;
+			height: 22px;
+			background-image: url( ${ getDirectionalStyle( angleRight( colors.$color_white ), angleLeft( colors.$color_snippet_hover ) ) } );
+			background-size: 24px;
+			background-repeat: no-repeat;
+			background-position: center;
+			content: "";
+		}
+	`;
+}
+
+const CaretContainer = addCaretStyle( styled.div`` );
 
 /**
  * A form with an image selection button, a title input field and a description field.
@@ -34,23 +66,27 @@ const SocialMetadataPreviewForm = ( props ) => {
 				warnings={ props.imageWarnings }
 				imageSelected={ props.imageSelected }
 			/>
-			<ReplacementVariableEditor
-				onChange={ props.onTitleChange }
-				content={ props.title }
-				replacementVariables={ props.replacementVariables }
-				recommendedReplacementVariables={ props.recommendedReplacementVariables }
-				type="title"
-				label={ titleEditorTitle }
-			/>
-			<ReplacementVariableEditor
-				onChange={ props.onDescriptionChange }
-				content={ props.description }
-				placeholder={ descEditorPlaceholder }
-				replacementVariables={ props.replacementVariables }
-				recommendedReplacementVariables={ props.recommendedReplacementVariables }
-				type="description"
-				label={ descEditorTitle }
-			/>
+			<CaretContainer>
+				<ReplacementVariableEditor
+					onChange={ props.onTitleChange }
+					content={ props.title }
+					replacementVariables={ props.replacementVariables }
+					recommendedReplacementVariables={ props.recommendedReplacementVariables }
+					type="title"
+					label={ titleEditorTitle }
+				/>
+			</CaretContainer>
+			<CaretContainer>
+				<ReplacementVariableEditor
+					onChange={ props.onDescriptionChange }
+					content={ props.description }
+					placeholder={ descEditorPlaceholder }
+					replacementVariables={ props.replacementVariables }
+					recommendedReplacementVariables={ props.recommendedReplacementVariables }
+					type="description"
+					label={ descEditorTitle }
+				/>
+			</CaretContainer>
 		</Fragment>
 	);
 }

--- a/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
+++ b/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
@@ -1,8 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The ImageSelect component displays warnings 1`] = `
-Array [
-  .c0 {
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+  font-size: 14px;
+  line-height: 1.5;
+  border: 1px solid rgba(0,0,0,0.2);
+  padding: 16px;
+  color: #674e00;
+  background: #fff3cd;
+  margin-bottom: 20px;
+}
+
+.c3 {
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+}
+
+.c3 a {
+  color: #004973;
+}
+
+.c2 {
+  margin-top: 0.125rem;
+  margin-right: 8px;
+}
+
+.c0 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -15,126 +48,7 @@ Array [
   font-weight: 500;
 }
 
-<div
-    className="c0"
-  >
-    Facebook image
-  </div>,
-  .c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  font-size: 14px;
-  line-height: 1.5;
-  border: 1px solid rgba(0,0,0,0.2);
-  padding: 16px;
-  color: #674e00;
-  background: #fff3cd;
-  margin-bottom: 20px;
-}
-
-.c2 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.c2 a {
-  color: #004973;
-}
-
-.c1 {
-  margin-top: 0.125rem;
-  margin-right: 8px;
-}
-
-<div
-    className="c0"
-  >
-    <svg
-      aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-alert-warning c1 createSvgIconComponent__StyledSvg-sc-1h4gl3a-0 cPnaHk"
-      fill="#674e00"
-      focusable="false"
-      role="img"
-      size="16px"
-      viewBox="0 0 576 512"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-      />
-    </svg>
-    <div
-      className="c2"
-    >
-      Your image is too small
-    </div>
-  </div>,
-  .c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-align-items: flex-start;
-  -webkit-box-align: flex-start;
-  -ms-flex-align: flex-start;
-  align-items: flex-start;
-  font-size: 14px;
-  line-height: 1.5;
-  border: 1px solid rgba(0,0,0,0.2);
-  padding: 16px;
-  color: #674e00;
-  background: #fff3cd;
-  margin-bottom: 20px;
-}
-
-.c2 {
-  -webkit-box-flex: 1;
-  -webkit-flex-grow: 1;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-}
-
-.c2 a {
-  color: #004973;
-}
-
-.c1 {
-  margin-top: 0.125rem;
-  margin-right: 8px;
-}
-
-<div
-    className="c0"
-  >
-    <svg
-      aria-hidden={true}
-      className="yoast-svg-icon yoast-svg-icon-alert-warning c1 createSvgIconComponent__StyledSvg-sc-1h4gl3a-0 cPnaHk"
-      fill="#674e00"
-      focusable="false"
-      role="img"
-      size="16px"
-      viewBox="0 0 576 512"
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path
-        d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
-      />
-    </svg>
-    <div
-      className="c2"
-    >
-      Wow, I like writing tests
-    </div>
-  </div>,
-  .c3 {
+.c7 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
@@ -180,18 +94,18 @@ Array [
   height: 40px;
 }
 
-.c3:active {
+.c7:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c3::-moz-focus-inner {
+.c7::-moz-focus-inner {
   border-width: 0;
 }
 
-.c3:focus {
+.c7:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -199,19 +113,19 @@ Array [
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c3:hover {
+.c7:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c3 svg {
+.c7 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4 {
+.c8 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
@@ -265,18 +179,18 @@ Array [
   box-shadow: none;
 }
 
-.c4:active {
+.c8:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c4::-moz-focus-inner {
+.c8::-moz-focus-inner {
   border-width: 0;
 }
 
-.c4:focus {
+.c8:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -284,31 +198,31 @@ Array [
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c4:hover {
+.c8:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c4 svg {
+.c8 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
-.c4:hover {
+.c8:hover {
   color: #F00;
 }
 
-.c4:focus {
+.c8:focus {
   color: #F00;
 }
 
-.c1 {
+.c5 {
   min-width: 100%;
 }
 
-.c1.c1.c1 {
+.c5.c5.c5 {
   padding: 0 8px;
   min-height: 34px;
   font-size: 1em;
@@ -317,12 +231,12 @@ Array [
   border-radius: 0;
 }
 
-.c1.c1.c1:focus {
+.c5.c5.c5:focus {
   border-color: #5b9dd9;
   box-shadow: 0 0 2px rgba( 30,140,190,0.8 );
 }
 
-.c0 {
+.c4 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -332,7 +246,7 @@ Array [
   flex-direction: column;
 }
 
-.c2 {
+.c6 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -341,7 +255,7 @@ Array [
 }
 
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c3::after {
+  .c7::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -349,7 +263,7 @@ Array [
 }
 
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c4::after {
+  .c8::after {
     display: inline-block;
     content: "";
     min-height: 22px;
@@ -357,38 +271,92 @@ Array [
 }
 
 <div
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
     className="c0"
   >
+    Facebook image
+  </div>
+  <div
+    className="c1"
+  >
+    <svg
+      aria-hidden={true}
+      className="yoast-svg-icon yoast-svg-icon-alert-warning c2 createSvgIconComponent__StyledSvg-sc-1h4gl3a-0 cPnaHk"
+      fill="#674e00"
+      focusable="false"
+      role="img"
+      size="16px"
+      viewBox="0 0 576 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+      />
+    </svg>
+    <div
+      className="c3"
+    >
+      Your image is too small
+    </div>
+  </div>
+  <div
+    className="c1"
+  >
+    <svg
+      aria-hidden={true}
+      className="yoast-svg-icon yoast-svg-icon-alert-warning c2 createSvgIconComponent__StyledSvg-sc-1h4gl3a-0 cPnaHk"
+      fill="#674e00"
+      focusable="false"
+      role="img"
+      size="16px"
+      viewBox="0 0 576 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+      />
+    </svg>
+    <div
+      className="c3"
+    >
+      Wow, I like writing tests
+    </div>
+  </div>
+  <div
+    className="c4"
+  >
     <input
-      className="c1"
+      className="c5"
       disabled="disabled"
       value=""
     />
     <div
-      className="c2"
+      className="c6"
     >
       <button
-        className="c3"
+        className="c7"
         onClick={[Function]}
         type="button"
       >
         Replace image
       </button>
       <button
-        className="c4"
+        className="c8"
         onClick={[Function]}
         type="button"
       >
         Remove image
       </button>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`The ImageSelect component renders 1`] = `
-Array [
-  .c0 {
+.c0 {
   -webkit-flex: 1 1 200px;
   -ms-flex: 1 1 200px;
   flex: 1 1 200px;
@@ -401,12 +369,7 @@ Array [
   font-weight: 500;
 }
 
-<div
-    className="c0"
-  >
-    Facebook image
-  </div>,
-  .c0 {
+.c1 {
   color: #555;
   border-color: #ccc;
   background: #f7f7f7;
@@ -452,18 +415,18 @@ Array [
   height: 40px;
 }
 
-.c0:active {
+.c1:active {
   color: #000;
   background-color: #f7f7f7;
   border-color: #888;
   box-shadow: inset 0 2px 5px -3px rgba( 0,0,0,0.5 );
 }
 
-.c0::-moz-focus-inner {
+.c1::-moz-focus-inner {
   border-width: 0;
 }
 
-.c0:focus {
+.c1:focus {
   outline: none;
   border-color: #0066cd;
   color: #000;
@@ -471,32 +434,41 @@ Array [
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
-.c0:hover {
+.c1:hover {
   color: #000;
   background-color: #fff;
   border-color: #888;
 }
 
-.c0 svg {
+.c1 svg {
   -webkit-align-self: center;
   -ms-flex-item-align: center;
   align-self: center;
 }
 
 @media all and (-ms-high-contrast:none),(-ms-high-contrast:active) {
-  .c0::after {
+  .c1::after {
     display: inline-block;
     content: "";
     min-height: 22px;
   }
 }
 
-<button
+<div
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <div
     className="c0"
+  >
+    Facebook image
+  </div>
+  <button
+    className="c1"
     onClick={[Function]}
     type="button"
   >
     Select image
-  </button>,
-]
+  </button>
+</div>
 `;

--- a/packages/social-metadata-previews/jest/__mocks__/styleMock.js
+++ b/packages/social-metadata-previews/jest/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/social-metadata-previews/package.json
+++ b/packages/social-metadata-previews/package.json
@@ -27,7 +27,10 @@
     "transformIgnorePatterns": [
       "/node_modules/(?!yoastseo|lodash-es).+\\.js$"
     ],
-    "setupTestFrameworkScriptFile": "<rootDir>/jest/setupTests.js"
+    "setupTestFrameworkScriptFile": "<rootDir>/jest/setupTests.js",
+    "moduleNameMapper": {
+			"\\.css$": "<rootDir>/jest/__mocks__/styleMock.js"
+		}
   },
   "publishConfig": {
     "access": "public"

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -130,7 +130,6 @@ class SocialPreviewEditor extends Component {
 			isPremium,
 			isLarge,
 		} = this.props;
-		console.log( "this.props.isLarge: ", isLarge );
 
 		return (
 			<React.Fragment>

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -1,0 +1,75 @@
+/* External dependencies */
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+/* Internal dependencies */
+import { SocialMetadataPreviewForm } from "@yoast/social-metadata-forms";
+import FacebookPreview from "../facebook/FacebookPreview";
+import { recommendedReplacementVariablesShape, replacementVariablesShape } from "@yoast/replacement-variable-editor";
+
+class SocialPreviewEditor extends Component {
+	render() {
+		const {
+			onDescriptionChange,
+			onTitleChange,
+			onSelectImageClick,
+			onRemoveImageClick,
+			imageWarnings,
+			siteName,
+			description,
+			image,
+			alt,
+			title,
+			replacementVariables,
+			recommendedReplacementVariables,
+		} = this.props;
+
+		return (
+			<React.Fragment>
+				<FacebookPreview
+					siteName={ siteName }
+					title={ title }
+					description={ description }
+					image={ image }
+					alt={ alt }
+				/>
+				<SocialMetadataPreviewForm
+					onDescriptionChange={ onDescriptionChange }
+					socialMediumName="Facebook"
+					title={ title }
+					onRemoveImageClick={ onRemoveImageClick }
+					imageSelected={ !! image }
+					onTitleChange={ onTitleChange }
+					onSelectImageClick={ onSelectImageClick }
+					description={ description }
+					imageWarnings={ imageWarnings }
+					replacementVariables={ replacementVariables }
+					recommendedReplacementVariables={ recommendedReplacementVariables }
+				/>
+			</React.Fragment>
+		);
+	}
+}
+
+SocialPreviewEditor.propTypes = {
+	title: PropTypes.string.isRequired,
+	onTitleChange: PropTypes.func.isRequired,
+	description: PropTypes.string.isRequired,
+	onDescriptionChange: PropTypes.func.isRequired,
+	image: PropTypes.string.isRequired,
+	alt: PropTypes.string.isRequired,
+	onSelectImageClick: PropTypes.func.isRequired,
+	onRemoveImageClick: PropTypes.func.isRequired,
+	imageWarnings: PropTypes.array,
+	siteName: PropTypes.string.isRequired,
+	replacementVariables: PropTypes.arrayOf( replacementVariablesShape ),
+	recommendedReplacementVariables: PropTypes.arrayOf( recommendedReplacementVariablesShape ),
+};
+
+SocialPreviewEditor.defaultProps = {
+	imageWarnings: [],
+	recommendedReplacementVariables: [],
+	replacementVariables: [],
+};
+
+export default SocialPreviewEditor;

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -135,9 +135,7 @@ class SocialPreviewEditor extends Component {
 			<React.Fragment>
 				<this.SocialPreview
 					onMouseHover={ this.setHoveredField }
-					hoveredField={ this.state.hoveredField }
 					onSelect={ this.setActiveField }
-					activeField={ this.state.activeField }
 					onImageClick={ onSelectImageClick }
 					siteName={ siteName }
 					title={ title }

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -5,6 +5,7 @@ import PropTypes from "prop-types";
 /* Internal dependencies */
 import { SocialMetadataPreviewForm } from "@yoast/social-metadata-forms";
 import FacebookPreview from "../facebook/FacebookPreview";
+import TwitterPreview from "../twitter/TwitterPreview";
 import { recommendedReplacementVariablesShape, replacementVariablesShape } from "@yoast/replacement-variable-editor";
 
 /**
@@ -15,18 +16,23 @@ import { recommendedReplacementVariablesShape, replacementVariablesShape } from 
 class SocialPreviewEditor extends Component {
 	/**
 	 * The constructor.
+	 * @param {Object} props The props object.
+	 *
+	 * @returns {void}
 	 */
-	constructor() {
-		super();
+	constructor( props ) {
+		super( props );
 
 		this.state = {
 			activeField: "",
 			hoveredField: "",
 		};
 
+		this.SocialPreview = props.socialMediumName === "Facebook" ? FacebookPreview : TwitterPreview;
 		this.setHoveredField = this.setHoveredField.bind( this );
 		this.setActiveField = this.setActiveField.bind( this );
 		this.handleImageClick = this.handleImageClick.bind( this );
+		this.setEditorRef = this.setEditorRef.bind( this );
 	}
 
 	/**
@@ -60,6 +66,16 @@ class SocialPreviewEditor extends Component {
 		console.log( "activefield", field );
 		this.setState( {
 			activeField: field,
+		}, () => {
+			switch ( field ) {
+				case "title":
+					this.titleEditorRef.focus();
+					return;
+				case "description":
+					console.log( "HERE!" );
+					this.descriptionEditorRef.focus();
+					return;
+			}
 		} );
 	}
 
@@ -75,6 +91,25 @@ class SocialPreviewEditor extends Component {
 	}
 
 	/**
+	 * Hoi
+	 * @param {*} field  hoi
+	 * @param {*} ref hoi
+	 *
+	 * @returns {void}
+	 */
+	setEditorRef( field, ref ) {
+		console.log( "setEditorRef: ", field, ref );
+		switch ( field ) {
+			case "title":
+				this.titleEditorRef = ref;
+				return;
+			case "description":
+				this.descriptionEditorRef = ref;
+				return;
+		}
+	}
+
+	/**
 	 * The render function.
 	 *
 	 * @returns {void} Void.
@@ -85,6 +120,7 @@ class SocialPreviewEditor extends Component {
 			onTitleChange,
 			onSelectImageClick,
 			onRemoveImageClick,
+			socialMediumName,
 			imageWarnings,
 			siteName,
 			description,
@@ -94,25 +130,27 @@ class SocialPreviewEditor extends Component {
 			replacementVariables,
 			recommendedReplacementVariables,
 			isPremium,
+			isLarge,
 		} = this.props;
 
 		return (
 			<React.Fragment>
-				<FacebookPreview
+				<this.SocialPreview
 					onMouseHover={ this.setHoveredField }
-					onSelect={ this.setActiveField }
-					onImageClick={ this.handleImageClick }
-					activeField={ this.state.activeField }
 					hoveredField={ this.state.hoveredField }
+					onSelect={ this.setActiveField }
+					activeField={ this.state.activeField }
+					onImageClick={ this.handleImageClick }
 					siteName={ siteName }
 					title={ title }
 					description={ description }
 					image={ image }
 					alt={ alt }
+					isLarge={ isLarge }
 				/>
 				<SocialMetadataPreviewForm
 					onDescriptionChange={ onDescriptionChange }
-					socialMediumName="Facebook"
+					socialMediumName={ socialMediumName }
 					title={ title }
 					onRemoveImageClick={ onRemoveImageClick }
 					imageSelected={ !! image }
@@ -122,11 +160,12 @@ class SocialPreviewEditor extends Component {
 					imageWarnings={ imageWarnings }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
-					onFocus={ this.setHoveredField }
+					onMouseHover={ this.setHoveredField }
+					hoveredField={ this.state.hoveredField }
 					onSelect={ this.setActiveField }
 					activeField={ this.state.activeField }
-					hoveredField={ this.state.hoveredField }
 					isPremium={ isPremium }
+					setEditorRef={ this.setEditorRef }
 				/>
 			</React.Fragment>
 		);
@@ -142,8 +181,10 @@ SocialPreviewEditor.propTypes = {
 	alt: PropTypes.string.isRequired,
 	onSelectImageClick: PropTypes.func.isRequired,
 	onRemoveImageClick: PropTypes.func.isRequired,
+	socialMediumName: PropTypes.string.isRequired,
 	isPremium: PropTypes.bool,
 	imageWarnings: PropTypes.array,
+	isLarge: PropTypes.bool,
 	siteName: PropTypes.string.isRequired,
 	replacementVariables: PropTypes.arrayOf( replacementVariablesShape ),
 	recommendedReplacementVariables: PropTypes.arrayOf( recommendedReplacementVariablesShape ),
@@ -154,6 +195,7 @@ SocialPreviewEditor.defaultProps = {
 	recommendedReplacementVariables: [],
 	replacementVariables: [],
 	isPremium: false,
+	isLarge: true,
 };
 
 export default SocialPreviewEditor;

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -25,6 +25,8 @@ class SocialPreviewEditor extends Component {
 		};
 
 		this.setHoveredField = this.setHoveredField.bind( this );
+		this.setActiveField = this.setActiveField.bind( this );
+		this.setState = this.setState.bind( this );
 	}
 
 	/**
@@ -35,10 +37,13 @@ class SocialPreviewEditor extends Component {
 	 * @returns {void}
 	 */
 	setHoveredField( field ) {
+		if ( field === this.state.hoveredField ) {
+			return;
+		}
+		console.log( "hoveredfield", field );
 		this.setState( {
 			hoveredField: field,
 		} );
-		console.log( "field", field );
 	}
 
 	/**
@@ -49,10 +54,13 @@ class SocialPreviewEditor extends Component {
 	 * @returns {void}
 	 */
 	setActiveField( field ) {
+		if ( field === this.state.activeField ) {
+			return;
+		}
+		console.log( "activefield", field );
 		this.setState( {
 			activeField: field,
 		} );
-		console.log( field );
 	}
 
 	/**
@@ -99,6 +107,8 @@ class SocialPreviewEditor extends Component {
 					imageWarnings={ imageWarnings }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
+					onFocus={ this.setHoveredField }
+					onSelect={ this.setActiveField }
 				/>
 			</React.Fragment>
 		);

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -7,7 +7,15 @@ import { SocialMetadataPreviewForm } from "@yoast/social-metadata-forms";
 import FacebookPreview from "../facebook/FacebookPreview";
 import { recommendedReplacementVariablesShape, replacementVariablesShape } from "@yoast/replacement-variable-editor";
 
+/**
+ * A form with an image selection button, a title input field and a description field and the social preview.
+ *
+ * @returns {void} Void.
+ */
 class SocialPreviewEditor extends Component {
+	/**
+	 * The constructor.
+	 */
 	constructor() {
 		super();
 
@@ -15,8 +23,43 @@ class SocialPreviewEditor extends Component {
 			activeField: "",
 			hoveredField: "",
 		};
+
+		this.setHoveredField = this.setHoveredField.bind( this );
 	}
 
+	/**
+	 * Sets the field that the mouse is hovering over in state.
+	 *
+	 * @param {string} field The field that is hovered over.
+	 *
+	 * @returns {void}
+	 */
+	setHoveredField( field ) {
+		this.setState( {
+			hoveredField: field,
+		} );
+		console.log( "field", field );
+	}
+
+	/**
+	 * Sets the active field that is selected in state.
+	 *
+	 * @param {string} field The field that is selected.
+	 *
+	 * @returns {void}
+	 */
+	setActiveField( field ) {
+		this.setState( {
+			activeField: field,
+		} );
+		console.log( field );
+	}
+
+	/**
+	 * The render function.
+	 *
+	 * @returns {void} Void.
+	 */
 	render() {
 		const {
 			onDescriptionChange,
@@ -36,7 +79,8 @@ class SocialPreviewEditor extends Component {
 		return (
 			<React.Fragment>
 				<FacebookPreview
-					onMouseHover={ console.log }
+					onMouseHover={ this.setHoveredField }
+					onSelect={ this.setActiveField }
 					siteName={ siteName }
 					title={ title }
 					description={ description }

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -26,7 +26,6 @@ class SocialPreviewEditor extends Component {
 
 		this.setHoveredField = this.setHoveredField.bind( this );
 		this.setActiveField = this.setActiveField.bind( this );
-		this.setState = this.setState.bind( this );
 	}
 
 	/**
@@ -109,6 +108,8 @@ class SocialPreviewEditor extends Component {
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					onFocus={ this.setHoveredField }
 					onSelect={ this.setActiveField }
+					activeField={ this.state.activeField }
+					hoveredField={ this.state.hoveredField }
 				/>
 			</React.Fragment>
 		);

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -8,6 +8,15 @@ import FacebookPreview from "../facebook/FacebookPreview";
 import { recommendedReplacementVariablesShape, replacementVariablesShape } from "@yoast/replacement-variable-editor";
 
 class SocialPreviewEditor extends Component {
+	constructor() {
+		super();
+
+		this.state = {
+			activeField: "",
+			hoveredField: "",
+		};
+	}
+
 	render() {
 		const {
 			onDescriptionChange,
@@ -27,6 +36,7 @@ class SocialPreviewEditor extends Component {
 		return (
 			<React.Fragment>
 				<FacebookPreview
+					onMouseHover={ console.log }
 					siteName={ siteName }
 					title={ title }
 					description={ description }

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -63,6 +63,12 @@ class SocialPreviewEditor extends Component {
 		} );
 	}
 
+	/**
+	 * Combines the setting of the activeField to "image" and the onSelectImageClick.
+	 * This helps with setting the caret's activeField and calling the image select function.
+	 *
+	 * @returns {void}
+	 */
 	handleImageClick() {
 		this.setActiveField( "image" );
 		this.props.onSelectImageClick();

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -176,16 +176,16 @@ SocialPreviewEditor.propTypes = {
 	description: PropTypes.string.isRequired,
 	onDescriptionChange: PropTypes.func.isRequired,
 	image: PropTypes.string.isRequired,
-	alt: PropTypes.string.isRequired,
 	onSelectImageClick: PropTypes.func.isRequired,
 	onRemoveImageClick: PropTypes.func.isRequired,
 	socialMediumName: PropTypes.string.isRequired,
+	alt: PropTypes.string,
 	isPremium: PropTypes.bool,
 	imageWarnings: PropTypes.array,
 	isLarge: PropTypes.bool,
-	siteName: PropTypes.string.isRequired,
-	replacementVariables: PropTypes.arrayOf( replacementVariablesShape ),
-	recommendedReplacementVariables: PropTypes.arrayOf( recommendedReplacementVariablesShape ),
+	siteName: PropTypes.string,
+	replacementVariables: replacementVariablesShape,
+	recommendedReplacementVariables: recommendedReplacementVariablesShape,
 };
 
 SocialPreviewEditor.defaultProps = {
@@ -194,6 +194,8 @@ SocialPreviewEditor.defaultProps = {
 	replacementVariables: [],
 	isPremium: false,
 	isLarge: true,
+	siteName: "",
+	alt: "",
 };
 
 export default SocialPreviewEditor;

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -26,6 +26,7 @@ class SocialPreviewEditor extends Component {
 
 		this.setHoveredField = this.setHoveredField.bind( this );
 		this.setActiveField = this.setActiveField.bind( this );
+		this.handleImageClick = this.handleImageClick.bind( this );
 	}
 
 	/**
@@ -62,6 +63,11 @@ class SocialPreviewEditor extends Component {
 		} );
 	}
 
+	handleImageClick() {
+		this.setActiveField( "image" );
+		this.props.onSelectImageClick();
+	}
+
 	/**
 	 * The render function.
 	 *
@@ -89,6 +95,7 @@ class SocialPreviewEditor extends Component {
 				<FacebookPreview
 					onMouseHover={ this.setHoveredField }
 					onSelect={ this.setActiveField }
+					onImageClick={ this.handleImageClick }
 					activeField={ this.state.activeField }
 					hoveredField={ this.state.hoveredField }
 					siteName={ siteName }

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -31,8 +31,8 @@ class SocialPreviewEditor extends Component {
 		this.SocialPreview = props.socialMediumName === "Facebook" ? FacebookPreview : TwitterPreview;
 		this.setHoveredField = this.setHoveredField.bind( this );
 		this.setActiveField = this.setActiveField.bind( this );
-		this.handleImageClick = this.handleImageClick.bind( this );
 		this.setEditorRef = this.setEditorRef.bind( this );
+		this.setEditorFocus = this.setEditorFocus.bind( this );
 	}
 
 	/**
@@ -46,7 +46,6 @@ class SocialPreviewEditor extends Component {
 		if ( field === this.state.hoveredField ) {
 			return;
 		}
-		console.log( "hoveredfield", field );
 		this.setState( {
 			hoveredField: field,
 		} );
@@ -63,42 +62,41 @@ class SocialPreviewEditor extends Component {
 		if ( field === this.state.activeField ) {
 			return;
 		}
-		console.log( "activefield", field );
-		this.setState( {
-			activeField: field,
-		}, () => {
-			switch ( field ) {
-				case "title":
-					this.titleEditorRef.focus();
-					return;
-				case "description":
-					console.log( "HERE!" );
-					this.descriptionEditorRef.focus();
-					return;
-			}
-		} );
+		this.setState(
+			{ activeField: field },
+			() => this.setEditorFocus( field )
+		);
 	}
 
 	/**
-	 * Combines the setting of the activeField to "image" and the onSelectImageClick.
-	 * This helps with setting the caret's activeField and calling the image select function.
+	 * Sets focus on the editor that is the active field.
+	 *
+	 * @param {String} field The active field belonging to the editor to focus.
 	 *
 	 * @returns {void}
 	 */
-	handleImageClick() {
-		this.setActiveField( "image" );
-		this.props.onSelectImageClick();
+	setEditorFocus( field ) {
+		switch ( field ) {
+			case "title":
+				this.titleEditorRef.focus();
+				return;
+			case "description":
+				this.descriptionEditorRef.focus();
+				return;
+		}
 	}
 
 	/**
-	 * Hoi
-	 * @param {*} field  hoi
-	 * @param {*} ref hoi
+	 * Sets the reference of each editor.
+	 * Used by child components to communicate with this focus managing component.
+	 * This component can then call the .focus() function on the passed refs.
+	 *
+	 * @param {String} field The field belonging to the editor that belongs to the ref.
+	 * @param {*} ref A ref to an editor.
 	 *
 	 * @returns {void}
 	 */
 	setEditorRef( field, ref ) {
-		console.log( "setEditorRef: ", field, ref );
 		switch ( field ) {
 			case "title":
 				this.titleEditorRef = ref;
@@ -132,6 +130,7 @@ class SocialPreviewEditor extends Component {
 			isPremium,
 			isLarge,
 		} = this.props;
+		console.log( "this.props.isLarge: ", isLarge );
 
 		return (
 			<React.Fragment>
@@ -140,7 +139,7 @@ class SocialPreviewEditor extends Component {
 					hoveredField={ this.state.hoveredField }
 					onSelect={ this.setActiveField }
 					activeField={ this.state.activeField }
-					onImageClick={ this.handleImageClick }
+					onImageClick={ onSelectImageClick }
 					siteName={ siteName }
 					title={ title }
 					description={ description }

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -81,6 +81,7 @@ class SocialPreviewEditor extends Component {
 			title,
 			replacementVariables,
 			recommendedReplacementVariables,
+			isPremium,
 		} = this.props;
 
 		return (
@@ -88,6 +89,8 @@ class SocialPreviewEditor extends Component {
 				<FacebookPreview
 					onMouseHover={ this.setHoveredField }
 					onSelect={ this.setActiveField }
+					activeField={ this.state.activeField }
+					hoveredField={ this.state.hoveredField }
 					siteName={ siteName }
 					title={ title }
 					description={ description }
@@ -110,6 +113,7 @@ class SocialPreviewEditor extends Component {
 					onSelect={ this.setActiveField }
 					activeField={ this.state.activeField }
 					hoveredField={ this.state.hoveredField }
+					isPremium={ isPremium }
 				/>
 			</React.Fragment>
 		);
@@ -125,6 +129,7 @@ SocialPreviewEditor.propTypes = {
 	alt: PropTypes.string.isRequired,
 	onSelectImageClick: PropTypes.func.isRequired,
 	onRemoveImageClick: PropTypes.func.isRequired,
+	isPremium: PropTypes.bool,
 	imageWarnings: PropTypes.array,
 	siteName: PropTypes.string.isRequired,
 	replacementVariables: PropTypes.arrayOf( replacementVariablesShape ),
@@ -135,6 +140,7 @@ SocialPreviewEditor.defaultProps = {
 	imageWarnings: [],
 	recommendedReplacementVariables: [],
 	replacementVariables: [],
+	isPremium: false,
 };
 
 export default SocialPreviewEditor;

--- a/packages/social-metadata-previews/src/facebook/FacebookDescription.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookDescription.js
@@ -40,6 +40,7 @@ const FacebookDescription = styled.p`
 	text-overflow: ellipsis;
 	margin: 3px 0 0 0;
 	display: -webkit-box;
+	cursor: pointer;
 	-webkit-line-clamp: ${ props => determineClamp( props.mode ) };
 	-webkit-box-orient: vertical;  
 	overflow: hidden;

--- a/packages/social-metadata-previews/src/facebook/FacebookDescription.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookDescription.js
@@ -21,6 +21,9 @@ const determineClamp = ( mode ) => {
 	}
 };
 
+// Used to sure the element also has a height when empty by setting min-height equal to line-height.
+const height = "16px";
+
 /**
  * Renders a FacebookDescription component.
  *
@@ -29,9 +32,10 @@ const determineClamp = ( mode ) => {
  * @returns {React.Component} The rendered element.
  */
 const FacebookDescription = styled.p`
+	line-height: ${ height };
+	min-height : ${ height };
 	color: #606770;
 	font-size: 12px;
-	line-height: 16px;
 	padding: 0;
 	text-overflow: ellipsis;
 	margin: 3px 0 0 0;

--- a/packages/social-metadata-previews/src/facebook/FacebookImage.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookImage.js
@@ -68,12 +68,14 @@ class FacebookImage extends Component {
 	}
 
 	/**
-	 * After the component has mounted, determine the properties of the FacebookImage.
+	 * Determine the image properties and set them in state.
 	 *
-	 * @returns {Promise} Resolves when there are image properties.
+	 * @param {string} src The image source URL.
+	 *
+	 * @returns {void}
 	 */
-	componentDidMount() {
-		return determineImageProperties( this.props.src, "Facebook" ).then( ( imageProperties ) => {
+	determineImageProperties( src ) {
+		determineImageProperties( src, "Facebook" ).then( ( imageProperties ) => {
 			this.props.onImageLoaded( imageProperties.mode );
 
 			this.setState( {
@@ -87,6 +89,28 @@ class FacebookImage extends Component {
 				status: "errored",
 			} );
 		} );
+	}
+
+	/**
+	 * After the component has mounted, determine the properties of the FacebookImage.
+	 *
+	 * @returns {void}
+	 */
+	componentDidMount() {
+		this.determineImageProperties( this.props.src );
+	}
+
+	/**
+	 * After the image has been updated, determine the properties of the FacebookImage.
+	 *
+	 * @param {Object} prevProps The previous properties.
+	 *
+	 * @returns {void}
+	 */
+	componentDidUpdate( prevProps ) {
+		if ( prevProps.src !== this.props.src ) {
+			this.determineImageProperties( this.props.src );
+		}
 	}
 
 	/**
@@ -125,7 +149,7 @@ class FacebookImage extends Component {
 		const { imageProperties, status } = this.state;
 
 		if ( status === "loading" || this.props.src === "" || status === "errored" ) {
-			return <PlaceholderImage>
+			return <PlaceholderImage onClick={ this.props.onSelectImage }>
 				{ __( "Select image", "yoast-components" ) }
 			</PlaceholderImage>;
 		}
@@ -147,11 +171,13 @@ FacebookImage.propTypes = {
 	src: PropTypes.string.isRequired,
 	alt: PropTypes.string,
 	onImageLoaded: PropTypes.func,
+	onSelectImage: PropTypes.func,
 };
 
 FacebookImage.defaultProps = {
 	alt: "",
 	onImageLoaded: () => {},
+	onSelectImage: () => {},
 };
 
 export default FacebookImage;

--- a/packages/social-metadata-previews/src/facebook/FacebookImage.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookImage.js
@@ -149,14 +149,22 @@ class FacebookImage extends Component {
 		const { imageProperties, status } = this.state;
 
 		if ( status === "loading" || this.props.src === "" || status === "errored" ) {
-			return <PlaceholderImage onClick={ this.props.onSelectImage }>
-				{ __( "Select image", "yoast-components" ) }
-			</PlaceholderImage>;
+			return (
+				<PlaceholderImage
+					onClick={ this.props.onSelectImage }
+					onMouseEnter={ this.props.onMouseEnter }
+					onMouseLeave={ this.props.onMouseLeave }
+				>
+					{ __( "Select image", "yoast-components" ) }
+				</PlaceholderImage>
+			);
 		}
 
 		const containerDimensions = this.retrieveContainerDimensions( imageProperties.mode );
 		return <FacebookImageContainer
 			dimensions={ containerDimensions }
+			onMouseEnter={ this.props.onMouseEnter }
+			onMouseLeave={ this.props.onMouseLeave }
 		>
 			<StyledImage
 				src={ this.props.src }

--- a/packages/social-metadata-previews/src/facebook/FacebookImage.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookImage.js
@@ -151,7 +151,7 @@ class FacebookImage extends Component {
 		if ( status === "loading" || this.props.src === "" || status === "errored" ) {
 			return (
 				<PlaceholderImage
-					onClick={ this.props.onSelectImage }
+					onClick={ this.props.onImageClick }
 					onMouseEnter={ this.props.onMouseEnter }
 					onMouseLeave={ this.props.onMouseLeave }
 				>
@@ -165,12 +165,12 @@ class FacebookImage extends Component {
 			dimensions={ containerDimensions }
 			onMouseEnter={ this.props.onMouseEnter }
 			onMouseLeave={ this.props.onMouseLeave }
+			onClick={ this.props.onImageClick }
 		>
 			<StyledImage
 				src={ this.props.src }
 				alt={ this.props.alt }
 				imageProperties={ imageProperties }
-				onClick={ this.props.onSelectImage }
 			/>
 		</FacebookImageContainer>;
 	}
@@ -180,13 +180,17 @@ FacebookImage.propTypes = {
 	src: PropTypes.string.isRequired,
 	alt: PropTypes.string,
 	onImageLoaded: PropTypes.func,
-	onSelectImage: PropTypes.func,
+	onImageClick: PropTypes.func,
+	onMouseEnter: PropTypes.func,
+	onMouseLeave: PropTypes.func,
 };
 
 FacebookImage.defaultProps = {
 	alt: "",
 	onImageLoaded: () => {},
-	onSelectImage: () => {},
+	onImageClick: () => {},
+	onMouseEnter: () => {},
+	onMouseLeave: () => {},
 };
 
 export default FacebookImage;

--- a/packages/social-metadata-previews/src/facebook/FacebookImage.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookImage.js
@@ -162,6 +162,7 @@ class FacebookImage extends Component {
 				src={ this.props.src }
 				alt={ this.props.alt }
 				imageProperties={ imageProperties }
+				onClick={ this.props.onSelectImage }
 			/>
 		</FacebookImageContainer>;
 	}

--- a/packages/social-metadata-previews/src/facebook/FacebookImage.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookImage.js
@@ -177,7 +177,7 @@ class FacebookImage extends Component {
 }
 
 FacebookImage.propTypes = {
-	src: PropTypes.string.isRequired,
+	src: PropTypes.string,
 	alt: PropTypes.string,
 	onImageLoaded: PropTypes.func,
 	onImageClick: PropTypes.func,
@@ -186,6 +186,7 @@ FacebookImage.propTypes = {
 };
 
 FacebookImage.defaultProps = {
+	src: "",
 	alt: "",
 	onImageLoaded: () => {},
 	onImageClick: () => {},

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -104,6 +104,7 @@ class FacebookPreview extends Component {
 		this.onImageLoaded = this.onImageLoaded.bind( this );
 
 		// Binding fields to onMouseHover to prevent arrow functions in JSX props.
+		this.onImageEnter = this.props.onMouseHover.bind( this, "image" );
 		this.onTitleEnter = this.props.onMouseHover.bind( this, "title" );
 		this.onDescriptionEnter = this.props.onMouseHover.bind( this, "description" );
 		this.onLeave = this.props.onMouseHover.bind( this, "" );
@@ -139,6 +140,8 @@ class FacebookPreview extends Component {
 					alt={ this.props.alt }
 					onImageLoaded={ this.onImageLoaded }
 					onSelectImage={ this.onSelectImage }
+					onMouseEnter={ this.onImageEnter }
+					onMouseLeave={ this.onLeave }
 				/>
 				<OuterTextWrapper mode={ imageMode }>
 					<FacebookSiteAndAuthorNames

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -129,6 +129,7 @@ class FacebookPreview extends Component {
 					src={ this.props.image }
 					alt={ this.props.alt }
 					onImageLoaded={ this.onImageLoaded }
+					onSelectImage={ this.props.onSelectImage }
 				/>
 				<OuterTextWrapper mode={ imageMode }>
 					<FacebookSiteAndAuthorNames
@@ -153,6 +154,7 @@ FacebookPreview.propTypes = {
 	description: PropTypes.string,
 	image: PropTypes.string,
 	alt: PropTypes.string,
+	onSelectImage: PropTypes.func,
 };
 
 FacebookPreview.defaultProps = {
@@ -160,6 +162,7 @@ FacebookPreview.defaultProps = {
 	description: "",
 	alt: "",
 	image: "",
+	onSelectImage: () => {},
 };
 
 export default FacebookPreview;

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -102,6 +102,10 @@ class FacebookPreview extends Component {
 			imageMode: null,
 		};
 		this.onImageLoaded = this.onImageLoaded.bind( this );
+
+		this.onTitleEnter = this.onMouseHover.bind( this, "title" );
+		this.onDescriptionEnter = this.onMouseHover.bind( this, "description" );
+		this.onLeave = this.onMouseHover.bind( this, "" );
 	}
 
 	/**
@@ -113,6 +117,10 @@ class FacebookPreview extends Component {
 	 */
 	onImageLoaded( mode ) {
 		this.setState( { imageMode: mode } );
+	}
+
+	onMouseHover( field ) {
+		this.props.onMouseHover( field );
 	}
 
 	/**
@@ -137,8 +145,17 @@ class FacebookPreview extends Component {
 						authorName={ this.props.authorName }
 						mode={ imageMode }
 					/>
-					<FacebookTitle title={ this.props.title } />
-					<FacebookDescription mode={ imageMode }>
+					<FacebookTitle
+						onMouseEnter={ this.onTitleEnter }
+						onMouseLeave={ this.onLeave }
+					>
+						{ this.props.title }
+					</FacebookTitle>
+					<FacebookDescription
+						onMouseEnter={ this.onDescriptionEnter }
+						onMouseLeave={ this.onLeave }
+						mode={ imageMode }
+					>
 						{ this.props.description }
 					</FacebookDescription>
 				</OuterTextWrapper>
@@ -155,6 +172,7 @@ FacebookPreview.propTypes = {
 	image: PropTypes.string,
 	alt: PropTypes.string,
 	onSelectImage: PropTypes.func,
+	onMouseHover: PropTypes.func,
 };
 
 FacebookPreview.defaultProps = {
@@ -163,6 +181,7 @@ FacebookPreview.defaultProps = {
 	alt: "",
 	image: "",
 	onSelectImage: () => {},
+	onMouseHover: () => {},
 };
 
 export default FacebookPreview;

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -106,6 +106,9 @@ class FacebookPreview extends Component {
 		this.onTitleEnter = this.onMouseHover.bind( this, "title" );
 		this.onDescriptionEnter = this.onMouseHover.bind( this, "description" );
 		this.onLeave = this.onMouseHover.bind( this, "" );
+
+		this.onSelectTitle = this.onSelect.bind( this, "title" );
+		this.onSelectDescription = this.onSelect.bind( this, "description" );
 	}
 
 	/**
@@ -120,7 +123,7 @@ class FacebookPreview extends Component {
 	}
 
 	/**
-	 * Retrieves the imageMode from the Facebook image container.
+	 * Sets the hovered field on the container via a callback.
 	 *
 	 * @param {string} field The field that is hovered.
 	 *
@@ -128,6 +131,17 @@ class FacebookPreview extends Component {
 	 */
 	onMouseHover( field ) {
 		this.props.onMouseHover( field );
+	}
+
+	/**
+	 * Sets the active field on the container via a callback.
+	 *
+	 * @param {string} field The field that is hovered.
+	 *
+	 * @returns {void} Void.
+	 */
+	onSelect( field ) {
+		this.props.onSelect( field );
 	}
 
 	/**
@@ -144,7 +158,7 @@ class FacebookPreview extends Component {
 					src={ this.props.image }
 					alt={ this.props.alt }
 					onImageLoaded={ this.onImageLoaded }
-					onSelectImage={ this.props.onSelectImage }
+					onSelectImage={ this.onSelectImage }
 				/>
 				<OuterTextWrapper mode={ imageMode }>
 					<FacebookSiteAndAuthorNames
@@ -155,13 +169,14 @@ class FacebookPreview extends Component {
 					<FacebookTitle
 						onMouseEnter={ this.onTitleEnter }
 						onMouseLeave={ this.onLeave }
-						onSelect={ this.props.onSelect }
+						onClick={ this.onSelectTitle }
 					>
 						{ this.props.title }
 					</FacebookTitle>
 					<FacebookDescription
 						onMouseEnter={ this.onDescriptionEnter }
 						onMouseLeave={ this.onLeave }
+						onClick={ this.onSelectDescription }
 						mode={ imageMode }
 					>
 						{ this.props.description }
@@ -179,7 +194,7 @@ FacebookPreview.propTypes = {
 	description: PropTypes.string,
 	image: PropTypes.string,
 	alt: PropTypes.string,
-	onSelectImage: PropTypes.func,
+	onSelect: PropTypes.func,
 	onMouseHover: PropTypes.func,
 };
 
@@ -188,7 +203,7 @@ FacebookPreview.defaultProps = {
 	description: "",
 	alt: "",
 	image: "",
-	onSelectImage: () => {},
+	onSelect: () => {},
 	onMouseHover: () => {},
 };
 

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -119,6 +119,13 @@ class FacebookPreview extends Component {
 		this.setState( { imageMode: mode } );
 	}
 
+	/**
+	 * Retrieves the imageMode from the Facebook image container.
+	 *
+	 * @param {string} field The field that is hovered.
+	 *
+	 * @returns {void} Void.
+	 */
 	onMouseHover( field ) {
 		this.props.onMouseHover( field );
 	}
@@ -148,6 +155,7 @@ class FacebookPreview extends Component {
 					<FacebookTitle
 						onMouseEnter={ this.onTitleEnter }
 						onMouseLeave={ this.onLeave }
+						onSelect={ this.props.onSelect }
 					>
 						{ this.props.title }
 					</FacebookTitle>

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -10,8 +10,8 @@ import { default as NoCaretTitle } from "./FacebookTitle";
 import { default as NoCaretDescription } from "./FacebookDescription";
 import { withCaretStyle } from "../../../social-metadata-forms/src/SocialMetadataPreviewForm.js";
 
-const FacebookTitle = withCaretStyle( NoCaretTitle );
-const FacebookDescription = withCaretStyle( NoCaretDescription );
+const FacebookTitle = withCaretStyle( NoCaretTitle, true );
+const FacebookDescription = withCaretStyle( NoCaretDescription, true );
 
 /**
  * Determines the height depending on the mode.
@@ -64,7 +64,6 @@ const FacebookPreviewWrapper = styled.div`
 	display: flex;
 	flex-direction: ${ props => props.mode === "landscape" ? "column" : "row" };
 	background-color: #f2f3f5;
-	overflow: hidden;
 	width: 527px;
 	height: ${ props => determineWrapperHeight( props.mode ) };
 `;

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -103,12 +103,14 @@ class FacebookPreview extends Component {
 		};
 		this.onImageLoaded = this.onImageLoaded.bind( this );
 
-		this.onTitleEnter = this.onMouseHover.bind( this, "title" );
-		this.onDescriptionEnter = this.onMouseHover.bind( this, "description" );
-		this.onLeave = this.onMouseHover.bind( this, "" );
+		// Binding fields to onMouseHover to prevent arrow functions in JSX props.
+		this.onTitleEnter = this.props.onMouseHover.bind( this, "title" );
+		this.onDescriptionEnter = this.props.onMouseHover.bind( this, "description" );
+		this.onLeave = this.props.onMouseHover.bind( this, "" );
 
-		this.onSelectTitle = this.onSelect.bind( this, "title" );
-		this.onSelectDescription = this.onSelect.bind( this, "description" );
+		// Binding fields to onSelect to prevent arrow functions in JSX props.
+		this.onSelectTitle = this.props.onSelect.bind( this, "title" );
+		this.onSelectDescription = this.props.onSelect.bind( this, "description" );
 	}
 
 	/**
@@ -120,28 +122,6 @@ class FacebookPreview extends Component {
 	 */
 	onImageLoaded( mode ) {
 		this.setState( { imageMode: mode } );
-	}
-
-	/**
-	 * Sets the hovered field on the container via a callback.
-	 *
-	 * @param {string} field The field that is hovered.
-	 *
-	 * @returns {void} Void.
-	 */
-	onMouseHover( field ) {
-		this.props.onMouseHover( field );
-	}
-
-	/**
-	 * Sets the active field on the container via a callback.
-	 *
-	 * @param {string} field The field that is hovered.
-	 *
-	 * @returns {void} Void.
-	 */
-	onSelect( field ) {
-		this.props.onSelect( field );
 	}
 
 	/**

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -6,12 +6,8 @@ import styled from "styled-components";
 /* Internal dependencies */
 import FacebookSiteAndAuthorNames from "./FacebookSiteAndAuthorNames";
 import FacebookImage from "./FacebookImage";
-import { default as NoCaretTitle } from "./FacebookTitle";
-import { default as NoCaretDescription } from "./FacebookDescription";
-import { withCaretStyle } from "../../../social-metadata-forms/src/SocialMetadataPreviewForm.js";
-
-const FacebookTitle = withCaretStyle( NoCaretTitle, true );
-const FacebookDescription = withCaretStyle( NoCaretDescription, true );
+import FacebookTitle from "./FacebookTitle";
+import FacebookDescription from "./FacebookDescription";
 
 /**
  * Determines the height depending on the mode.
@@ -145,8 +141,6 @@ class FacebookPreview extends Component {
 					onImageClick={ this.props.onImageClick }
 					onMouseEnter={ this.onImageEnter }
 					onMouseLeave={ this.onLeave }
-					isActive={ this.props.activeField === "image" }
-					isHovered={ this.props.hoveredField === "image" }
 				/>
 				<OuterTextWrapper mode={ imageMode }>
 					<FacebookSiteAndAuthorNames
@@ -158,8 +152,6 @@ class FacebookPreview extends Component {
 						onMouseEnter={ this.onTitleEnter }
 						onMouseLeave={ this.onLeave }
 						onClick={ this.onSelectTitle }
-						isActive={ this.props.activeField === "title" }
-						isHovered={ this.props.hoveredField === "title" }
 					>
 						{ this.props.title }
 					</FacebookTitle>
@@ -168,8 +160,6 @@ class FacebookPreview extends Component {
 						onMouseLeave={ this.onLeave }
 						onClick={ this.onSelectDescription }
 						mode={ imageMode }
-						isActive={ this.props.activeField === "description" }
-						isHovered={ this.props.hoveredField === "description" }
 					>
 						{ this.props.description }
 					</FacebookDescription>
@@ -189,8 +179,6 @@ FacebookPreview.propTypes = {
 	onSelect: PropTypes.func,
 	onImageClick: PropTypes.func,
 	onMouseHover: PropTypes.func,
-	activeField: PropTypes.string,
-	hoveredField: PropTypes.string,
 };
 
 FacebookPreview.defaultProps = {
@@ -198,8 +186,6 @@ FacebookPreview.defaultProps = {
 	description: "",
 	alt: "",
 	image: "",
-	activeField: "",
-	hoveredField: "",
 	onSelect: () => {},
 	onImageClick: () => {},
 	onMouseHover: () => {},

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -6,8 +6,12 @@ import styled from "styled-components";
 /* Internal dependencies */
 import FacebookSiteAndAuthorNames from "./FacebookSiteAndAuthorNames";
 import FacebookImage from "./FacebookImage";
-import FacebookTitle from "./FacebookTitle";
-import FacebookDescription from "./FacebookDescription";
+import { default as NoCaretTitle } from "./FacebookTitle";
+import { default as NoCaretDescription } from "./FacebookDescription";
+import { withCaretStyle } from "../../../social-metadata-forms/src/SocialMetadataPreviewForm.js";
+
+const FacebookTitle = withCaretStyle( NoCaretTitle );
+const FacebookDescription = withCaretStyle( NoCaretDescription );
 
 /**
  * Determines the height depending on the mode.
@@ -142,6 +146,8 @@ class FacebookPreview extends Component {
 					onImageClick={ this.props.onImageClick }
 					onMouseEnter={ this.onImageEnter }
 					onMouseLeave={ this.onLeave }
+					isActive={ this.props.activeField === "image" }
+					isHovered={ this.props.hoveredField === "image" }
 				/>
 				<OuterTextWrapper mode={ imageMode }>
 					<FacebookSiteAndAuthorNames
@@ -153,6 +159,8 @@ class FacebookPreview extends Component {
 						onMouseEnter={ this.onTitleEnter }
 						onMouseLeave={ this.onLeave }
 						onClick={ this.onSelectTitle }
+						isActive={ this.props.activeField === "title" }
+						isHovered={ this.props.hoveredField === "title" }
 					>
 						{ this.props.title }
 					</FacebookTitle>
@@ -161,6 +169,8 @@ class FacebookPreview extends Component {
 						onMouseLeave={ this.onLeave }
 						onClick={ this.onSelectDescription }
 						mode={ imageMode }
+						isActive={ this.props.activeField === "description" }
+						isHovered={ this.props.hoveredField === "description" }
 					>
 						{ this.props.description }
 					</FacebookDescription>
@@ -180,6 +190,8 @@ FacebookPreview.propTypes = {
 	onSelect: PropTypes.func,
 	onImageClick: PropTypes.func,
 	onMouseHover: PropTypes.func,
+	activeField: PropTypes.string,
+	hoveredField: PropTypes.string,
 };
 
 FacebookPreview.defaultProps = {
@@ -187,6 +199,8 @@ FacebookPreview.defaultProps = {
 	description: "",
 	alt: "",
 	image: "",
+	activeField: "",
+	hoveredField: "",
 	onSelect: () => {},
 	onImageClick: () => {},
 	onMouseHover: () => {},

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -109,7 +109,7 @@ class FacebookPreview extends Component {
 		this.onDescriptionEnter = this.props.onMouseHover.bind( this, "description" );
 		this.onLeave = this.props.onMouseHover.bind( this, "" );
 
-		// Binding fields to onSelect to prevent arrow functions in JSX props.
+		// Binding fields to onSelect to prevent arrow functions in JSX props. Image field is handled in onImageClick function.
 		this.onSelectTitle = this.props.onSelect.bind( this, "title" );
 		this.onSelectDescription = this.props.onSelect.bind( this, "description" );
 	}
@@ -139,7 +139,7 @@ class FacebookPreview extends Component {
 					src={ this.props.image }
 					alt={ this.props.alt }
 					onImageLoaded={ this.onImageLoaded }
-					onSelectImage={ this.onSelectImage }
+					onImageClick={ this.props.onImageClick }
 					onMouseEnter={ this.onImageEnter }
 					onMouseLeave={ this.onLeave }
 				/>
@@ -178,6 +178,7 @@ FacebookPreview.propTypes = {
 	image: PropTypes.string,
 	alt: PropTypes.string,
 	onSelect: PropTypes.func,
+	onImageClick: PropTypes.func,
 	onMouseHover: PropTypes.func,
 };
 
@@ -187,6 +188,7 @@ FacebookPreview.defaultProps = {
 	alt: "",
 	image: "",
 	onSelect: () => {},
+	onImageClick: () => {},
 	onMouseHover: () => {},
 };
 

--- a/packages/social-metadata-previews/src/facebook/FacebookTitle.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookTitle.js
@@ -1,12 +1,16 @@
 /* External dependencies */
 import styled from "styled-components";
 
+// Used to sure the element also has a height when empty by setting min-height equal to line-height.
+const height = "20px";
+
 const FacebookTitle = styled.span`
+	line-height: ${ height };
+	min-height : ${ height };
 	color: #1d2129;
 	font-weight: 600;
 	overflow: hidden;
 	font-size: 16px;
-	line-height: 20px;
 	margin: 0;
 	letter-spacing: normal;
 	white-space: normal;

--- a/packages/social-metadata-previews/src/facebook/FacebookTitle.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookTitle.js
@@ -1,9 +1,7 @@
 /* External dependencies */
-import React from "react";
 import styled from "styled-components";
-import PropTypes from "prop-types";
 
-const FacebookTitleWrapper = styled.span`
+const FacebookTitle = styled.span`
 	color: #1d2129;
 	font-weight: 600;
 	overflow: hidden;
@@ -16,27 +14,8 @@ const FacebookTitleWrapper = styled.span`
 	cursor: pointer;
 	display: -webkit-box;
 	-webkit-line-clamp: 2;
-	-webkit-box-orient: vertical;  
+	-webkit-box-orient: vertical;
 	overflow: hidden;
 `;
-
-/**
- * Renders a FacebookTitle component.
- *
- * @param {object} props The props.
- *
- * @returns {React.Element} The rendered element.
- */
-const FacebookTitle = ( props ) => {
-	return (
-		<FacebookTitleWrapper>
-			{ props.title }
-		</FacebookTitleWrapper>
-	);
-};
-
-FacebookTitle.propTypes = {
-	title: PropTypes.string.isRequired,
-};
 
 export default FacebookTitle;

--- a/packages/social-metadata-previews/src/index.js
+++ b/packages/social-metadata-previews/src/index.js
@@ -1,3 +1,3 @@
 export { default as FacebookPreview } from "./facebook/FacebookPreview";
 export { default as TwitterPreview } from "./twitter/TwitterPreview";
-export { default as FacebookPreviewEditor } from "./editor/SocialPreviewEditor";
+export { default as SocialPreviewEditor } from "./editor/SocialPreviewEditor";

--- a/packages/social-metadata-previews/src/index.js
+++ b/packages/social-metadata-previews/src/index.js
@@ -1,2 +1,3 @@
 export { default as FacebookPreview } from "./facebook/FacebookPreview";
 export { default as TwitterPreview } from "./twitter/TwitterPreview";
+export { default as FacebookPreviewEditor } from "./editor/SocialPreviewEditor";

--- a/packages/social-metadata-previews/src/twitter/TwitterDescription.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterDescription.js
@@ -11,6 +11,7 @@ import styled from "styled-components";
  */
 const TwitterDescription = styled.p`
 	max-height: 55px;
+	min-height: 20px;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	margin: 0 0 2px;

--- a/packages/social-metadata-previews/src/twitter/TwitterDescription.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterDescription.js
@@ -17,6 +17,7 @@ const TwitterDescription = styled.p`
 	margin: 0 0 2px;
 	color: rgb(101, 119, 134);
 	display: -webkit-box;
+	cursor: pointer;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 `;

--- a/packages/social-metadata-previews/src/twitter/TwitterDescription.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterDescription.js
@@ -1,7 +1,5 @@
 /* External dependencies */
-import React from "react";
 import styled from "styled-components";
-import PropTypes from "prop-types";
 
 /**
  * Renders a TwitterDescription component.
@@ -11,7 +9,7 @@ import PropTypes from "prop-types";
  *
  * @returns {React.Component} The rendered element.
  */
-const TwitterDescriptionText = styled.p`
+const TwitterDescription = styled.p`
 	max-height: 55px;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -21,22 +19,5 @@ const TwitterDescriptionText = styled.p`
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
 `;
-
-/**
- * Component that contains the twitter description text.
- *
- * @param {object} props The properties passed to the component.
- *
- * @returns {React.Element} The TwitterDescription component.
- */
-const TwitterDescription = ( props ) =>
-	<TwitterDescriptionText>
-		{ props.description }
-	</TwitterDescriptionText>
-;
-
-TwitterDescription.propTypes = {
-	description: PropTypes.string.isRequired,
-};
 
 export default TwitterDescription;

--- a/packages/social-metadata-previews/src/twitter/TwitterImage.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterImage.js
@@ -156,8 +156,8 @@ export default class TwitterImage extends React.Component {
 }
 
 TwitterImage.propTypes = {
-	src: PropTypes.string.isRequired,
 	isLarge: PropTypes.bool.isRequired,
+	src: PropTypes.string,
 	alt: PropTypes.string,
 	onImageClick: PropTypes.func,
 	onMouseEnter: PropTypes.func,
@@ -165,8 +165,9 @@ TwitterImage.propTypes = {
 };
 
 TwitterImage.defaultProps = {
+	src: "",
 	alt: "",
-	onImageClick: () => {},
 	onMouseEnter: () => {},
+	onImageClick: () => {},
 	onMouseLeave: () => {},
 };

--- a/packages/social-metadata-previews/src/twitter/TwitterImage.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterImage.js
@@ -25,6 +25,7 @@ const injectCardDependentStyles = ( isLarge, border = true ) => {
 			height: ${ TWITTER_IMAGE_SIZES.landscapeHeight }px;
 			width: ${ TWITTER_IMAGE_SIZES.landscapeWidth }px;
 			${ border ? "border-bottom: 1px solid #E1E8ED;" : "" }
+			border-radius: 14px 14px 0 0;
 			`
 		);
 	}
@@ -32,6 +33,7 @@ const injectCardDependentStyles = ( isLarge, border = true ) => {
 		`
 		width: ${ TWITTER_IMAGE_SIZES.squareWidth }px;
 		${ border ? "border-right: 1px solid #E1E8ED;" : "" }
+		border-radius: 14px 0 0 14px;
 		`
 	);
 };

--- a/packages/social-metadata-previews/src/twitter/TwitterImage.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterImage.js
@@ -128,13 +128,21 @@ export default class TwitterImage extends React.Component {
 		const { imageProperties, status } = this.state;
 
 		if ( status === "loading" || this.props.src === "" || status === "errored" ) {
-			return <PlaceholderImage isLarge={ this.props.isLarge }>
+			return <PlaceholderImage
+				isLarge={ this.props.isLarge }
+				onClick={ this.props.onImageClick }
+				onMouseEnter={ this.props.onMouseEnter }
+				onMouseLeave={ this.props.onMouseLeave }
+			>
 				{ __( "Select image", "yoast-components" ) }
 			</PlaceholderImage>;
 		}
 
 		return <TwitterImageContainer
 			isLarge={ this.props.isLarge }
+			onClick={ this.props.onImageClick }
+			onMouseEnter={ this.props.onMouseEnter }
+			onMouseLeave={ this.props.onMouseLeave }
 		>
 			<StyledImage
 				src={ this.props.src }
@@ -149,8 +157,14 @@ TwitterImage.propTypes = {
 	src: PropTypes.string.isRequired,
 	isLarge: PropTypes.bool.isRequired,
 	alt: PropTypes.string,
+	onImageClick: PropTypes.func,
+	onMouseEnter: PropTypes.func,
+	onMouseLeave: PropTypes.func,
 };
 
 TwitterImage.defaultProps = {
 	alt: "",
+	onImageClick: () => {},
+	onMouseEnter: () => {},
+	onMouseLeave: () => {},
 };

--- a/packages/social-metadata-previews/src/twitter/TwitterPreview.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterPreview.js
@@ -1,14 +1,18 @@
 /* External dependencies */
-import React from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 
 /* Internal dependencies */
-import TwitterTitle from "./TwitterTitle";
-import TwitterDescription from "./TwitterDescription";
 import TwitterSiteName from "./TwitterSiteName";
 import TwitterImage from "../twitter/TwitterImage";
 import TwitterTextWrapper from "./TwitterTextWrapper";
+import { default as NoCaretTitle } from "./TwitterTitle";
+import { default as NoCaretDescription } from "./TwitterDescription";
+import { withCaretStyle } from "../../../social-metadata-forms/src/SocialMetadataPreviewForm.js";
+
+const TwitterTitle = withCaretStyle( NoCaretTitle );
+const TwitterDescription = withCaretStyle( NoCaretDescription );
 
 const TwitterPreviewWrapper = styled.div`
 	font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
@@ -54,36 +58,109 @@ const SmallTwitterPreviewWrapper = styled( TwitterPreviewWrapper )`
  *
  * @returns {React.Element} The rendered element.
  */
-const TwitterPreview = ( props ) => {
-	const Wrapper = props.isLarge ? LargeTwitterPreviewWrapper : SmallTwitterPreviewWrapper;
+class TwitterPreview extends Component {
+	/**
+	 * The constructor.
+	 *
+	 * @param {Object} props The props.
+	 *
+	 * @returns {void}
+	 */
+	constructor( props ) {
+		super( props );
+		this.Wrapper = props.isLarge ? LargeTwitterPreviewWrapper : SmallTwitterPreviewWrapper;
 
-	return (
-		<Wrapper isLarge={ props.isLarge }>
-			<TwitterImage src={ props.image } alt={ props.alt } isLarge={ props.isLarge } />
-			<TwitterTextWrapper>
-				<TwitterTitle title={ props.title } />
-				<TwitterDescription description={ props.description } />
-				<TwitterSiteName siteName={ props.siteName } />
-			</TwitterTextWrapper>
-		</Wrapper>
-	);
-};
+		// Binding fields to onMouseHover to prevent arrow functions in JSX props.
+		this.onImageEnter = this.props.onMouseHover.bind( this, "image" );
+		this.onTitleEnter = this.props.onMouseHover.bind( this, "title" );
+		this.onDescriptionEnter = this.props.onMouseHover.bind( this, "description" );
+		this.onLeave = this.props.onMouseHover.bind( this, "" );
+
+		// Binding fields to onSelect to prevent arrow functions in JSX props. Image field is handled in onImageClick function.
+		this.onSelectTitle = this.props.onSelect.bind( this, "title" );
+		this.onSelectDescription = this.props.onSelect.bind( this, "description" );
+	}
+
+	/**
+	 * The render function.
+	 *
+	 * @returns {*} The rendered component.
+	 */
+	render() {
+		const {
+			isLarge,
+			image,
+			alt,
+			title,
+			description,
+			siteName,
+			activeField,
+			hoveredField,
+		} = this.props;
+		return (
+			<this.Wrapper isLarge={ isLarge }>
+				<TwitterImage
+					src={ image }
+					alt={ alt }
+					isLarge={ isLarge }
+					onImageClick={ this.props.onImageClick }
+					onMouseEnter={ this.onImageEnter }
+					onMouseLeave={ this.onLeave }
+					isActive={ activeField === "image" }
+					isHovered={ hoveredField === "image" }
+				/>
+				<TwitterTextWrapper>
+					<TwitterTitle
+						onMouseEnter={ this.onTitleEnter }
+						onMouseLeave={ this.onLeave }
+						onClick={ this.onSelectTitle }
+						isActive={ activeField === "title" }
+						isHovered={ hoveredField === "title" }
+					>
+						{ title }
+					</TwitterTitle>
+					<TwitterDescription
+						onMouseEnter={ this.onDescriptionEnter }
+						onMouseLeave={ this.onLeave }
+						onClick={ this.onSelectDescription }
+						isActive={ activeField === "description" }
+						isHovered={ hoveredField === "description" }
+					>
+						{ description }
+					</TwitterDescription>
+					<TwitterSiteName
+						siteName={ siteName }
+					/>
+				</TwitterTextWrapper>
+			</this.Wrapper>
+		);
+	}
+}
 
 TwitterPreview.propTypes = {
+	siteName: PropTypes.string.isRequired,
 	title: PropTypes.string.isRequired,
 	description: PropTypes.string,
-	isLarge: PropTypes.bool.isRequired,
-	siteName: PropTypes.string.isRequired,
-	image: PropTypes.string.isRequired,
+	isLarge: PropTypes.bool,
+	image: PropTypes.string,
 	alt: PropTypes.string,
-};
-
-TwitterPreview.defaultProps = {
-	alt: "",
+	onSelect: PropTypes.func,
+	onImageClick: PropTypes.func,
+	onMouseHover: PropTypes.func,
+	activeField: PropTypes.string,
+	hoveredField: PropTypes.string,
 };
 
 TwitterPreview.defaultProps = {
 	description: "",
+	alt: "",
+	image: "",
+	activeField: "",
+	hoveredField: "",
+	onSelect: () => {},
+	onImageClick: () => {},
+	onMouseHover: () => {},
+	isLarge: true,
 };
 
 export default TwitterPreview;

--- a/packages/social-metadata-previews/src/twitter/TwitterPreview.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterPreview.js
@@ -7,12 +7,8 @@ import styled from "styled-components";
 import TwitterSiteName from "./TwitterSiteName";
 import TwitterImage from "../twitter/TwitterImage";
 import TwitterTextWrapper from "./TwitterTextWrapper";
-import { default as NoCaretTitle } from "./TwitterTitle";
-import { default as NoCaretDescription } from "./TwitterDescription";
-import { withCaretStyle } from "../../../social-metadata-forms/src/SocialMetadataPreviewForm.js";
-
-const TwitterTitle = withCaretStyle( NoCaretTitle, true );
-const TwitterDescription = withCaretStyle( NoCaretDescription, true );
+import TwitterTitle from "./TwitterTitle";
+import TwitterDescription from "./TwitterDescription";
 
 const TwitterPreviewWrapper = styled.div`
 	font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
@@ -92,8 +88,6 @@ class TwitterPreview extends Component {
 			title,
 			description,
 			siteName,
-			activeField,
-			hoveredField,
 		} = this.props;
 
 		const Wrapper = isLarge ? LargeTwitterPreviewWrapper : SmallTwitterPreviewWrapper;
@@ -107,16 +101,12 @@ class TwitterPreview extends Component {
 					onImageClick={ this.props.onImageClick }
 					onMouseEnter={ this.onImageEnter }
 					onMouseLeave={ this.onLeave }
-					isActive={ activeField === "image" }
-					isHovered={ hoveredField === "image" }
 				/>
 				<TwitterTextWrapper>
 					<TwitterTitle
 						onMouseEnter={ this.onTitleEnter }
 						onMouseLeave={ this.onLeave }
 						onClick={ this.onSelectTitle }
-						isActive={ activeField === "title" }
-						isHovered={ hoveredField === "title" }
 					>
 						{ title }
 					</TwitterTitle>
@@ -124,8 +114,6 @@ class TwitterPreview extends Component {
 						onMouseEnter={ this.onDescriptionEnter }
 						onMouseLeave={ this.onLeave }
 						onClick={ this.onSelectDescription }
-						isActive={ activeField === "description" }
-						isHovered={ hoveredField === "description" }
 					>
 						{ description }
 					</TwitterDescription>
@@ -148,16 +136,12 @@ TwitterPreview.propTypes = {
 	onSelect: PropTypes.func,
 	onImageClick: PropTypes.func,
 	onMouseHover: PropTypes.func,
-	activeField: PropTypes.string,
-	hoveredField: PropTypes.string,
 };
 
 TwitterPreview.defaultProps = {
 	description: "",
 	alt: "",
 	image: "",
-	activeField: "",
-	hoveredField: "",
 	onSelect: () => {},
 	onImageClick: () => {},
 	onMouseHover: () => {},

--- a/packages/social-metadata-previews/src/twitter/TwitterPreview.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterPreview.js
@@ -11,8 +11,8 @@ import { default as NoCaretTitle } from "./TwitterTitle";
 import { default as NoCaretDescription } from "./TwitterDescription";
 import { withCaretStyle } from "../../../social-metadata-forms/src/SocialMetadataPreviewForm.js";
 
-const TwitterTitle = withCaretStyle( NoCaretTitle );
-const TwitterDescription = withCaretStyle( NoCaretDescription );
+const TwitterTitle = withCaretStyle( NoCaretTitle, true );
+const TwitterDescription = withCaretStyle( NoCaretDescription, true );
 
 const TwitterPreviewWrapper = styled.div`
 	font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Helvetica Neue", sans-serif;
@@ -20,15 +20,14 @@ const TwitterPreviewWrapper = styled.div`
 	font-weight: 400;
 	line-height: 20px;
 	width: 507px;
-	border-radius: 14px;
 	border: 1px solid #E1E8ED;
 	box-sizing: border-box;
+	border-radius: 14px;
 	color: #292F33;
 	background: #FFFFFF;
-	overflow: hidden;
 	text-overflow: ellipsis;
 	display: flex;
-
+	
 	&:hover {
 		background: #f5f8fa;
 		border: 1px solid rgba(136,153,166,.5);
@@ -98,7 +97,7 @@ class TwitterPreview extends Component {
 			hoveredField,
 		} = this.props;
 		return (
-			<this.Wrapper isLarge={ isLarge }>
+			<this.Wrapper>
 				<TwitterImage
 					src={ image }
 					alt={ alt }

--- a/packages/social-metadata-previews/src/twitter/TwitterPreview.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterPreview.js
@@ -67,7 +67,6 @@ class TwitterPreview extends Component {
 	 */
 	constructor( props ) {
 		super( props );
-		this.Wrapper = props.isLarge ? LargeTwitterPreviewWrapper : SmallTwitterPreviewWrapper;
 
 		// Binding fields to onMouseHover to prevent arrow functions in JSX props.
 		this.onImageEnter = this.props.onMouseHover.bind( this, "image" );
@@ -96,8 +95,11 @@ class TwitterPreview extends Component {
 			activeField,
 			hoveredField,
 		} = this.props;
+
+		const Wrapper = isLarge ? LargeTwitterPreviewWrapper : SmallTwitterPreviewWrapper;
+
 		return (
-			<this.Wrapper>
+			<Wrapper>
 				<TwitterImage
 					src={ image }
 					alt={ alt }
@@ -131,7 +133,7 @@ class TwitterPreview extends Component {
 						siteName={ siteName }
 					/>
 				</TwitterTextWrapper>
-			</this.Wrapper>
+			</Wrapper>
 		);
 	}
 }

--- a/packages/social-metadata-previews/src/twitter/TwitterTitle.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterTitle.js
@@ -13,6 +13,7 @@ const TwitterTitle = styled.p`
 	margin-top: 0;
 	margin-bottom: 2px;
 	color: rgb(20, 23, 26);
+	cursor: pointer;
 `;
 
 export default TwitterTitle;

--- a/packages/social-metadata-previews/src/twitter/TwitterTitle.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterTitle.js
@@ -1,9 +1,7 @@
 /* External dependencies */
-import React from "react";
 import styled from "styled-components";
-import PropTypes from "prop-types";
 
-const TwitterTitleWrapper = styled.p`
+const TwitterTitle = styled.p`
 	line-height: 18px;
 	white-space: nowrap;
 	overflow: hidden;
@@ -12,23 +10,5 @@ const TwitterTitleWrapper = styled.p`
 	margin-bottom: 2px;
 	color: rgb(20, 23, 26);
 `;
-
-/**
- * Renders a TwitterTitle component.
- *
- * @param {object} props                    The props.
- * @param {string} props.title              The title.
- *
- * @returns {React.Element} The rendered element.
- */
-const TwitterTitle = ( props ) =>
-	<TwitterTitleWrapper>
-		{ props.title }
-	</TwitterTitleWrapper>
-;
-
-TwitterTitle.propTypes = {
-	title: PropTypes.string.isRequired,
-};
 
 export default TwitterTitle;

--- a/packages/social-metadata-previews/src/twitter/TwitterTitle.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterTitle.js
@@ -1,8 +1,12 @@
 /* External dependencies */
 import styled from "styled-components";
 
+// Used to sure the element also has a height when empty by setting min-height equal to line-height.
+const height = "18px";
+
 const TwitterTitle = styled.p`
-	line-height: 18px;
+	line-height: ${ height };
+	min-height : ${ height };
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookDescriptionTest.js.snap
+++ b/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookDescriptionTest.js.snap
@@ -2,9 +2,10 @@
 
 exports[`FacebookDescription matches the snapshot by default 1`] = `
 .c0 {
+  line-height: 16px;
+  min-height: 16px;
   color: #606770;
   font-size: 12px;
-  line-height: 16px;
   padding: 0;
   text-overflow: ellipsis;
   margin: 3px 0 0 0;

--- a/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookDescriptionTest.js.snap
+++ b/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookDescriptionTest.js.snap
@@ -10,6 +10,7 @@ exports[`FacebookDescription matches the snapshot by default 1`] = `
   text-overflow: ellipsis;
   margin: 3px 0 0 0;
   display: -webkit-box;
+  cursor: pointer;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;

--- a/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookImageTest.js.snap
+++ b/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookImageTest.js.snap
@@ -26,6 +26,9 @@ exports[`FacebookImage Component matches the snapshot for a faulty image 1`] = `
 
 <div
   className="c0"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   Select image
 </div>
@@ -53,6 +56,9 @@ exports[`FacebookImage Component matches the snapshot for a landscape image 1`] 
 
 <div
   className="c0"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <img
     alt=""
@@ -84,6 +90,9 @@ exports[`FacebookImage Component matches the snapshot for a portrait image 1`] =
 
 <div
   className="c0"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <img
     alt=""
@@ -115,6 +124,9 @@ exports[`FacebookImage Component matches the snapshot for a square image 1`] = `
 
 <div
   className="c0"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <img
     alt=""
@@ -146,6 +158,9 @@ exports[`FacebookImage Component matches the snapshot for a too small image 1`] 
 
 <div
   className="c0"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <img
     alt=""
@@ -181,6 +196,9 @@ exports[`FacebookImage Component matches the snapshot in the loading state 1`] =
 
 <div
   className="c0"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   Select image
 </div>

--- a/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookPreviewTest.js.snap
+++ b/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookPreviewTest.js.snap
@@ -48,12 +48,13 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c7 {
+  line-height: 20px;
+  min-height: 20px;
   color: #1d2129;
   font-weight: 600;
   overflow: hidden;
   font-size: 16px;
-  line-height: 20px;
   margin: 0;
   -webkit-letter-spacing: normal;
   -moz-letter-spacing: normal;
@@ -70,10 +71,11 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
   overflow: hidden;
 }
 
-.c6 {
+.c8 {
+  line-height: 16px;
+  min-height: 16px;
   color: #606770;
   font-size: 12px;
-  line-height: 16px;
   padding: 0;
   text-overflow: ellipsis;
   margin: 3px 0 0 0;
@@ -81,6 +83,28 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+.c5 {
+  position: relative;
+}
+
+.c6 {
+  display: none;
+}
+
+.c6::before {
+  position: absolute;
+  top: -2px;
+  left: -35px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  color: #ccc;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: "";
 }
 
 .c0 {
@@ -93,7 +117,6 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   background-color: #f2f3f5;
-  overflow: hidden;
   width: 527px;
   height: 57px;
 }
@@ -128,6 +151,9 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
 >
   <div
     className="c1"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     Select image
   </div>
@@ -150,17 +176,37 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
         yoast.com
       </span>
     </p>
-    <span
+    <div
       className="c5"
     >
-      YoastCon Workshops
-    </span>
-    <p
-      className="c6"
-      mode={null}
+      <div
+        className="c6"
+      />
+      <span
+        className="c7"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        YoastCon Workshops
+      </span>
+    </div>
+    <div
+      className="c5"
     >
-      Description to go along with a faulty image.
-    </p>
+      <div
+        className="c6"
+      />
+      <p
+        className="c8"
+        mode={null}
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Description to go along with a faulty image.
+      </p>
+    </div>
   </div>
 </div>
 `;
@@ -213,12 +259,13 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c7 {
+  line-height: 20px;
+  min-height: 20px;
   color: #1d2129;
   font-weight: 600;
   overflow: hidden;
   font-size: 16px;
-  line-height: 20px;
   margin: 0;
   -webkit-letter-spacing: normal;
   -moz-letter-spacing: normal;
@@ -235,10 +282,11 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
   overflow: hidden;
 }
 
-.c6 {
+.c8 {
+  line-height: 16px;
+  min-height: 16px;
   color: #606770;
   font-size: 12px;
-  line-height: 16px;
   padding: 0;
   text-overflow: ellipsis;
   margin: 3px 0 0 0;
@@ -246,6 +294,28 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+.c5 {
+  position: relative;
+}
+
+.c6 {
+  display: none;
+}
+
+.c6::before {
+  position: absolute;
+  top: -2px;
+  left: -35px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  color: #ccc;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: "";
 }
 
 .c0 {
@@ -258,7 +328,6 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   background-color: #f2f3f5;
-  overflow: hidden;
   width: 527px;
   height: 57px;
 }
@@ -293,6 +362,9 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
 >
   <div
     className="c1"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     Select image
   </div>
@@ -315,17 +387,37 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
         yoast.com
       </span>
     </p>
-    <span
+    <div
       className="c5"
     >
-      YoastCon Workshops
-    </span>
-    <p
-      className="c6"
-      mode={null}
+      <div
+        className="c6"
+      />
+      <span
+        className="c7"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        YoastCon Workshops
+      </span>
+    </div>
+    <div
+      className="c5"
     >
-      Description to go along with a landscape image.
-    </p>
+      <div
+        className="c6"
+      />
+      <p
+        className="c8"
+        mode={null}
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Description to go along with a landscape image.
+      </p>
+    </div>
   </div>
 </div>
 `;
@@ -378,12 +470,13 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c7 {
+  line-height: 20px;
+  min-height: 20px;
   color: #1d2129;
   font-weight: 600;
   overflow: hidden;
   font-size: 16px;
-  line-height: 20px;
   margin: 0;
   -webkit-letter-spacing: normal;
   -moz-letter-spacing: normal;
@@ -400,10 +493,11 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
   overflow: hidden;
 }
 
-.c6 {
+.c8 {
+  line-height: 16px;
+  min-height: 16px;
   color: #606770;
   font-size: 12px;
-  line-height: 16px;
   padding: 0;
   text-overflow: ellipsis;
   margin: 3px 0 0 0;
@@ -411,6 +505,28 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+.c5 {
+  position: relative;
+}
+
+.c6 {
+  display: none;
+}
+
+.c6::before {
+  position: absolute;
+  top: -2px;
+  left: -35px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  color: #ccc;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: "";
 }
 
 .c0 {
@@ -423,7 +539,6 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   background-color: #f2f3f5;
-  overflow: hidden;
   width: 527px;
   height: 57px;
 }
@@ -458,6 +573,9 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
 >
   <div
     className="c1"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     Select image
   </div>
@@ -480,17 +598,37 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
         yoast.com
       </span>
     </p>
-    <span
+    <div
       className="c5"
     >
-      YoastCon Workshops
-    </span>
-    <p
-      className="c6"
-      mode={null}
+      <div
+        className="c6"
+      />
+      <span
+        className="c7"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        YoastCon Workshops
+      </span>
+    </div>
+    <div
+      className="c5"
     >
-      Description to go along with a portrait image.
-    </p>
+      <div
+        className="c6"
+      />
+      <p
+        className="c8"
+        mode={null}
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Description to go along with a portrait image.
+      </p>
+    </div>
   </div>
 </div>
 `;
@@ -543,12 +681,13 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c7 {
+  line-height: 20px;
+  min-height: 20px;
   color: #1d2129;
   font-weight: 600;
   overflow: hidden;
   font-size: 16px;
-  line-height: 20px;
   margin: 0;
   -webkit-letter-spacing: normal;
   -moz-letter-spacing: normal;
@@ -565,10 +704,11 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
   overflow: hidden;
 }
 
-.c6 {
+.c8 {
+  line-height: 16px;
+  min-height: 16px;
   color: #606770;
   font-size: 12px;
-  line-height: 16px;
   padding: 0;
   text-overflow: ellipsis;
   margin: 3px 0 0 0;
@@ -576,6 +716,28 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+.c5 {
+  position: relative;
+}
+
+.c6 {
+  display: none;
+}
+
+.c6::before {
+  position: absolute;
+  top: -2px;
+  left: -35px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  color: #ccc;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: "";
 }
 
 .c0 {
@@ -588,7 +750,6 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   background-color: #f2f3f5;
-  overflow: hidden;
   width: 527px;
   height: 57px;
 }
@@ -623,6 +784,9 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
 >
   <div
     className="c1"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     Select image
   </div>
@@ -645,17 +809,37 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
         yoast.com
       </span>
     </p>
-    <span
+    <div
       className="c5"
     >
-      YoastCon Workshops
-    </span>
-    <p
-      className="c6"
-      mode={null}
+      <div
+        className="c6"
+      />
+      <span
+        className="c7"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        YoastCon Workshops
+      </span>
+    </div>
+    <div
+      className="c5"
     >
-      Description to go along with a square image.
-    </p>
+      <div
+        className="c6"
+      />
+      <p
+        className="c8"
+        mode={null}
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Description to go along with a square image.
+      </p>
+    </div>
   </div>
 </div>
 `;
@@ -708,12 +892,13 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
   align-items: center;
 }
 
-.c5 {
+.c7 {
+  line-height: 20px;
+  min-height: 20px;
   color: #1d2129;
   font-weight: 600;
   overflow: hidden;
   font-size: 16px;
-  line-height: 20px;
   margin: 0;
   -webkit-letter-spacing: normal;
   -moz-letter-spacing: normal;
@@ -730,10 +915,11 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
   overflow: hidden;
 }
 
-.c6 {
+.c8 {
+  line-height: 16px;
+  min-height: 16px;
   color: #606770;
   font-size: 12px;
-  line-height: 16px;
   padding: 0;
   text-overflow: ellipsis;
   margin: 3px 0 0 0;
@@ -741,6 +927,28 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
+}
+
+.c5 {
+  position: relative;
+}
+
+.c6 {
+  display: none;
+}
+
+.c6::before {
+  position: absolute;
+  top: -2px;
+  left: -35px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  color: #ccc;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: "";
 }
 
 .c0 {
@@ -753,7 +961,6 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   background-color: #f2f3f5;
-  overflow: hidden;
   width: 527px;
   height: 57px;
 }
@@ -788,6 +995,9 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
 >
   <div
     className="c1"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     Select image
   </div>
@@ -810,17 +1020,37 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
         yoast.com
       </span>
     </p>
-    <span
+    <div
       className="c5"
     >
-      YoastCon Workshops
-    </span>
-    <p
-      className="c6"
-      mode={null}
+      <div
+        className="c6"
+      />
+      <span
+        className="c7"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        YoastCon Workshops
+      </span>
+    </div>
+    <div
+      className="c5"
     >
-      Description to go along with too small an image.
-    </p>
+      <div
+        className="c6"
+      />
+      <p
+        className="c8"
+        mode={null}
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        Description to go along with too small an image.
+      </p>
+    </div>
   </div>
 </div>
 `;

--- a/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookPreviewTest.js.snap
+++ b/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookPreviewTest.js.snap
@@ -48,7 +48,7 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c5 {
   line-height: 20px;
   min-height: 20px;
   color: #1d2129;
@@ -71,7 +71,7 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
   overflow: hidden;
 }
 
-.c8 {
+.c6 {
   line-height: 16px;
   min-height: 16px;
   color: #606770;
@@ -80,31 +80,10 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
   text-overflow: ellipsis;
   margin: 3px 0 0 0;
   display: -webkit-box;
+  cursor: pointer;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
-}
-
-.c5 {
-  position: relative;
-}
-
-.c6 {
-  display: none;
-}
-
-.c6::before {
-  position: absolute;
-  top: -2px;
-  left: -35px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  color: #ccc;
-  background-size: 24px;
-  background-repeat: no-repeat;
-  background-position: center;
-  content: "";
 }
 
 .c0 {
@@ -176,37 +155,23 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
         yoast.com
       </span>
     </p>
-    <div
+    <span
       className="c5"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c6"
-      />
-      <span
-        className="c7"
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        YoastCon Workshops
-      </span>
-    </div>
-    <div
-      className="c5"
+      YoastCon Workshops
+    </span>
+    <p
+      className="c6"
+      mode={null}
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c6"
-      />
-      <p
-        className="c8"
-        mode={null}
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        Description to go along with a faulty image.
-      </p>
-    </div>
+      Description to go along with a faulty image.
+    </p>
   </div>
 </div>
 `;
@@ -259,7 +224,7 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c5 {
   line-height: 20px;
   min-height: 20px;
   color: #1d2129;
@@ -282,7 +247,7 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
   overflow: hidden;
 }
 
-.c8 {
+.c6 {
   line-height: 16px;
   min-height: 16px;
   color: #606770;
@@ -291,31 +256,10 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
   text-overflow: ellipsis;
   margin: 3px 0 0 0;
   display: -webkit-box;
+  cursor: pointer;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
-}
-
-.c5 {
-  position: relative;
-}
-
-.c6 {
-  display: none;
-}
-
-.c6::before {
-  position: absolute;
-  top: -2px;
-  left: -35px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  color: #ccc;
-  background-size: 24px;
-  background-repeat: no-repeat;
-  background-position: center;
-  content: "";
 }
 
 .c0 {
@@ -387,37 +331,23 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
         yoast.com
       </span>
     </p>
-    <div
+    <span
       className="c5"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c6"
-      />
-      <span
-        className="c7"
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        YoastCon Workshops
-      </span>
-    </div>
-    <div
-      className="c5"
+      YoastCon Workshops
+    </span>
+    <p
+      className="c6"
+      mode={null}
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c6"
-      />
-      <p
-        className="c8"
-        mode={null}
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        Description to go along with a landscape image.
-      </p>
-    </div>
+      Description to go along with a landscape image.
+    </p>
   </div>
 </div>
 `;
@@ -470,7 +400,7 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c5 {
   line-height: 20px;
   min-height: 20px;
   color: #1d2129;
@@ -493,7 +423,7 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
   overflow: hidden;
 }
 
-.c8 {
+.c6 {
   line-height: 16px;
   min-height: 16px;
   color: #606770;
@@ -502,31 +432,10 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
   text-overflow: ellipsis;
   margin: 3px 0 0 0;
   display: -webkit-box;
+  cursor: pointer;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
-}
-
-.c5 {
-  position: relative;
-}
-
-.c6 {
-  display: none;
-}
-
-.c6::before {
-  position: absolute;
-  top: -2px;
-  left: -35px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  color: #ccc;
-  background-size: 24px;
-  background-repeat: no-repeat;
-  background-position: center;
-  content: "";
 }
 
 .c0 {
@@ -598,37 +507,23 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
         yoast.com
       </span>
     </p>
-    <div
+    <span
       className="c5"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c6"
-      />
-      <span
-        className="c7"
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        YoastCon Workshops
-      </span>
-    </div>
-    <div
-      className="c5"
+      YoastCon Workshops
+    </span>
+    <p
+      className="c6"
+      mode={null}
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c6"
-      />
-      <p
-        className="c8"
-        mode={null}
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        Description to go along with a portrait image.
-      </p>
-    </div>
+      Description to go along with a portrait image.
+    </p>
   </div>
 </div>
 `;
@@ -681,7 +576,7 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c5 {
   line-height: 20px;
   min-height: 20px;
   color: #1d2129;
@@ -704,7 +599,7 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
   overflow: hidden;
 }
 
-.c8 {
+.c6 {
   line-height: 16px;
   min-height: 16px;
   color: #606770;
@@ -713,31 +608,10 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
   text-overflow: ellipsis;
   margin: 3px 0 0 0;
   display: -webkit-box;
+  cursor: pointer;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
-}
-
-.c5 {
-  position: relative;
-}
-
-.c6 {
-  display: none;
-}
-
-.c6::before {
-  position: absolute;
-  top: -2px;
-  left: -35px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  color: #ccc;
-  background-size: 24px;
-  background-repeat: no-repeat;
-  background-position: center;
-  content: "";
 }
 
 .c0 {
@@ -809,37 +683,23 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
         yoast.com
       </span>
     </p>
-    <div
+    <span
       className="c5"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c6"
-      />
-      <span
-        className="c7"
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        YoastCon Workshops
-      </span>
-    </div>
-    <div
-      className="c5"
+      YoastCon Workshops
+    </span>
+    <p
+      className="c6"
+      mode={null}
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c6"
-      />
-      <p
-        className="c8"
-        mode={null}
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        Description to go along with a square image.
-      </p>
-    </div>
+      Description to go along with a square image.
+    </p>
   </div>
 </div>
 `;
@@ -892,7 +752,7 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
   align-items: center;
 }
 
-.c7 {
+.c5 {
   line-height: 20px;
   min-height: 20px;
   color: #1d2129;
@@ -915,7 +775,7 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
   overflow: hidden;
 }
 
-.c8 {
+.c6 {
   line-height: 16px;
   min-height: 16px;
   color: #606770;
@@ -924,31 +784,10 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
   text-overflow: ellipsis;
   margin: 3px 0 0 0;
   display: -webkit-box;
+  cursor: pointer;
   -webkit-line-clamp: 1;
   -webkit-box-orient: vertical;
   overflow: hidden;
-}
-
-.c5 {
-  position: relative;
-}
-
-.c6 {
-  display: none;
-}
-
-.c6::before {
-  position: absolute;
-  top: -2px;
-  left: -35px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  color: #ccc;
-  background-size: 24px;
-  background-repeat: no-repeat;
-  background-position: center;
-  content: "";
 }
 
 .c0 {
@@ -1020,37 +859,23 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
         yoast.com
       </span>
     </p>
-    <div
+    <span
       className="c5"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c6"
-      />
-      <span
-        className="c7"
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        YoastCon Workshops
-      </span>
-    </div>
-    <div
-      className="c5"
+      YoastCon Workshops
+    </span>
+    <p
+      className="c6"
+      mode={null}
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c6"
-      />
-      <p
-        className="c8"
-        mode={null}
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        Description to go along with too small an image.
-      </p>
-    </div>
+      Description to go along with too small an image.
+    </p>
   </div>
 </div>
 `;

--- a/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookTitleTest.js.snap
+++ b/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookTitleTest.js.snap
@@ -2,11 +2,12 @@
 
 exports[`FacebookTitle matches the snapshot by default 1`] = `
 .c0 {
+  line-height: 20px;
+  min-height: 20px;
   color: #1d2129;
   font-weight: 600;
   overflow: hidden;
   font-size: 16px;
-  line-height: 20px;
   margin: 0;
   -webkit-letter-spacing: normal;
   -moz-letter-spacing: normal;
@@ -25,7 +26,6 @@ exports[`FacebookTitle matches the snapshot by default 1`] = `
 
 <span
   className="c0"
->
-  YoastCon Workshops
-</span>
+  title="YoastCon Workshops"
+/>
 `;

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterDescriptionTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterDescriptionTest.js.snap
@@ -3,6 +3,7 @@
 exports[`TwitterDescription matches the snapshot for the summary card 1`] = `
 .c0 {
   max-height: 55px;
+  min-height: 20px;
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0 0 2px;
@@ -14,14 +15,13 @@ exports[`TwitterDescription matches the snapshot for the summary card 1`] = `
 
 <p
   className="c0"
->
-  A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description.
-</p>
+/>
 `;
 
 exports[`TwitterDescription matches the snapshot for the summary with large image card 1`] = `
 .c0 {
   max-height: 55px;
+  min-height: 20px;
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0 0 2px;
@@ -33,7 +33,5 @@ exports[`TwitterDescription matches the snapshot for the summary with large imag
 
 <p
   className="c0"
->
-  A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description. A very long description.
-</p>
+/>
 `;

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterDescriptionTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterDescriptionTest.js.snap
@@ -9,6 +9,7 @@ exports[`TwitterDescription matches the snapshot for the summary card 1`] = `
   margin: 0 0 2px;
   color: rgb(101,119,134);
   display: -webkit-box;
+  cursor: pointer;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }
@@ -27,6 +28,7 @@ exports[`TwitterDescription matches the snapshot for the summary with large imag
   margin: 0 0 2px;
   color: rgb(101,119,134);
   display: -webkit-box;
+  cursor: pointer;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterImageTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterImageTest.js.snap
@@ -11,6 +11,7 @@ exports[`TwitterImage Component matches the snapshot for a landscape image in a 
   flex-shrink: 0;
   width: 125px;
   border-right: 1px solid #E1E8ED;
+  border-radius: 14px 0 0 14px;
 }
 
 .c1 {
@@ -26,6 +27,9 @@ exports[`TwitterImage Component matches the snapshot for a landscape image in a 
 
 <div
   className="c0"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <img
     alt=""
@@ -47,6 +51,7 @@ exports[`TwitterImage Component matches the snapshot for a landscape image in a 
   height: 265px;
   width: 506px;
   border-bottom: 1px solid #E1E8ED;
+  border-radius: 14px 14px 0 0;
 }
 
 .c1 {
@@ -62,6 +67,9 @@ exports[`TwitterImage Component matches the snapshot for a landscape image in a 
 
 <div
   className="c0"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <img
     alt=""
@@ -82,6 +90,7 @@ exports[`TwitterImage Component matches the snapshot for a square image in a sum
   flex-shrink: 0;
   width: 125px;
   border-right: 1px solid #E1E8ED;
+  border-radius: 14px 0 0 14px;
 }
 
 .c1 {
@@ -97,6 +106,9 @@ exports[`TwitterImage Component matches the snapshot for a square image in a sum
 
 <div
   className="c0"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <img
     alt=""
@@ -118,6 +130,7 @@ exports[`TwitterImage Component matches the snapshot for a square image in a sum
   height: 265px;
   width: 506px;
   border-bottom: 1px solid #E1E8ED;
+  border-radius: 14px 14px 0 0;
 }
 
 .c1 {
@@ -133,6 +146,9 @@ exports[`TwitterImage Component matches the snapshot for a square image in a sum
 
 <div
   className="c0"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   <img
     alt=""
@@ -164,6 +180,7 @@ exports[`TwitterImage Component matches the snapshot in the loading state 1`] = 
   font-size: 1rem;
   height: 265px;
   width: 506px;
+  border-radius: 14px 14px 0 0;
   border-top-left-radius: 14px;
   border-top-right-radius: 14px;
   border-style: dashed;
@@ -174,6 +191,9 @@ exports[`TwitterImage Component matches the snapshot in the loading state 1`] = 
 
 <div
   className="c0"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
 >
   Select image
 </div>

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TwitterPreview matches the snapshot 1`] = `
-.c7 {
+.c5 {
   text-transform: lowercase;
   color: #8899a6;
   white-space: nowrap;
@@ -22,7 +22,7 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   align-items: flex-end;
 }
 
-.c8 {
+.c6 {
   height: 1.25em;
   max-width: 100%;
   margin-right: 2px;
@@ -78,7 +78,7 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   min-width: 0px;
 }
 
-.c5 {
+.c3 {
   line-height: 18px;
   min-height: 18px;
   white-space: nowrap;
@@ -87,9 +87,10 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   margin-top: 0;
   margin-bottom: 2px;
   color: rgb(20,23,26);
+  cursor: pointer;
 }
 
-.c6 {
+.c4 {
   max-height: 55px;
   min-height: 20px;
   overflow: hidden;
@@ -97,30 +98,9 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   margin: 0 0 2px;
   color: rgb(101,119,134);
   display: -webkit-box;
+  cursor: pointer;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
-}
-
-.c3 {
-  position: relative;
-}
-
-.c4 {
-  display: none;
-}
-
-.c4::before {
-  position: absolute;
-  top: -2px;
-  left: -35px;
-  width: 24px;
-  height: 24px;
-  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
-  color: #ccc;
-  background-size: 24px;
-  background-repeat: no-repeat;
-  background-position: center;
-  content: "";
 }
 
 .c0 {
@@ -164,41 +144,27 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   <div
     className="c2"
   >
-    <div
+    <p
       className="c3"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c4"
-      />
-      <p
-        className="c5"
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        YoastCon Workshops • Yoast
-      </p>
-    </div>
-    <div
-      className="c3"
+      YoastCon Workshops • Yoast
+    </p>
+    <p
+      className="c4"
+      onClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
     >
-      <div
-        className="c4"
-      />
-      <p
-        className="c6"
-        onClick={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-      >
-        
-      </p>
-    </div>
+      
+    </p>
     <div
-      className="c7"
+      className="c5"
     >
       <svg
-        className="c8"
+        className="c6"
         viewBox="0 0 24 24"
       >
         <g>

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
@@ -1,28 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TwitterPreview matches the snapshot 1`] = `
-.c3 {
-  line-height: 18px;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin-top: 0;
-  margin-bottom: 2px;
-  color: rgb(20,23,26);
-}
-
-.c4 {
-  max-height: 55px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin: 0 0 2px;
-  color: rgb(101,119,134);
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-}
-
-.c5 {
+.c7 {
   text-transform: lowercase;
   color: #8899a6;
   white-space: nowrap;
@@ -43,7 +22,7 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   align-items: flex-end;
 }
 
-.c6 {
+.c8 {
   height: 1.25em;
   max-width: 100%;
   margin-right: 2px;
@@ -69,6 +48,7 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   text-align: center;
   font-size: 1rem;
   width: 125px;
+  border-radius: 14px 0 0 14px;
   border-top-left-radius: 14px;
   border-bottom-left-radius: 14px;
   border-style: dashed;
@@ -98,18 +78,62 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   min-width: 0px;
 }
 
+.c5 {
+  line-height: 18px;
+  min-height: 18px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-top: 0;
+  margin-bottom: 2px;
+  color: rgb(20,23,26);
+}
+
+.c6 {
+  max-height: 55px;
+  min-height: 20px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0 0 2px;
+  color: rgb(101,119,134);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.c3 {
+  position: relative;
+}
+
+.c4 {
+  display: none;
+}
+
+.c4::before {
+  position: absolute;
+  top: -2px;
+  left: -35px;
+  width: 24px;
+  height: 24px;
+  background-image: url( data:image/svg+xml;charset=utf8,%3Csvg%20width%3D%221792%22%20height%3D%221792%22%20viewBox%3D%220%200%201792%201792%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20fill%3D%22%23ccc%22%20d%3D%22M1152%20896q0%2026-19%2045l-448%20448q-19%2019-45%2019t-45-19-19-45v-896q0-26%2019-45t45-19%2045%2019l448%20448q19%2019%2019%2045z%22%20%2F%3E%3C%2Fsvg%3E );
+  color: #ccc;
+  background-size: 24px;
+  background-repeat: no-repeat;
+  background-position: center;
+  content: "";
+}
+
 .c0 {
   font-family: system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Ubuntu,"Helvetica Neue",sans-serif;
   font-size: 15px;
   font-weight: 400;
   line-height: 20px;
   width: 507px;
-  border-radius: 14px;
   border: 1px solid #E1E8ED;
   box-sizing: border-box;
+  border-radius: 14px;
   color: #292F33;
   background: #FFFFFF;
-  overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
   display: -webkit-flex;
@@ -131,27 +155,50 @@ exports[`TwitterPreview matches the snapshot 1`] = `
 >
   <div
     className="c1"
+    onClick={[Function]}
+    onMouseEnter={[Function]}
+    onMouseLeave={[Function]}
   >
     Select image
   </div>
   <div
     className="c2"
   >
-    <p
+    <div
       className="c3"
     >
-      YoastCon Workshops • Yoast
-    </p>
-    <p
-      className="c4"
-    >
-      
-    </p>
+      <div
+        className="c4"
+      />
+      <p
+        className="c5"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        YoastCon Workshops • Yoast
+      </p>
+    </div>
     <div
-      className="c5"
+      className="c3"
+    >
+      <div
+        className="c4"
+      />
+      <p
+        className="c6"
+        onClick={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+      >
+        
+      </p>
+    </div>
+    <div
+      className="c7"
     >
       <svg
-        className="c6"
+        className="c8"
         viewBox="0 0 24 24"
       >
         <g>

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterTitleTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterTitleTest.js.snap
@@ -10,6 +10,7 @@ exports[`TwitterTitle matches the snapshot by default 1`] = `
   margin-top: 0;
   margin-bottom: 2px;
   color: rgb(20,23,26);
+  cursor: pointer;
 }
 
 <p

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterTitleTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterTitleTest.js.snap
@@ -3,6 +3,7 @@
 exports[`TwitterTitle matches the snapshot by default 1`] = `
 .c0 {
   line-height: 18px;
+  min-height: 18px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -13,7 +14,6 @@ exports[`TwitterTitle matches the snapshot by default 1`] = `
 
 <p
   className="c0"
->
-  My Twitter Title
-</p>
+  title="My Twitter Title"
+/>
 `;

--- a/packages/style-guide/src/helpers.js
+++ b/packages/style-guide/src/helpers.js
@@ -88,7 +88,7 @@ export const withCaretStyles = Component => {
 			${ getDirectionalStyle( "left", "right" ) }: -25px;
 			width: 24px;
 			height: 24px;
-			background-image: url( ${getBackgroundImage} );
+			background-image: url( ${ getBackgroundImage } );
 			background-size: 25px;
 			content: "";
 		}


### PR DESCRIPTION
Also check Yoast/wordpress-seo-premium#2736

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [social-metadata-previews] Adds a SocialPreviewEditor component, which combines a SocialPreview with the fields to edit it.

## Relevant technical choices:

* The Caret styles are implemented in different components in different ways. @Xyfi and I have tried extracting the logic in this PR, but the rabbit-hole ran too deep. We will refactor once there is time for technical debt issues.
* Image updating is fixed in a different PR.
* Carets have been removed from the Social Previews, are now only on forms.
* Hover and "click to focus" functionality remains in both previews and forms.
* Already placed in Premium in https://github.com/Yoast/wordpress-seo-premium/pull/2736 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Build the monorepo components app, and verify that the components on the `Social Preview` tab work as intended. (hovering, carets, etc).
* Checkout premium branch `533-social-preview-editor` https://github.com/Yoast/wordpress-seo-premium/pull/2736, where we've placed the editor in its fill.
* `yarn link-monorepo` in the root.
* Because `link-monorepo` does not work in the premium folder, you have to do this the old fashioned way:
	* in the `wordpress-seo-premium/premium` folder, run the following:
		`yarn link "@yoast/social-metadata-previews"`
		`yarn link "@yoast/social-metadata-forms"`
* Now, build everything. In the root you can build or run de dev-server, in the premium folder you'll have to `grunt build`.
* When all is done, check the premium plugin in your browser. Edit a post, go to the social react tab, verify that it works as expected (except for the image setting, fixed in different PR).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #533 
