### PR TITLE
Export the help-icon.css from the index

### DIFF
--- a/packages/components/src/help-icon/index.js
+++ b/packages/components/src/help-icon/index.js
@@ -1,0 +1,1 @@
+import "./help-icon.css";

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -10,6 +10,7 @@ export * from "./field-group";
 export * from "./inputs";
 export * from "./radiobutton";
 export * from "./select";
+export * from "./help-icon";
 
 // Referenced index.js explicitly due to case-sensitive path conflicts.
 export * from "./toggle/index.js";

--- a/packages/helpers/src/index.js
+++ b/packages/helpers/src/index.js
@@ -17,3 +17,5 @@ export {
 };
 
 export { makeOutboundLink } from "./makeOutboundLink";
+
+export * from "./hiddenInputHelper";

--- a/packages/helpers/src/index.js
+++ b/packages/helpers/src/index.js
@@ -17,5 +17,3 @@ export {
 };
 
 export { makeOutboundLink } from "./makeOutboundLink";
-
-export * from "./hiddenInputHelper";


### PR DESCRIPTION
This ensures that the styles can be used in the plugin

## Summary
Exports the styles for `HelpIcon` from the index of `@yoast/components`.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoast-components] Fixes a bug where loading the styles from the monorepo would not include styles for the `HelpIcon`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
1. Checkout the `develop` branch of the monorepo
1. Include a component that uses the `HelpIcon` component in the plugin. For example `TextInput`.
2. Build the plugin and check the output, the `HelpIcon` should either be:
	- Not visible, which seemed to be the case on Chrome
	- Super large, which seemed to be the case on FireFox
3. Checkout this PR
4. Build the plugin and check the output, the `HelpIcon` should be 12x12px.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes N/A
