### PR TITLE
Add full forms and multiple stems exception checks for French

### DIFF
--- a/packages/yoastseo/spec/morphology/french/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/french/stemSpec.js
@@ -69,8 +69,17 @@ const wordsToStem = [
 	// Input a noun ending in -ment.
 	[ "clément", "clément" ],
 	[ "cléments", "clément" ],
-
-
+	// Words on the exception list with full forms.
+	[ "yeux", "œil" ],
+	[ "oeil", "œil" ],
+	[ "œil", "œil" ],
+	[ "ciels", "ciel" ],
+	[ "cieux", "ciel" ],
+	[ "fol", "fou" ],
+	// Words that have multiple stems.
+	[ "favorit", "favor" ],
+	[ "fraîch", "frais" ],
+	[ "fraich", "frais" ],
 ];
 
 const paradigms = [

--- a/packages/yoastseo/spec/morphology/french/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/french/stemSpec.js
@@ -76,6 +76,7 @@ const wordsToStem = [
 	[ "ciels", "ciel" ],
 	[ "cieux", "ciel" ],
 	[ "fol", "fou" ],
+	[ "doucement", "doux" ],
 	// Words that have multiple stems.
 	[ "favorit", "favor" ],
 	[ "fraîch", "frais" ],


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [yoastseo] Adds checks for exception list with full forms and exception list of words with multiple stems to the French stemmer
* [Yoast SEO Premium] Improves keyphrase recognition when keyphrase contains irregular nouns or adjectives.


## Test instructions

This PR can be tested by following these steps:

* Make sure all the current specs for the French stemmer pass
* Add more words from the new exception lists to the specs and make sure they still pass

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #https://yoast.atlassian.net/jira/software/projects/LIN/boards/4?selectedIssue=LIN-402
