### PR TITLE
Show HelpIcon only if link is provided to FieldGroup

### DIFF
--- a/packages/components/src/field-group/FieldGroup.js
+++ b/packages/components/src/field-group/FieldGroup.js
@@ -22,7 +22,7 @@ const FieldGroup = ( { htmlFor, label, linkTo, linkText, description, children }
 		<div className="yoast-field-group">
 			<div className="yoast-field-group__title">
 				<label htmlFor={ htmlFor }>{ label }</label>
-				{ ( !! linkTo ) && <HelpIcon
+				{ linkTo !== "" && <HelpIcon
 					linkTo={ linkTo }
 					linkText={ linkText }
 				/> }

--- a/packages/components/src/field-group/FieldGroup.js
+++ b/packages/components/src/field-group/FieldGroup.js
@@ -22,10 +22,10 @@ const FieldGroup = ( { htmlFor, label, linkTo, linkText, description, children }
 		<div className="yoast-field-group">
 			<div className="yoast-field-group__title">
 				<label htmlFor={ htmlFor }>{ label }</label>
-				<HelpIcon
+				{ ( !! linkTo ) && <HelpIcon
 					linkTo={ linkTo }
 					linkText={ linkText }
-				/>
+				/> }
 			</div>
 			{ description !== ""  && <p className="description" id="yoast_unique_description_id">{ description }</p> }
 			{ children }

--- a/packages/components/src/help-icon/HelpIcon.js
+++ b/packages/components/src/help-icon/HelpIcon.js
@@ -16,8 +16,8 @@ export const helpIconProps = {
  * Default props for the HelpIcon.
  */
 export const helpIconDefaultProps = {
-	linkTo: "https://yoast.com",
-	linkText: "Tell me what this link does",
+	linkTo: "",
+	linkText: "",
 };
 
 /**

--- a/packages/components/tests/__snapshots__/CheckboxGroupTest.js.snap
+++ b/packages/components/tests/__snapshots__/CheckboxGroupTest.js.snap
@@ -12,38 +12,6 @@ exports[`CheckboxGroup should render with only the required props 1`] = `
     >
       Nice label
     </label>
-    <a
-      className="yoast-help"
-      href="https://yoast.com"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      <span
-        className="yoast-help__icon"
-      >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          role="img"
-          viewBox="0 0 12 12"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 6A6 6 0 110 6a6 6 0 0112 0zM6.2 2C4.8 2 4 2.5 3.3 3.5l.1.4.8.7.4-.1c.5-.5.8-.9 1.4-.9.5 0 1.1.4 1.1.8s-.3.6-.7.9C5.8 5.6 5 6 5 7c0 .2.2.4.3.4h1.4L7 7c0-.8 2-.8 2-2.6C9 3 7.5 2 6.2 2zM6 8a1.1 1.1 0 100 2.2A1.1 1.1 0 006 8z"
-          />
-        </svg>
-      </span>
-      <span
-        className="screen-reader-text"
-      >
-        Tell me what this link does
-      </span>
-      <span
-        className="screen-reader-text"
-      >
-        (Opens in a new browser tab)
-      </span>
-    </a>
   </div>
   <div
     onChange={[Function]}

--- a/packages/components/tests/__snapshots__/SelectTest.js.snap
+++ b/packages/components/tests/__snapshots__/SelectTest.js.snap
@@ -12,38 +12,6 @@ exports[`Select should render a multiselect 1`] = `
     >
       Nice label
     </label>
-    <a
-      className="yoast-help"
-      href="https://yoast.com"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      <span
-        className="yoast-help__icon"
-      >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          role="img"
-          viewBox="0 0 12 12"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 6A6 6 0 110 6a6 6 0 0112 0zM6.2 2C4.8 2 4 2.5 3.3 3.5l.1.4.8.7.4-.1c.5-.5.8-.9 1.4-.9.5 0 1.1.4 1.1.8s-.3.6-.7.9C5.8 5.6 5 6 5 7c0 .2.2.4.3.4h1.4L7 7c0-.8 2-.8 2-2.6C9 3 7.5 2 6.2 2zM6 8a1.1 1.1 0 100 2.2A1.1 1.1 0 006 8z"
-          />
-        </svg>
-      </span>
-      <span
-        className="screen-reader-text"
-      >
-        Tell me what this link does
-      </span>
-      <span
-        className="screen-reader-text"
-      >
-        (Opens in a new browser tab)
-      </span>
-    </a>
   </div>
   <select
     defaultValue={Array []}
@@ -77,38 +45,6 @@ exports[`Select should render a select 1`] = `
     >
       Nice label
     </label>
-    <a
-      className="yoast-help"
-      href="https://yoast.com"
-      rel="noopener noreferrer"
-      target="_blank"
-    >
-      <span
-        className="yoast-help__icon"
-      >
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          role="img"
-          viewBox="0 0 12 12"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 6A6 6 0 110 6a6 6 0 0112 0zM6.2 2C4.8 2 4 2.5 3.3 3.5l.1.4.8.7.4-.1c.5-.5.8-.9 1.4-.9.5 0 1.1.4 1.1.8s-.3.6-.7.9C5.8 5.6 5 6 5 7c0 .2.2.4.3.4h1.4L7 7c0-.8 2-.8 2-2.6C9 3 7.5 2 6.2 2zM6 8a1.1 1.1 0 100 2.2A1.1 1.1 0 006 8z"
-          />
-        </svg>
-      </span>
-      <span
-        className="screen-reader-text"
-      >
-        Tell me what this link does
-      </span>
-      <span
-        className="screen-reader-text"
-      >
-        (Opens in a new browser tab)
-      </span>
-    </a>
   </div>
   <select
     defaultValue="hi"

--- a/packages/components/tests/inputs/TextAreaTest.js
+++ b/packages/components/tests/inputs/TextAreaTest.js
@@ -10,7 +10,6 @@ describe( "TextArea", () => {
 		const result = renderer.getRenderOutput();
 
 		expect( result ).toBeDefined();
-		expect( result.props.linkTo ).toBe( "https://yoast.com" );
 	} );
 
 	it( "should render based on provided props", () => {

--- a/packages/components/tests/inputs/TextInputTest.js
+++ b/packages/components/tests/inputs/TextInputTest.js
@@ -11,13 +11,14 @@ describe( "TextInput", () => {
 				type="text"
 				name="textInput"
 				label="Heya"
+				linkTo="linkTo"
 			/>
 		);
 
 		const result = renderer.getRenderOutput();
 
 		expect( result.props.label ).toBe( "Heya" );
-		expect( result.props.linkTo ).toBe( "https://yoast.com" );
+		expect( result.props.linkTo ).toBe( "linkTo" );
 		expect( result.props.children.props.name ).toBe( "textInput" );
 		expect( result.props.children.props.defaultValue ).toBe( "" );
 	} );
@@ -31,7 +32,6 @@ describe( "TextInput", () => {
 
 		const result = renderer.getRenderOutput();
 
-		expect( result.props.linkTo ).toBe( "https://yoast.com" );
 		expect( result.props.children.props.name ).toBe( "" );
 		expect( result.props.children.props.type ).toBe( "text" );
 		expect( result.props.children.props.defaultValue ).toBe( "" );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [components] The HelpIcon next to a label is now conditionally shown if a link (`linkTo`) is provided.

## Relevant technical choices:

* HelpIcon being present should depend on link being provided to the HelpIcon.
* We wanted to be able to optionally display the help icon, because some help URLs are not available (yet).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run the components app. Note that in the `reactified components` tab, some fieldgroups have a HelpIcon, an others don't.
* Verify in the app's code that the fieldgroups with HelpIcons are the ones with a `linkTo` provided.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
