### PR TITLE
Placeholders for description (via props) and for title (via replacevars)

### DIFF
--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -154,6 +154,7 @@ class SocialMetadataPreviewForm extends Component {
 			onRemoveImageClick,
 			title,
 			description,
+			descriptionPlaceholder,
 			onTitleChange,
 			onDescriptionChange,
 			hoveredField,
@@ -173,12 +174,6 @@ class SocialMetadataPreviewForm extends Component {
 		const titleEditorTitle = sprintf( __( "%s title", "yoast-components" ), socialMediumName );
 		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
 		const descEditorTitle = sprintf( __( "%s desciption", "yoast-components" ), socialMediumName );
-		/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-		const descEditorPlaceholder  = sprintf(
-			/* Translators: %s expands to the social medium name, i.e. Faceboook. */
-			__( "Modify your %s description by editing it right here...", "yoast-components" ),
-			socialMediumName
-		);
 
 		return (
 			<Fragment>
@@ -214,7 +209,7 @@ class SocialMetadataPreviewForm extends Component {
 				<ReplacementVariableEditor
 					onChange={ onDescriptionChange }
 					content={ description }
-					placeholder={ descEditorPlaceholder }
+					placeholder={ descriptionPlaceholder }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					type="description"
@@ -250,6 +245,7 @@ SocialMetadataPreviewForm.propTypes = {
 	recommendedReplacementVariables: PropTypes.arrayOf( PropTypes.string ),
 	imageWarnings: PropTypes.array,
 	imageUrl: PropTypes.string,
+	descriptionPlaceholder: PropTypes.string,
 	setEditorRef: PropTypes.func,
 	onMouseHover: PropTypes.func,
 };
@@ -262,6 +258,7 @@ SocialMetadataPreviewForm.defaultProps = {
 	activeField: "",
 	onSelect: () => {},
 	imageUrl: "",
+	descriptionPlaceholder: "",
 	isPremium: false,
 	setEditorRef: () => {},
 	onMouseHover: () => {},

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -128,6 +128,7 @@ class SocialPreviewEditor extends Component {
 			imageFallbackUrl,
 			alt,
 			title,
+			titlePlaceholder,
 			replacementVariables,
 			recommendedReplacementVariables,
 			applyReplacementVariables,
@@ -136,7 +137,7 @@ class SocialPreviewEditor extends Component {
 		} = this.props;
 
 		// Preset a title fallback for the preview if title is empty.
-		const previewTitle = title === "" ? "%%title%% %%sep%% %%sitename%%" : title;
+		const previewTitle = title === "" ? titlePlaceholder : title;
 
 		const replacedVars = applyReplacementVariables( { title: previewTitle, description } );
 		const previewDescription = replacedVars.description === "" ? descriptionPlaceholder : replacedVars.description;
@@ -198,6 +199,7 @@ SocialPreviewEditor.propTypes = {
 	isLarge: PropTypes.bool,
 	siteUrl: PropTypes.string,
 	descriptionPlaceholder: PropTypes.string,
+	titlePlaceholder: PropTypes.string,
 	authorName: PropTypes.string,
 	replacementVariables: replacementVariablesShape,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
@@ -212,6 +214,7 @@ SocialPreviewEditor.defaultProps = {
 	isLarge: true,
 	siteUrl: "",
 	descriptionPlaceholder: "",
+	titlePlaceholder: "",
 	alt: "",
 	authorName: "",
 	applyReplacementVariables: data => data,

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -123,6 +123,7 @@ class SocialPreviewEditor extends Component {
 			siteUrl,
 			authorName,
 			description,
+			descriptionPlaceholder,
 			imageUrl,
 			imageFallbackUrl,
 			alt,
@@ -134,7 +135,11 @@ class SocialPreviewEditor extends Component {
 			isLarge,
 		} = this.props;
 
-		const replacedVars = applyReplacementVariables( { title, description } );
+		// Preset a title fallback for the preview if title is empty.
+		const previewTitle = title === "" ? "%%title%% %%sep%% %%sitename%%" : title;
+
+		const replacedVars = applyReplacementVariables( { title: previewTitle, description } );
+		const previewDescription = replacedVars.description === "" ? descriptionPlaceholder : replacedVars.description;
 
 		return (
 			<React.Fragment>
@@ -145,7 +150,7 @@ class SocialPreviewEditor extends Component {
 					siteUrl={ siteUrl }
 					authorName={ authorName }
 					title={ replacedVars.title }
-					description={ replacedVars.description }
+					description={ previewDescription }
 					imageUrl={ imageUrl }
 					imageFallbackUrl={ imageFallbackUrl }
 					alt={ alt }
@@ -161,6 +166,7 @@ class SocialPreviewEditor extends Component {
 					onTitleChange={ onTitleChange }
 					onSelectImageClick={ onSelectImageClick }
 					description={ description }
+					descriptionPlaceholder={ descriptionPlaceholder }
 					imageWarnings={ imageWarnings }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
@@ -191,6 +197,7 @@ SocialPreviewEditor.propTypes = {
 	imageWarnings: PropTypes.array,
 	isLarge: PropTypes.bool,
 	siteUrl: PropTypes.string,
+	descriptionPlaceholder: PropTypes.string,
 	authorName: PropTypes.string,
 	replacementVariables: replacementVariablesShape,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
@@ -204,6 +211,7 @@ SocialPreviewEditor.defaultProps = {
 	isPremium: false,
 	isLarge: true,
 	siteUrl: "",
+	descriptionPlaceholder: "",
 	alt: "",
 	authorName: "",
 	applyReplacementVariables: data => data,


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/social-metadata-previews] Social previews now accept descriptionPlaceholder and titlePlaceholder props, which will be shown when no description or title is provided.
* [@yoast/social-metadata-forms] The SocialMetadataPreviewForm now accepts descriptionPlaceholder prop, which will be shown when the description input is empty.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* *Test together with the [premium PR](https://github.com/Yoast/wordpress-seo-premium/pull/2772).* On loading a new post, there should be a placeholder text in the input field and preview for description, and the standard search appearance title in the preview (empty inputfield for title).
* This is the current behavior of the old social previews. Check if everything is indeed the same.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/javascript/issues/631
