### PR TITLE
Improve hungarian transition word

### DIFF
--- a/packages/yoastseo/spec/researches/findTransitionWordsSpec.js
+++ b/packages/yoastseo/spec/researches/findTransitionWordsSpec.js
@@ -407,9 +407,23 @@ describe( "a test for finding transition words from a string", function() {
 		expect( result.totalSentences ).toBe( 1 );
 		expect( result.transitionWordSentences ).toBe( 1 );
 	} );
+	it( "returns 1 when a transition word is found in a sentence (Hungarian)", function() {
+		// Transition word: például
+		mockPaper = new Paper( "például növekedési arány és szaporodásbiológia szempontjából.", { locale: "hu_HU" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
 	it( "returns 1 when a two-part transition word is found in a sentence (Hungarian)", function() {
 		// Transition word: ahogy, akkor
 		mockPaper = new Paper( "Csak később, ahogy felnőttem, akkor kezdődött a sok baj.", { locale: "hu_HU" } );
+		result = transitionWordsResearch( mockPaper );
+		expect( result.totalSentences ).toBe( 1 );
+		expect( result.transitionWordSentences ).toBe( 1 );
+	} );
+	it( "returns 1 when a multiple transition word is found in a sentence (Hungarian)", function() {
+		// Transition word: azzal a feltétellel, hogy
+		mockPaper = new Paper( "Azzal a feltétellel, hogy én forgathatom a kést.", { locale: "hu_HU" } );
 		result = transitionWordsResearch( mockPaper );
 		expect( result.totalSentences ).toBe( 1 );
 		expect( result.transitionWordSentences ).toBe( 1 );

--- a/packages/yoastseo/src/researches/hungarian/transitionWords.js
+++ b/packages/yoastseo/src/researches/hungarian/transitionWords.js
@@ -16,16 +16,20 @@ const singleWords = [ "ahányszor", "ahelyett", "ahelyt", "ahogy", "ahol", "ahon
 	"sőt", "szintén", "tehát", "továbbá", "tudniillik", "úgy", "ugyan", "ugyanis", "úgyhogy", "vagy", "vagyis",
 	"valamennyi", "valamint", "valóban", "végezetül", "végül", "végülis", "viszont" ];
 
-const multipleWords =  [ "abba hogy", "abban hogy", "abból hogy", "addig amíg", "addig hogy", "addig míg", "afelé hogy",
-	"ahelyett hogy", "ahhoz hogy", "akként hogy", "akkorra hogy", "amiatt hogy", "amellett hogy", "amint csak",
-	"anélkül hogy", "annak okáért", "annyi hogy", "annyi mint", "annyira hogy", "annyira mint", "arra hogy",
-	"arra hogy", "arról hogy", "attól fogva hogy", "attól hogy", "avégett hogy", "avégre hogy", "az ellen hogy",
-	"az iránt hogy", "azelőtt hogy", "azért hogy", "azért hogy", "azok után", "azon hogy", "azonkívül hogy",
-	"azóta hogy", "aztán pedig", "azután hogy", "azzal hogy", "ennek folytán", "ha csak", "ha egyébként", "ha egyszer",
-	"ha egyszer", "ha is", "ha különben", "ha ugyan", "hogy sem", "hogy sem mint", "hol hol", "holott pedig",
-	"igaz hogy", "így tehát", "még akkor is", "még ha", "mert különben", "mert tény hogy", "mind mind", "mindenek előtt",
-	"mindezek után", "mint sem", "mint sem hogy", "nem úgy mint", "oda hogy", "oly módon hogy", "sem hogy", "tény hogy",
-	"úgy hogy", "úgy mint" ];
+const multipleWords =  [ "a továbbiakban", "abba hogy", "abban hogy", "abból hogy", "addig amíg", "addig hogy", "addig míg", "afelé hogy",
+	"ahelyett hogy", "ahhoz hogy", "ahogy fent látható", "ahogy írtam", "ahogy megmutattam", "ahogy megjegyeztem", "akként hogy",
+	"akkorra hogy", "amiatt hogy", "amellett hogy", "amint azt megjegyeztük", "amint csak", "amint láthatjuk", "anélkül hogy",
+	"annak érdekében, hogy", "annak okáért", "annyi hogy", "annyi mint", "annyira hogy", "annyira mint", "arra hogy", "arra hogy",
+	"arról hogy", "attól fogva hogy", "attól hogy", "avégett hogy", "avégre hogy", "az ellen hogy", "az első dolog",
+	"az első dolog, amit meg kell jegyezni", "az iránt hogy", "azelőtt hogy", "azért hogy", "azért hogy", "azonos módon",
+	"azok után", "azon hogy", "azonkívül hogy", "azóta hogy", "azt követően", "aztán pedig", "azután hogy", "azzal a feltétellel, hogy",
+	"azzal hogy", "bár igaz lehet", "ebből a célból", "ebből az okból", "előbb vagy utóbb", "ennek eredményeként", "ennek folytán",
+	"ennek megfelelően", "éppen ellenkezőleg", "éppen úgy", "erre a célra", "ezen felül", "fenntartás nélkül", "ha csak",
+	"ha egyébként", "ha egyszer", "ha egyszer", "ha is", "ha különben", "ha ugyan", "hasonló módon", "hogy sem", "hogy sem mint", "hol hol",
+	"holott pedig", "időről időre", "igaz hogy", "így tehát", "ilyen körülmények között", "késedelem nélkül", "kétség nélkül",
+	"más szóval", "más szavakkal", "másképpen fogalmazva", "még akkor is", "még ha", "mert különben", "mert tény hogy", "mind mind",
+	"mindaddig, amíg", "mindenek előtt", "mindezek után", "mint sem", "mint sem hogy", "nem is beszélve", "nem különben", "nem úgy mint", "oda hogy",
+	"oly módon hogy", "sem hogy", "szem előtt tartva", "tény hogy", "úgy hogy", "úgy mint", "ugyanazon okból", "ugyanolyan okból" ];
 
 /**
  * Returns an list with transition words to be used by the assessments.

--- a/packages/yoastseo/src/researches/hungarian/transitionWords.js
+++ b/packages/yoastseo/src/researches/hungarian/transitionWords.js
@@ -8,11 +8,11 @@ const singleWords = [ "ahányszor", "ahelyett", "ahelyt", "ahogy", "ahol", "ahon
 	"és", "eszerint", "ezért", "feltétlenül", "főként", "főleg", "ha", "habár", "hanem", "hányszor", "harmadjára",
 	"hasonlóképpen", "hát", "hirtelen", "hirtelenjében", "hiszen", "hogy", "hogyha", "hol", "holott", "honnan",
 	"hová", "így", "illetőleg", "illetve", "immár", "is", "jóllehet", "kár", "kétségtelenül", "kiváltképp",
-	"következésképpen", "maga", "máskülönben", "másodsorban", "meg", "mégis", "megkérdőjelezhetetlenül",
+	"következésképpen", "legfőképp", "maga", "máskülönben", "másodsorban", "meg", "mégis", "megkérdőjelezhetetlenül",
 	"megkérdőjelezhetően", "mégpedig", "mégsem", "mennél", "mennyiszer", "merre", "mert", "merthogy", "midőn",
-	"mielőtt", "míg", "mihelyt", "miként", "miképp", "mikor", "mikorra", "mindamellett", "mindazáltal", "mindazonáltal",
+	"mielőtt", "míg", "mihelyt", "miként", "miképp", "mikor", "mikorra", "mindamellett", "mindazáltal", "mindazonáltal", "mindenekelőtt",
 	"minél", "mint", "mintha", "minthogy", "mióta", "mire", "miután", "mivel", "mivelhogy", "nahát", "nehogy", "noha",
-	"nos", "óh", "összehasonlításképp", "összehasonlításképpen", "pedig", "plusz", "s", "sajna", "satöbbi", "se", "sem",
+	"nos", "óh", "összehasonlításképp", "összehasonlításképpen", "pedig", "például", "plusz", "s", "sajna", "satöbbi", "se", "sem",
 	"sőt", "szintén", "tehát", "továbbá", "tudniillik", "úgy", "ugyan", "ugyanis", "úgyhogy", "vagy", "vagyis",
 	"valamennyi", "valamint", "valóban", "végezetül", "végül", "végülis", "viszont" ];
 

--- a/packages/yoastseo/src/researches/hungarian/transitionWords.js
+++ b/packages/yoastseo/src/researches/hungarian/transitionWords.js
@@ -3,19 +3,20 @@
 const singleWords = [ "ahányszor", "ahelyett", "ahelyt", "ahogy", "ahol", "ahonnan", "ahová", "akár", "akárcsak",
 	"akkor", "alapvetően", "alighogy", "ám", "ámbár", "ámde", "ameddig", "amennyiben", "amennyire", "amennyiszer",
 	"amíg", "amikor", "amikorra", "aminthogy", "amióta", "amire", "annálfogva", "annyira", "avagy", "azaz", "azazhogy",
-	"azért", "azonban", "azután", "bár", "bizony", "csakhogy", "de", "dehát", "dehogy", "egybehangzóan", "egyöntetűen",
-	"egyöntetűleg", "ekképpen", "ellenben", "előzőleg", "elsősorban", "ennélfogva", "eredményeképp", "eredményeképpen",
-	"és", "eszerint", "ezért", "feltétlenül", "főként", "főleg", "ha", "habár", "hanem", "hányszor", "harmadjára",
-	"hasonlóképpen", "hát", "hirtelen", "hirtelenjében", "hiszen", "hogy", "hogyha", "hol", "holott", "honnan",
-	"hová", "így", "illetőleg", "illetve", "immár", "is", "jóllehet", "kár", "kétségtelenül", "kiváltképp",
-	"következésképpen", "legfőképp", "maga", "máskülönben", "másodsorban", "meg", "mégis", "megkérdőjelezhetetlenül",
+	"azért", "azonban", "azonkívül", "azután", "bár", "befejezésül", "bizony", "csakhogy", "de", "dehát", "dehogy", "egybehangzóan", "egyidejűleg",
+	"egyöntetűen", "egyöntetűleg", "ekképpen", "ellenben", "először", "előzőleg", "elsősorban", "ennélfogva", "eredményeképp", "eredményeképpen",
+	"és", "eszerint", "ezért", "feltétlenül", "főként", "főleg", "függetlenül", "ha", "habár", "hanem", "hányszor", "harmadjára", "harmadszor",
+	"hasonlóan", "hasonlóképpen", "hát", "hirtelen", "hirtelenjében", "hiszen", "hogy", "hogyha", "hol", "holott", "honnan",
+	"hová", "így", "illetőleg", "illetve", "immár", "is", "jóllehet", "kár", "kétségtelenül", "kifejezetten", "kiváltképp",
+	"következésképpen", "legalábbis", "legfőképp", "maga", "máskülönben", "másodsorban", "másodszor", "meg", "mégis", "megkérdőjelezhetetlenül",
 	"megkérdőjelezhetően", "mégpedig", "mégsem", "mennél", "mennyiszer", "merre", "mert", "merthogy", "midőn",
 	"mielőtt", "míg", "mihelyt", "miként", "miképp", "mikor", "mikorra", "mindamellett", "mindazáltal", "mindazonáltal", "mindenekelőtt",
 	"minél", "mint", "mintha", "minthogy", "mióta", "mire", "miután", "mivel", "mivelhogy", "nahát", "nehogy", "noha",
-	"nos", "óh", "összehasonlításképp", "összehasonlításképpen", "pedig", "például", "plusz", "s", "sajna", "satöbbi", "se", "sem",
-	"sőt", "szintén", "tehát", "továbbá", "tudniillik", "úgy", "ugyan", "ugyanis", "úgyhogy", "vagy", "vagyis",
-	"valamennyi", "valamint", "valóban", "végezetül", "végül", "végülis", "viszont" ];
+	"nos", "nyilvánvalóan", "óh", "összefoglalva", "összehasonlításképp", "összehasonlításképpen", "pedig", "például", "plusz", "s", "sajna",
+	"satöbbi", "se", "sem", "sőt", "szintén", "tagadhatatlanul", "tehát", "továbbá", "tudniillik", "úgy", "ugyan", "ugyanis",
+	"úgyhogy", "vagy", "vagyis", "valamennyi", "valamint", "valóban", "végezetül", "végül", "végülis", "viszont" ];
 
+<<<<<<< HEAD
 const multipleWords =  [ "a továbbiakban", "abba hogy", "abban hogy", "abból hogy", "addig amíg", "addig hogy", "addig míg", "afelé hogy",
 	"ahelyett hogy", "ahhoz hogy", "ahogy fent látható", "ahogy írtam", "ahogy megmutattam", "ahogy megjegyeztem", "akként hogy",
 	"akkorra hogy", "amiatt hogy", "amellett hogy", "amint azt megjegyeztük", "amint csak", "amint láthatjuk", "anélkül hogy",
@@ -30,6 +31,18 @@ const multipleWords =  [ "a továbbiakban", "abba hogy", "abban hogy", "abból h
 	"más szóval", "más szavakkal", "másképpen fogalmazva", "még akkor is", "még ha", "mert különben", "mert tény hogy", "mind mind",
 	"mindaddig, amíg", "mindenek előtt", "mindezek után", "mint sem", "mint sem hogy", "nem is beszélve", "nem különben", "nem úgy mint", "oda hogy",
 	"oly módon hogy", "sem hogy", "szem előtt tartva", "tény hogy", "úgy hogy", "úgy mint", "ugyanazon okból", "ugyanolyan okból" ];
+=======
+const multipleWords =  [ "abba hogy", "abban hogy", "abból hogy", "addig amíg", "addig hogy", "addig míg", "afelé hogy",
+	"ahelyett hogy", "ahhoz hogy", "akként hogy", "akkorra hogy", "amiatt hogy", "amellett hogy", "amint csak",
+	"anélkül hogy", "annak okáért", "annyi hogy", "annyi mint", "annyira hogy", "annyira mint", "arra hogy",
+	"arra hogy", "arról hogy", "attól fogva hogy", "attól hogy", "avégett hogy", "avégre hogy", "az ellen hogy",
+	"az iránt hogy", "azelőtt hogy", "azért hogy", "azért hogy", "azok után", "azon hogy", "azonkívül hogy",
+	"azóta hogy", "aztán pedig", "azután hogy", "azzal a feltétellel, hogy", "azzal hogy", "ennek folytán", "ha csak", "ha egyébként", "ha egyszer",
+	"ha egyszer", "ha is", "ha különben", "ha ugyan", "hogy sem", "hogy sem mint", "hol hol", "holott pedig",
+	"igaz hogy", "így tehát", "még akkor is", "még ha", "mert különben", "mert tény hogy", "mind mind", "mindenek előtt",
+	"mindezek után", "mint sem", "mint sem hogy", "nem úgy mint", "oda hogy", "oly módon hogy", "sem hogy", "tény hogy",
+	"úgy hogy", "úgy mint" ];
+>>>>>>> 8c709fc05bb902406812fae1ba8fcc12b306a46f
 
 /**
  * Returns an list with transition words to be used by the assessments.

--- a/packages/yoastseo/src/researches/hungarian/transitionWords.js
+++ b/packages/yoastseo/src/researches/hungarian/transitionWords.js
@@ -16,7 +16,7 @@ const singleWords = [ "ahányszor", "ahelyett", "ahelyt", "ahogy", "ahol", "ahon
 	"satöbbi", "se", "sem", "sőt", "szintén", "tagadhatatlanul", "tehát", "továbbá", "tudniillik", "úgy", "ugyan", "ugyanis",
 	"úgyhogy", "vagy", "vagyis", "valamennyi", "valamint", "valóban", "végezetül", "végül", "végülis", "viszont" ];
 
-<<<<<<< HEAD
+
 const multipleWords =  [ "a továbbiakban", "abba hogy", "abban hogy", "abból hogy", "addig amíg", "addig hogy", "addig míg", "afelé hogy",
 	"ahelyett hogy", "ahhoz hogy", "ahogy fent látható", "ahogy írtam", "ahogy megmutattam", "ahogy megjegyeztem", "akként hogy",
 	"akkorra hogy", "amiatt hogy", "amellett hogy", "amint azt megjegyeztük", "amint csak", "amint láthatjuk", "anélkül hogy",
@@ -31,18 +31,6 @@ const multipleWords =  [ "a továbbiakban", "abba hogy", "abban hogy", "abból h
 	"más szóval", "más szavakkal", "másképpen fogalmazva", "még akkor is", "még ha", "mert különben", "mert tény hogy", "mind mind",
 	"mindaddig, amíg", "mindenek előtt", "mindezek után", "mint sem", "mint sem hogy", "nem is beszélve", "nem különben", "nem úgy mint", "oda hogy",
 	"oly módon hogy", "sem hogy", "szem előtt tartva", "tény hogy", "úgy hogy", "úgy mint", "ugyanazon okból", "ugyanolyan okból" ];
-=======
-const multipleWords =  [ "abba hogy", "abban hogy", "abból hogy", "addig amíg", "addig hogy", "addig míg", "afelé hogy",
-	"ahelyett hogy", "ahhoz hogy", "akként hogy", "akkorra hogy", "amiatt hogy", "amellett hogy", "amint csak",
-	"anélkül hogy", "annak okáért", "annyi hogy", "annyi mint", "annyira hogy", "annyira mint", "arra hogy",
-	"arra hogy", "arról hogy", "attól fogva hogy", "attól hogy", "avégett hogy", "avégre hogy", "az ellen hogy",
-	"az iránt hogy", "azelőtt hogy", "azért hogy", "azért hogy", "azok után", "azon hogy", "azonkívül hogy",
-	"azóta hogy", "aztán pedig", "azután hogy", "azzal a feltétellel, hogy", "azzal hogy", "ennek folytán", "ha csak", "ha egyébként", "ha egyszer",
-	"ha egyszer", "ha is", "ha különben", "ha ugyan", "hogy sem", "hogy sem mint", "hol hol", "holott pedig",
-	"igaz hogy", "így tehát", "még akkor is", "még ha", "mert különben", "mert tény hogy", "mind mind", "mindenek előtt",
-	"mindezek után", "mint sem", "mint sem hogy", "nem úgy mint", "oda hogy", "oly módon hogy", "sem hogy", "tény hogy",
-	"úgy hogy", "úgy mint" ];
->>>>>>> 8c709fc05bb902406812fae1ba8fcc12b306a46f
 
 /**
  * Returns an list with transition words to be used by the assessments.

--- a/packages/yoastseo/src/researches/hungarian/twoPartTransitionWords.js
+++ b/packages/yoastseo/src/researches/hungarian/twoPartTransitionWords.js
@@ -14,11 +14,11 @@ export default function() {
 		[ "amikor", "azalatt" ], [ "amikorra", "addigra" ], [ "amikorra", "akkorra" ], [ "amint", "akkor" ],
 		[ "amint", "azonnal" ], [ "amint", "máris" ], [ "amint", "nyomban" ], [ "amint", "tüstént" ],
 		[ "amióta", "attól kezdve" ], [ "amióta", "azóta" ], [ "amire", "addig" ], [ "amire", "addigra" ],
-		[ "azóta", "hogy" ], [ "ha", "akkor" ], [ "hogyha", "akkor" ], [ "mialatt", "azalatt" ],
+		[ "azóta", "hogy" ], [ "ha", "akkor" ], [ "hogyha", "akkor" ], [ "is", "is" ], [ "mialatt", "azalatt" ],
 		[ "mielőtt", "azelőtt" ], [ "mihelyt", "azonnal" ], [ "mihelyt", "máris" ], [ "mihelyt", "nyomban" ],
 		[ "mihelyt", "tüstént" ], [ "mikor", "akkor" ], [ "mikor", "aközben" ], [ "mikor", "azalatt" ],
 		[ "mikor", "azután" ], [ "mikorra", "addigra" ], [ "mikorra", "akkorra" ], [ "miközben", "azalatt" ],
 		[ "mióta", "attól kezdve" ], [ "mióta", "azóta" ], [ "mire", "addig" ], [ "mire", "addigra" ],
-		[ "miután", "azután" ], [ "nemcsak", "hanem" ], [ "sem", "sem" ] ];
+		[ "miután", "azután" ], [ "nemcsak", "hanem" ], [ "sem", "sem" ], [ "vagy", "vagy" ] ];
 }
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [yoastseo] Improves the transition word assessment for Hungarian.

## Test instructions

This PR can be tested by following these steps:

* Change locale to hu_HU and paste the added transition words into the text editor. Make sure they are marked as transition words.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #https://yoast.atlassian.net/browse/LIN-338
