### PR TITLE
Move Polish stemming data to morphology data file

### DIFF
--- a/apps/content-analysis/src/utils/getMorphologyData.js
+++ b/apps/content-analysis/src/utils/getMorphologyData.js
@@ -6,7 +6,7 @@ let morphologyData = null;
  * @returns {Object} The morphology data, or an empty object if not available.
  */
 function loadLocalMorphologyData() {
-	let data, dataDe, dataNL, dataES, dataFR = {};
+	let data, dataDe, dataNL, dataES, dataFR, dataPL = {};
 	try {
 		// Disabling global require to be able to fail.
 		// eslint-disable-next-line global-require
@@ -19,11 +19,13 @@ function loadLocalMorphologyData() {
 		dataES = require( "../../../../packages/yoastseo/premium-configuration/data/morphologyData-es-v5.json" );
 		// eslint-disable-next-line global-require
 		dataFR = require( "../../../../packages/yoastseo/premium-configuration/data/morphologyData-fr-v5.json" );
+		// eslint-disable-next-line global-require
+		dataPL = require( "../../../../packages/yoastseo/premium-configuration/data/morphologyData-pl-v6.json" );
 	} catch ( error ) {
 		// Falling back to empty data.
 	}
 
-	return merge( data, dataDe, dataNL, dataES, dataFR );
+	return merge( data, dataDe, dataNL, dataES, dataFR, dataPL );
 }
 
 /**

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper1.js
@@ -29,7 +29,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 4,
 		resultText: "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 0 times. That's less than the recommended minimum of 5 times for a text of this length." +
+			"The focus keyphrase was found 1 time. That's less than the recommended minimum of 5 times for a text of this length." +
 			" <a href='https://yoa.st/33w' target='_blank'>Focus on your keyphrase</a>!",
 	},
 	metaDescriptionKeyword: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper3.js
@@ -74,8 +74,8 @@ const expectedResults = {
 	},
 	titleKeyword: {
 		isApplicable: true,
-		score: 2,
-		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: Not all the words from your keyphrase \"Nazwa i historia Koranu\" appear in the SEO title. <a href='https://yoa.st/33h' target='_blank'>Try to use the exact match of your keyphrase in the SEO title</a>.",
+		score: 6,
+		resultText: "<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: Does not contain the exact match. <a href='https://yoa.st/33h' target='_blank'>Try to write the exact match of your keyphrase in the SEO title</a>.",
 	},
 	titleWidth: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/helpers/getLanguagesWithWordFormSupportSpec.js
+++ b/packages/yoastseo/spec/helpers/getLanguagesWithWordFormSupportSpec.js
@@ -2,6 +2,6 @@ import getLanguagesWithWordFormSupport from "../../src/helpers/getLanguagesWithW
 
 describe( "Checks which languages have morphology support in YoastSEO.js", function() {
 	it( "returns an array of languages that have morphology support", function() {
-		expect( getLanguagesWithWordFormSupport() ).toEqual( [ "en", "de", "nl", "es", "fr" ] );
+		expect( getLanguagesWithWordFormSupport() ).toEqual( [ "en", "de", "nl", "es", "fr", "pl" ] );
 	} );
 } );

--- a/packages/yoastseo/spec/morphology/polish/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/polish/stemSpec.js
@@ -1,4 +1,7 @@
 import stem from "../../../src/morphology/polish/stem";
+import getMorphologyData from "../../specHelpers/getMorphologyData";
+
+const morphologyDataPL = getMorphologyData( "pl" ).pl;
 
 const wordsToStem = [
 	// Words with diminutive suffixes
@@ -112,7 +115,7 @@ describe( "Test for stemming Polish words", () => {
 	for ( let i = 0; i < wordsToStem.length; i++ ) {
 		const wordToCheck = wordsToStem[ i ];
 		it( "stems the word " + wordToCheck[ 0 ], () => {
-			expect( stem( wordToCheck[ 0 ] ) ).toBe( wordToCheck[ 1 ] );
+			expect( stem( wordToCheck[ 0 ], morphologyDataPL ) ).toBe( wordToCheck[ 1 ] );
 		} );
 	}
 } );

--- a/packages/yoastseo/spec/morphology/polish/stemmerCoverage/calculateCoverage.js
+++ b/packages/yoastseo/spec/morphology/polish/stemmerCoverage/calculateCoverage.js
@@ -1,11 +1,14 @@
 /* eslint-disable no-console */
 import stem from "../../../../src/morphology/polish/stem";
+import getMorphologyData from "../../../specHelpers/getMorphologyData";
 import goldStandard from "./goldStandardStems.json";
+
+const morphologyDataPL = getMorphologyData( "pl" ).pl;
 
 const coverageThreshold = 0.8;
 
 describe( "Calculate coverage for the Polish stemmer", () => {
-	const stemsComparison = goldStandard.stems.map( word => [ word[ 0 ], word[ 1 ], stem( word[ 0 ] ) ] );
+	const stemsComparison = goldStandard.stems.map( word => [ word[ 0 ], word[ 1 ], stem( word[ 0 ], morphologyDataPL ) ] );
 
 	const errors = stemsComparison.filter( word => word[ 1 ] !== word[ 2 ] );
 

--- a/packages/yoastseo/spec/specHelpers/getMorphologyData.js
+++ b/packages/yoastseo/spec/specHelpers/getMorphologyData.js
@@ -3,7 +3,7 @@ import de from "../../premium-configuration/data/morphologyData-de-v5.json";
 import nl from "../../premium-configuration/data/morphologyData-nl-v5.json";
 import es from "../../premium-configuration/data/morphologyData-es-v5.json";
 import fr from "../../premium-configuration/data/morphologyData-fr-v5.json";
-
+import pl from "../../premium-configuration/data/morphologyData-pl-v6.json";
 
 const morphologyData = {
 	en,
@@ -11,6 +11,7 @@ const morphologyData = {
 	nl,
 	es,
 	fr,
+	pl,
 };
 
 /**

--- a/packages/yoastseo/src/helpers/getStemForLanguage.js
+++ b/packages/yoastseo/src/helpers/getStemForLanguage.js
@@ -3,6 +3,7 @@ import { determineStem as germanDetermineStem } from "../morphology/german/deter
 import { determineStem as dutchDetermineStem } from "../morphology/dutch/determineStem";
 import spanishDetermineStem from "../morphology/spanish/stem";
 import frenchDetermineStem from "../morphology/french/stem";
+import polishDetermineStem from "../morphology/polish/stem";
 
 /**
  * Collects all functions for determining a stem per language and returns this collection to a Researcher
@@ -16,5 +17,6 @@ export default function() {
 		nl: dutchDetermineStem,
 		es: spanishDetermineStem,
 		fr: frenchDetermineStem,
+		pl: polishDetermineStem,
 	};
 }

--- a/packages/yoastseo/src/morphology/polish/stem.js
+++ b/packages/yoastseo/src/morphology/polish/stem.js
@@ -20,167 +20,6 @@
  * SOFTWARE.
  */
 
-const diminutiveSuffixes = {
-	suffixes1: {
-		wordEndings: [ "eczek", "eczka", "eczki", "iczek", "iczka", "iczki", "iszek", "iszka", "iszki", "aszek", "aszki",
-			"aszka", "uszek", "uszka", "uszki", "aczek", "aczka", "aczki" ],
-		wordShouldBeLongerThan: 6,
-		suffixLength: 5,
-	},
-	suffixes2: {
-		wordEndings: [ "ątko", "unio", "usia" ],
-		wordShouldBeLongerThan: 6,
-		suffixLength: 4,
-	},
-	suffixes3: {
-		wordEndings: [ "enek", "enka", "enki", "enką", "ejek", "ejka", "ejki", "ejką", "erek", "erki" ],
-		wordShouldBeLongerThan: 6,
-		suffixLength: 2,
-	},
-	suffixes4: {
-		wordEndings: [ "ek", "ak", "ka", "ko", "uś" ],
-		wordShouldBeLongerThan: 4,
-		suffixLength: 2,
-	},
-};
-
-const verbSuffixes = {
-	suffixes1: {
-		wordEndings: [ "łybyście", "libyście" ],
-		wordShouldBeLongerThan: 10,
-		suffixLength: 8,
-	},
-	suffixes2: {
-		wordEndings: [ "łybyśmy", "libyśmy" ],
-		wordShouldBeLongerThan: 9,
-		suffixLength: 7,
-	},
-	suffixes3: {
-		wordEndings: [ "liście", "łyśmy", "liśmy" ],
-		wordShouldBeLongerThan: 8,
-		suffixLength: 6,
-	},
-	suffixes4: {
-		wordEndings: [ "łabym", "łabyś" ],
-		wordShouldBeLongerThan: 7,
-		suffixLength: 5,
-	},
-	suffixes5: {
-		wordEndings: [ "łyby", "liby", "łaby", "łszy", "wszy" ],
-		wordShouldBeLongerThan: 5,
-		suffixLength: 4,
-	},
-	suffixes6: {
-		wordEndings: [ "bym", "byś", "esz", "asz", "cie", "eść", "eźć", "aść", "łem", "łam", "łeś", "amy", "emy", "ała", "iła" ],
-		wordShouldBeLongerThan: 5,
-		suffixLength: 3,
-	},
-	suffixes7: {
-		wordEndings: [ "łby" ],
-		wordShouldBeLongerThan: 4,
-		suffixLength: 3,
-	},
-	suffixes8: {
-		wordEndings: [ "esz", "asz", "eść", "aść", "ać", "em", "am", "ał", "ił", "ić", "ąc", "eć" ],
-		wordShouldBeLongerThan: 3,
-		suffixLength: 2,
-	},
-	suffixes9: {
-		wordEndings: [ "aj" ],
-		wordShouldBeLongerThan: 3,
-		suffixLength: 1,
-	},
-};
-
-const nounSuffixes = {
-	suffixes1: {
-		wordEndings: [ "zacja", "zacją", "zacji" ],
-		wordShouldBeLongerThan: 7,
-		suffixLength: 4,
-	},
-	suffixes2: {
-		wordEndings: [ "acja", "acji", "acją", "tach", "anie", "enie", "eniu", "aniu" ],
-		wordShouldBeLongerThan: 6,
-		suffixLength: 4,
-	},
-	suffixes3: {
-		wordEndings: [ "tyka" ],
-		wordShouldBeLongerThan: 6,
-		suffixLength: 2,
-	},
-	suffixes4: {
-		wordEndings: [ "nia", "niu", "cia", "ciu" ],
-		wordShouldBeLongerThan: 5,
-		suffixLength: 3,
-	},
-	suffixes5: {
-		wordEndings: [ "cji", "cja", "cją", "ce", "ta" ],
-		wordShouldBeLongerThan: 5,
-		suffixLength: 2,
-	},
-	suffixes6: {
-		wordEndings: [ "ów", "om" ],
-		wordShouldBeLongerThan: 4,
-		suffixLength: 2,
-	},
-	suffixes7: {
-		wordEndings: [ "ami", "ach" ],
-		wordShouldBeLongerThan: 4,
-		suffixLength: 3,
-	},
-};
-
-const adjectiveAndAdverbSuffixes = {
-	suffixes1: {
-		wordEndings: [ "ejszych", "ejszego", "owszych", "owszego" ],
-		wordShouldBeLongerThan: 9,
-		suffixLength: 7,
-	},
-	suffixes2: {
-		wordEndings: [ "cznych", "ejszej", "owszej", "cznego" ],
-		wordShouldBeLongerThan: 8,
-		suffixLength: 6,
-	},
-	suffixes3: {
-		wordEndings: [ "szych", "ejsze", "ejszy", "ejsza", "ejszą", "owsze", "owszy", "owsza", "owszą", "cznej" ],
-		wordShouldBeLongerThan: 7,
-		suffixLength: 5,
-	},
-	suffixes4: {
-		wordEndings: [ "sze", "szy", "sza", "owy", "owa", "owe", "ych", "ego" ],
-		wordShouldBeLongerThan: 5,
-		suffixLength: 3,
-	},
-	suffixes5: {
-		wordEndings: [ "czny", "czna", "czne" ],
-		wordShouldBeLongerThan: 6,
-		suffixLength: 4,
-	},
-	suffixes6: {
-		wordEndings: [ "ej" ],
-		wordShouldBeLongerThan: 5,
-		suffixLength: 2,
-	},
-	suffixes7: {
-		wordEndings: [ "nie", "wie", "rze" ],
-		wordShouldBeLongerThan: 4,
-		suffixLength: 2,
-	},
-};
-
-const generalSuffixes = {
-	suffixes1: {
-		wordEndings: [ "ia", "ie" ],
-		wordShouldBeLongerThan: 4,
-		suffixLength: 2,
-	},
-	suffixes2: {
-		wordEndings: [ "u", "ą", "i", "a", "ę", "y", "ł" ],
-		wordShouldBeLongerThan: 4,
-		suffixLength: 1,
-	},
-};
-
 /**
  * Loops through an array of word endings and returns the longest ending that was matched at the end of the word.
  *
@@ -262,15 +101,17 @@ const findSuffixInClassAndStem = function( word, suffixClass ) {
  * Stems adjective and adverb suffixes. After stemming the suffixes, looks for the superlative prefix 'naj' and stems it
  * as well if found. For example, in 'najsilniejsze', first the 'ejsze' is stemmed and then the 'naj'.
  *
- * @param {string}  word    The word to stem.
- * @returns {string}        The word with removed adjective/adverb suffixes
+ * @param {string}  word                The word to stem.
+ * @param {Object}  morphologyData      The Polish morphology data file.
+ *
+ * @returns {string} The word with removed adjective/adverb suffixes
  */
-const stemAdjectivesAndAdverbs = function( word ) {
-	const stemmedWord = findSuffixInClassAndStem( word, adjectiveAndAdverbSuffixes );
+const stemAdjectivesAndAdverbs = function( word, morphologyData ) {
+	const stemmedWord = findSuffixInClassAndStem( word, morphologyData.externalStemmer.adjectiveAndAdverbSuffixes );
 
 	if ( stemmedWord ) {
 		// Remove superlative prefix if found
-		if ( word.startsWith( "naj" ) ) {
+		if ( word.startsWith( morphologyData.externalStemmer.superlativePrefix ) ) {
 			return stemmedWord.slice( 3 );
 		}
 		return stemmedWord;
@@ -280,10 +121,12 @@ const stemAdjectivesAndAdverbs = function( word ) {
 /**
  * Stems Polish words.
  *
- * @param {string}      word    The word to stem.
- * @returns {string}            The stemmed word.
+ * @param {string}  word                The word to stem.
+ * @param {Object}  morphologyData      The Polish morphology data file.
+ *
+ * @returns {string} The stemmed word.
  */
-export default function stem( word ) {
+export default function stem( word, morphologyData ) {
 	word.toLowerCase();
 
 	// If the word is three characters long or shorter, the stem should be the same as the word.
@@ -295,18 +138,18 @@ export default function stem( word ) {
 	 * Go through diminutive, noun, verb, and adjective stemming steps. If a suffix (and optional prefix in case of adjectives/adverbs)
 	 *  is found, delete it and stop searching further.
 	 */
-	let stemmedWord = findSuffixInClassAndStem( word, diminutiveSuffixes );
+	let stemmedWord = findSuffixInClassAndStem( word, morphologyData.externalStemmer.diminutiveSuffixes );
 
 	if ( ! stemmedWord ) {
-		stemmedWord = findSuffixInClassAndStem( word, nounSuffixes );
+		stemmedWord = findSuffixInClassAndStem( word, morphologyData.externalStemmer.nounSuffixes );
 	}
 
 	if ( ! stemmedWord ) {
-		stemmedWord = findSuffixInClassAndStem( word, verbSuffixes );
+		stemmedWord = findSuffixInClassAndStem( word, morphologyData.externalStemmer.verbSuffixes );
 	}
 
 	if ( ! stemmedWord ) {
-		stemmedWord = stemAdjectivesAndAdverbs( word );
+		stemmedWord = stemAdjectivesAndAdverbs( word, morphologyData );
 	}
 
 	// If the word was stemmed in any of the previous steps, replace the word with the stem.
@@ -315,7 +158,7 @@ export default function stem( word ) {
 	}
 
 	// Find and stem general suffixes
-	stemmedWord = findSuffixInClassAndStem( word, generalSuffixes );
+	stemmedWord = findSuffixInClassAndStem( word, morphologyData.externalStemmer.generalSuffixes );
 
 	if ( stemmedWord ) {
 		return stemmedWord;
@@ -323,5 +166,3 @@ export default function stem( word ) {
 
 	return word;
 }
-
-


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Moves the Polish stemming data to a newly created Polish morphology data file.

## Relevant technical choices:
* I also enabled support in `getLanguagesWithWordFormSupport` because that's needed to test whether the morphology data file gets properly picked up in the content analysis app.
* Enabling morphology support meant that the behavior of some unit tests that previously assumed no morphology support for Polish changed. Those were adapted to reflect the new situation.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check the unit tests
  * Run `yarn test` and make sure that all tests still pass.
  * Make sure that the coverage is still the same as before the change.
* Test in the content analysis app
  * Start the content analysis app by going to `javascript/apps/content-analysis` and run `yarn start`.
  * In the content analysis app, make sure that the locale is set to the right language and that the toggle for morphology support is switched on.
  * Add a text of at least 150 words.
  * Set a keyphrase and use various (supported) forms of that keyphrase in the text.
  * Make sure that all forms get recognized in the keyphrase density assessment (click on the eye marker next to the result and confirm that you can see all forms marked below).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-395
