### PR TITLE
Change Warning component colors

### DIFF
--- a/packages/components/src/Warning.js
+++ b/packages/components/src/Warning.js
@@ -13,8 +13,8 @@ import SvgIcon from "./SvgIcon";
 const WarningBox = styled.div`
 	display: flex;
 	padding: 16px;
-	background: ${ colors.$color_yellow };
-	color: ${ colors.$color_black };
+	background: ${ colors.$color_alert_warning_background };
+	color: ${ colors.$color_alert_warning_text };
 `;
 
 const StyledSvgIcon = styled( SvgIcon )`

--- a/packages/components/tests/__snapshots__/YoastWarningTest.js.snap
+++ b/packages/components/tests/__snapshots__/YoastWarningTest.js.snap
@@ -4,7 +4,7 @@ exports[`YoastWarning does not render without a message 1`] = `null`;
 
 exports[`YoastWarning matches the snapshot 1`] = `
 <div
-  className="PiBkT"
+  className="cleOfn"
 >
   <svg
     aria-hidden={true}
@@ -39,7 +39,7 @@ exports[`YoastWarning matches the snapshot 1`] = `
 
 exports[`YoastWarning with a right to left language matches the snapshot 1`] = `
 <div
-  className="PiBkT"
+  className="cleOfn"
 >
   <svg
     aria-hidden={true}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoast-components] Changes the Warning component colors to match the new Yoast notification styling.

## Relevant technical choices:

- This tiny PR is needed for https://github.com/Yoast/wordpress-seo-premium/pull/2743
- It just changes the colors, using the ones that already exist for the notifications

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- launch the demo
- go the the Components tab
- see the Warning new colors 

Screenshot before:

<img width="1440" alt="Screenshot 2020-05-04 at 12 07 20" src="https://user-images.githubusercontent.com/1682452/80959569-60e8b480-8e07-11ea-9eac-c9de181f279f.png">


Screenshot after;

<img width="1440" alt="Screenshot 2020-05-04 at 12 11 12" src="https://user-images.githubusercontent.com/1682452/80959575-647c3b80-8e07-11ea-80b0-c83e5a79ada4.png">


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Notifications that use the Warning component e.g. the Morphology one in https://github.com/Yoast/wordpress-seo-premium/pull/2743

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo-premium/issues/2742
