### PR TITLE
Bump version of node-sass

### DIFF
--- a/packages/yoastseo/package.json
+++ b/packages/yoastseo/package.json
@@ -62,7 +62,7 @@
     "js-yaml": "^3.12.1",
     "load-grunt-config": "^1.0.0",
     "lodash-cli": "^4.14.1",
-    "node-sass": "^4.9.3"
+    "node-sass": "4.13.0"
   },
   "bugs": {
     "url": "https://github.com/Yoast/js-text-analysis/issues"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14023,7 +14023,7 @@ node-releases@^1.1.8:
   dependencies:
     semver "^5.3.0"
 
-"node-sass@^3.1.2, ^4.0.0", node-sass@^4.9.3:
+node-sass@4.13.0, "node-sass@^3.1.2, ^4.0.0":
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.0.tgz#b647288babdd6a1cb726de4545516b31f90da066"
   integrity sha512-W1XBrvoJ1dy7VsvTAS5q1V45lREbTlZQqFbiHb3R3OTTCma0XBtuG6xZ6Z4506nR4lmHPTqVRwxT6KgtWC97CA==


### PR DESCRIPTION
## Summary
Bumps the version of `node-sass` to `4.13.0`.

4.13.0 was the currently installed package but since the constraint was rather weak (`^4.9.3`) we ran into problems on the feature branch because `node-sass` was installed at version `4.11.0`. That version is incompatible with node `v12.16.2` which was being used on Travis.

By upping the requirements for `node-sass` to be `4.13.0`, we are fixing this problem.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:
* [yoastseo] Bump version of `node-sass` to `4.13.0`.

## Relevant technical choices:
* `4.13.0` is the same version as was currently specified in the `yarn.lock`.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes N/A
