### PR TITLE
Fix Twitter Title and Description styles in metabox

### DIFF
--- a/packages/social-metadata-previews/src/twitter/TwitterDescription.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterDescription.js
@@ -13,6 +13,8 @@ const TwitterDescription = styled.p`
 	max-height: 55px;
 	min-height: 20px;
 	overflow: hidden;
+	font-size: 15px;
+	line-height: 20px;
 	text-overflow: ellipsis;
 	margin: 0 0 2px;
 	color: rgb(101, 119, 134);

--- a/packages/social-metadata-previews/src/twitter/TwitterTitle.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterTitle.js
@@ -7,6 +7,7 @@ const height = "18px";
 const TwitterTitle = styled.p`
 	line-height: ${ height };
 	min-height : ${ height };
+	font-size: 15px;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterDescriptionTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterDescriptionTest.js.snap
@@ -5,6 +5,8 @@ exports[`TwitterDescription matches the snapshot for the summary card 1`] = `
   max-height: 55px;
   min-height: 20px;
   overflow: hidden;
+  font-size: 15px;
+  line-height: 20px;
   text-overflow: ellipsis;
   margin: 0 0 2px;
   color: rgb(101,119,134);
@@ -24,6 +26,8 @@ exports[`TwitterDescription matches the snapshot for the summary with large imag
   max-height: 55px;
   min-height: 20px;
   overflow: hidden;
+  font-size: 15px;
+  line-height: 20px;
   text-overflow: ellipsis;
   margin: 0 0 2px;
   color: rgb(101,119,134);

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
@@ -81,6 +81,7 @@ exports[`TwitterPreview matches the snapshot 1`] = `
 .c3 {
   line-height: 18px;
   min-height: 18px;
+  font-size: 15px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -94,6 +95,8 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   max-height: 55px;
   min-height: 20px;
   overflow: hidden;
+  font-size: 15px;
+  line-height: 20px;
   text-overflow: ellipsis;
   margin: 0 0 2px;
   color: rgb(101,119,134);

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterTitleTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterTitleTest.js.snap
@@ -4,6 +4,7 @@ exports[`TwitterTitle matches the snapshot by default 1`] = `
 .c0 {
   line-height: 18px;
   min-height: 18px;
+  font-size: 15px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:
* [@yoast/social-metadata-previews] Fixes a bug where the line-height and font-size would not be set correctly in the Metabox.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
1. Build everything in Premium.
2. Check out the `Social React` tab
3. Start the example components app
4. Check that the Twitter Preview form in the example components app matches the one in the plugin, most notably check:
	- Twitter Description has a `line-height` of `20px` and a `font-size` of `15px`.
	- Twitter Title has a `font-size` of `15px`.

## Quality assurance
* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #653 
