### PR TITLE
Provide the correct props to the components

### DIFF
--- a/packages/social-metadata-forms/src/ImageSelect.js
+++ b/packages/social-metadata-forms/src/ImageSelect.js
@@ -92,7 +92,6 @@ const ImageSelect = ( {
 	imageSelected,
 	onRemoveImageClick,
 	imageUrl,
-	imageFallbackUrl,
 	isPremium,
 	onMouseEnter,
 	onMouseLeave,
@@ -113,7 +112,7 @@ const ImageSelect = ( {
 		{
 			isPremium ? renderButtons( onClick, imageSelected, onRemoveImageClick )
 				:	<ColumnWrapper>
-					<UrlInputField disabled={ "disabled" } value={ imageUrl || imageFallbackUrl } />
+					<UrlInputField disabled={ "disabled" } value={ imageUrl } />
 					<RowWrapper>
 						{ renderButtons( onClick, imageSelected, onRemoveImageClick ) }
 					</RowWrapper>
@@ -130,7 +129,6 @@ ImageSelect.propTypes = {
 	onRemoveImageClick: PropTypes.func,
 	warnings: PropTypes.arrayOf( PropTypes.string ),
 	imageUrl: PropTypes.string,
-	imageFallbackUrl: PropTypes.string,
 	onMouseEnter: PropTypes.func,
 	onMouseLeave: PropTypes.func,
 };
@@ -140,7 +138,6 @@ ImageSelect.defaultProps = {
 	onClick: () => {},
 	warnings: [],
 	imageUrl: "",
-	imageFallbackUrl: "",
 	onMouseEnter: () => {},
 	onMouseLeave: () => {},
 };

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -163,7 +163,6 @@ class SocialMetadataPreviewForm extends Component {
 			recommendedReplacementVariables,
 			imageWarnings,
 			imageUrl,
-			imageFallbackUrl,
 		} = this.props;
 
 		const imageSelected = !! imageUrl;
@@ -181,7 +180,6 @@ class SocialMetadataPreviewForm extends Component {
 			socialMediumName
 		);
 
-
 		return (
 			<Fragment>
 				<ImageSelectWithCaret
@@ -195,7 +193,6 @@ class SocialMetadataPreviewForm extends Component {
 					isActive={ activeField === "image" }
 					isHovered={ hoveredField === "image" }
 					imageUrl={ imageUrl }
-					imageFallbackUrl={ imageFallbackUrl }
 					isPremium={ isPremium }
 				/>
 				<ReplacementVariableEditor
@@ -253,7 +250,6 @@ SocialMetadataPreviewForm.propTypes = {
 	recommendedReplacementVariables: PropTypes.arrayOf( PropTypes.string ),
 	imageWarnings: PropTypes.array,
 	imageUrl: PropTypes.string,
-	imageFallbackUrl: PropTypes.string,
 	setEditorRef: PropTypes.func,
 	onMouseHover: PropTypes.func,
 };
@@ -266,7 +262,6 @@ SocialMetadataPreviewForm.defaultProps = {
 	activeField: "",
 	onSelect: () => {},
 	imageUrl: "",
-	imageFallbackUrl: "",
 	isPremium: false,
 	setEditorRef: () => {},
 	onMouseHover: () => {},

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -123,7 +123,8 @@ class SocialPreviewEditor extends Component {
 			siteUrl,
 			authorName,
 			description,
-			image,
+			imageUrl,
+			imageFallbackUrl,
 			alt,
 			title,
 			replacementVariables,
@@ -145,7 +146,8 @@ class SocialPreviewEditor extends Component {
 					authorName={ authorName }
 					title={ replacedVars.title }
 					description={ replacedVars.description }
-					image={ image }
+					imageUrl={ imageUrl }
+					imageFallbackUrl={ imageFallbackUrl }
 					alt={ alt }
 					isLarge={ isLarge }
 				/>
@@ -154,7 +156,8 @@ class SocialPreviewEditor extends Component {
 					socialMediumName={ socialMediumName }
 					title={ title }
 					onRemoveImageClick={ onRemoveImageClick }
-					imageSelected={ !! image }
+					imageSelected={ !! imageUrl }
+					imageUrl={ imageUrl }
 					onTitleChange={ onTitleChange }
 					onSelectImageClick={ onSelectImageClick }
 					description={ description }
@@ -178,7 +181,8 @@ SocialPreviewEditor.propTypes = {
 	onTitleChange: PropTypes.func.isRequired,
 	description: PropTypes.string.isRequired,
 	onDescriptionChange: PropTypes.func.isRequired,
-	image: PropTypes.string.isRequired,
+	imageUrl: PropTypes.string.isRequired,
+	imageFallbackUrl: PropTypes.string.isRequired,
 	onSelectImageClick: PropTypes.func.isRequired,
 	onRemoveImageClick: PropTypes.func.isRequired,
 	socialMediumName: PropTypes.string.isRequired,

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -135,7 +135,7 @@ class FacebookPreview extends Component {
 		return (
 			<FacebookPreviewWrapper mode={ imageMode }>
 				<FacebookImage
-					src={ this.props.image }
+					src={ this.props.imageUrl || this.props.imageFallbackUrl }
 					alt={ this.props.alt }
 					onImageLoaded={ this.onImageLoaded }
 					onImageClick={ this.props.onImageClick }
@@ -174,7 +174,8 @@ FacebookPreview.propTypes = {
 	title: PropTypes.string.isRequired,
 	authorName: PropTypes.string,
 	description: PropTypes.string,
-	image: PropTypes.string,
+	imageUrl: PropTypes.string,
+	imageFallbackUrl: PropTypes.string,
 	alt: PropTypes.string,
 	onSelect: PropTypes.func,
 	onImageClick: PropTypes.func,
@@ -185,7 +186,8 @@ FacebookPreview.defaultProps = {
 	authorName: "",
 	description: "",
 	alt: "",
-	image: "",
+	imageUrl: "",
+	imageFallbackUrl: "",
 	onSelect: () => {},
 	onImageClick: () => {},
 	onMouseHover: () => {},

--- a/packages/social-metadata-previews/src/twitter/TwitterPreview.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterPreview.js
@@ -83,7 +83,8 @@ class TwitterPreview extends Component {
 	render() {
 		const {
 			isLarge,
-			image,
+			imageUrl,
+			imageFallbackUrl,
 			alt,
 			title,
 			description,
@@ -95,7 +96,7 @@ class TwitterPreview extends Component {
 		return (
 			<Wrapper>
 				<TwitterImage
-					src={ image }
+					src={ imageUrl || imageFallbackUrl }
 					alt={ alt }
 					isLarge={ isLarge }
 					onImageClick={ this.props.onImageClick }
@@ -131,7 +132,8 @@ TwitterPreview.propTypes = {
 	title: PropTypes.string.isRequired,
 	description: PropTypes.string,
 	isLarge: PropTypes.bool,
-	image: PropTypes.string,
+	imageUrl: PropTypes.string,
+	imageFallbackUrl: PropTypes.string,
 	alt: PropTypes.string,
 	onSelect: PropTypes.func,
 	onImageClick: PropTypes.func,
@@ -141,7 +143,8 @@ TwitterPreview.propTypes = {
 TwitterPreview.defaultProps = {
 	description: "",
 	alt: "",
-	image: "",
+	imageUrl: "",
+	imageFallbackUrl: "",
 	onSelect: () => {},
 	onImageClick: () => {},
 	onMouseHover: () => {},


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->
* The new social preview form should be connected to the store so that we can actually use it.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
If the changelog item is meant for the changelog of another repo, start you changelog item with the repo name between square brackets, for example: * [wordpress-seo-premium] Fixes a bug where ....
If the same changelog item is applicable to multiple changelogs/repos, add a separate changelog item for all of them.
-->
This PR can be summarized in the following changelog entry:

* [@yoast/social-metadata-forms] Fixes a bug where the Preview components did not accept the correct props.

## Relevant technical choices:
* Redux has been moved from the monorepo to wordpress-seo. This keeps the component "dumb" and makes it easier to implement them in other places.
* The Selectors, Actions and Reducers have been split in two. The reason was that some duplication > less obvious code. Omar has approved this.
* I have chosen for a pragmatic way to determine post/taxonomy. This is something that definitely can be approved.
* Taxonomies seem to work. This means that https://github.com/Yoast/wordpress-seo/issues/14608 possibly can be closed 🎉  
* I have not tested with Premium.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Enter data in the Social Preview form and check that it is written to the hidden inputs (easy way to check is to see if the data persists after a reload when you update the page) and to the store (use redux dev tools).
* Test this for both taxonomies and post types.
* I have not tested with Premium, please do a quick check to see if it works and create an issue if it doesn't (I do not have a premium install running and I do not want to block this PR any longer).

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Documentation
* [ ] I have written documentation for this change.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes N/A
