### PR TITLE
Transfer Portuguese stemming data to morphology data file

### DIFF
--- a/apps/content-analysis/src/utils/getMorphologyData.js
+++ b/apps/content-analysis/src/utils/getMorphologyData.js
@@ -6,7 +6,7 @@ let morphologyData = null;
  * @returns {Object} The morphology data, or an empty object if not available.
  */
 function loadLocalMorphologyData() {
-	let data, dataDe, dataNL, dataES, dataFR, dataRU = {};
+	let data, dataDe, dataNL, dataES, dataFR, dataRU, dataPT = {};
 	try {
 		// Disabling global require to be able to fail.
 		// eslint-disable-next-line global-require
@@ -21,11 +21,13 @@ function loadLocalMorphologyData() {
 		dataFR = require( "../../../../packages/yoastseo/premium-configuration/data/morphologyData-fr-v6.json" );
 		// eslint-disable-next-line global-require
 		dataRU = require( "../../../../packages/yoastseo/premium-configuration/data/morphologyData-ru-v6.json" );
+		// eslint-disable-next-line global-require
+		dataPT = require( "../../../../packages/yoastseo/premium-configuration/data/morphologyData-pt-v6.json" );
 	} catch ( error ) {
 		// Falling back to empty data.
 	}
 
-	return merge( data, dataDe, dataNL, dataES, dataFR, dataRU );
+	return merge( data, dataDe, dataNL, dataES, dataFR, dataRU, dataPT );
 }
 
 /**

--- a/packages/yoastseo/spec/helpers/getLanguagesWithWordFormSupportSpec.js
+++ b/packages/yoastseo/spec/helpers/getLanguagesWithWordFormSupportSpec.js
@@ -2,6 +2,6 @@ import getLanguagesWithWordFormSupport from "../../src/helpers/getLanguagesWithW
 
 describe( "Checks which languages have morphology support in YoastSEO.js", function() {
 	it( "returns an array of languages that have morphology support", function() {
-		expect( getLanguagesWithWordFormSupport() ).toEqual( [ "en", "de", "nl", "es", "fr", "ru" ] );
+		expect( getLanguagesWithWordFormSupport() ).toEqual( [ "en", "de", "nl", "es", "fr", "ru", "pt" ] );
 	} );
 } );

--- a/packages/yoastseo/spec/morphology/portuguese/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/portuguese/stemSpec.js
@@ -1,4 +1,7 @@
 import stem from "../../../src/morphology/portuguese/stem";
+import getMorphologyData from "../../specHelpers/getMorphologyData";
+
+const morphologyDataPT = getMorphologyData( "pt" ).pt;
 
 const wordsToStem = [
 	// Words with suffixes from the first stemming step
@@ -36,7 +39,7 @@ describe( "Test for stemming Portuguese words", () => {
 	for ( let i = 0; i < wordsToStem.length; i++ ) {
 		const wordToCheck = wordsToStem[ i ];
 		it( "stems the word " + wordToCheck[ 0 ], () => {
-			expect( stem( wordToCheck[ 0 ] ) ).toBe( wordToCheck[ 1 ] );
+			expect( stem( wordToCheck[ 0 ], morphologyDataPT ) ).toBe( wordToCheck[ 1 ] );
 		} );
 	}
 } );

--- a/packages/yoastseo/spec/morphology/portuguese/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/portuguese/stemSpec.js
@@ -15,6 +15,7 @@ const wordsToStem = [
 	[ "publicidade", "public" ],
 	[ "qualitativas", "qualit" ],
 	[ "roubalheiras", "roubalheir" ],
+	[ "aeronáutica", "aeronáut" ],
 	// Words with verb suffixes
 	[ "produziremos", "produz" ],
 	[ "proliferaram", "prolifer" ],

--- a/packages/yoastseo/spec/morphology/portuguese/stemmerCoverage/calculateCoverage.js
+++ b/packages/yoastseo/spec/morphology/portuguese/stemmerCoverage/calculateCoverage.js
@@ -1,11 +1,14 @@
 /* eslint-disable no-console */
 import stem from "../../../../src/morphology/portuguese/stem";
+import getMorphologyData from "../../../specHelpers/getMorphologyData";
 import goldStandard from "./goldStandardStems.json";
+
+const morphologyDataPT = getMorphologyData( "pt" ).pt;
 
 const coverageThreshold = 0.8;
 
 describe( "Calculate coverage for the Portuguese stemmer", () => {
-	const stemsComparison = goldStandard.stems.map( word => [ word[ 0 ], word[ 1 ], stem( word[ 0 ] ) ] );
+	const stemsComparison = goldStandard.stems.map( word => [ word[ 0 ], word[ 1 ], stem( word[ 0 ], morphologyDataPT ) ] );
 
 	const errors = stemsComparison.filter( word => word[ 1 ] !== word[ 2 ] );
 

--- a/packages/yoastseo/spec/specHelpers/getMorphologyData.js
+++ b/packages/yoastseo/spec/specHelpers/getMorphologyData.js
@@ -4,6 +4,7 @@ import nl from "../../premium-configuration/data/morphologyData-nl-v6.json";
 import es from "../../premium-configuration/data/morphologyData-es-v6.json";
 import fr from "../../premium-configuration/data/morphologyData-fr-v6.json";
 import ru from "../../premium-configuration/data/morphologyData-ru-v6.json";
+import pt from "../../premium-configuration/data/morphologyData-pt-v6.json";
 
 
 const morphologyData = {
@@ -13,6 +14,7 @@ const morphologyData = {
 	es,
 	fr,
 	ru,
+	pt,
 };
 
 /**

--- a/packages/yoastseo/src/helpers/getStemForLanguage.js
+++ b/packages/yoastseo/src/helpers/getStemForLanguage.js
@@ -4,6 +4,7 @@ import { determineStem as dutchDetermineStem } from "../morphology/dutch/determi
 import spanishDetermineStem from "../morphology/spanish/stem";
 import frenchDetermineStem from "../morphology/french/stem";
 import russianDetermineStem from "../morphology/russian/stem";
+import portugueseDetermineStem from "../morphology/portuguese/stem";
 
 /**
  * Collects all functions for determining a stem per language and returns this collection to a Researcher
@@ -18,5 +19,6 @@ export default function() {
 		es: spanishDetermineStem,
 		fr: frenchDetermineStem,
 		ru: russianDetermineStem,
+		pt: portugueseDetermineStem,
 	};
 }

--- a/packages/yoastseo/src/morphology/portuguese/stem.js
+++ b/packages/yoastseo/src/morphology/portuguese/stem.js
@@ -249,7 +249,7 @@ export default function stem( word, morphologyData ) {
 	// Go through the first step of removing suffixes.
 	const wordAfterStep1 = stemStandardSuffixes( word, morphologyData.externalStemmer.standardSuffixes, r1Text, r2Text, rvText );
 
-	// If no suffixes were removed in the first step, search for an remove verb suffixes.
+	// If no suffixes were removed in the first step, search for and remove verb suffixes.
 	let wordAfterStep2 = "";
 
 	if ( word === wordAfterStep1 ) {

--- a/packages/yoastseo/src/morphology/portuguese/stem.js
+++ b/packages/yoastseo/src/morphology/portuguese/stem.js
@@ -27,30 +27,30 @@ import { findMatchingEndingInArray } from "../morphoHelpers/findMatchingEndingIn
 /**
  * Checks whether the character is a vowel.
  *
- * @param {string}	character	The character to check.
+ * @param {string}	    character	The character to check.
+ * @param {string[]}    vowels      The Portuguese vowels.
  *
  * @returns {boolean}	Whether the character is a vowel.
  */
-const isVowel = function( character ) {
-	const regex = /[aeiouáéíóúâêô]/gi;
-
-	return regex.test( character );
+const isVowel = function( character, vowels ) {
+	return vowels.includes( character );
 };
 
 /**
  * Finds the first vowel in a string after the specified index and returns the index of the character following that vowel
  * (if found).
  *
- * @param {string}	word	    The word to check.
- * @param {number}	[start=0]   The index at which the search for a vowel should begin.
+ * @param {string}	    word	        The word to check.
+ * @param {string[]}    vowels          The Portuguese vowels.
+ * @param {number}	    [start=0]       The index at which the search for a vowel should begin.
  *
  * @returns {number} The index of the character following the found vowel. If this is not found, the length of the word.
  */
-const nextVowelPosition = function( word, start = 0 ) {
+const nextVowelPosition = function( word, vowels, start = 0 ) {
 	const length = word.length;
 
 	for ( let position = start; position < length; position++ ) {
-		if ( isVowel( word[ position ] ) ) {
+		if ( isVowel( word[ position ], vowels ) ) {
 			return position;
 		}
 	}
@@ -62,16 +62,17 @@ const nextVowelPosition = function( word, start = 0 ) {
  * Finds the first consonant in a string after the specified index and returns the index of the character following that
  * consonant (if found).
  *
- * @param {string}	word	    The word to check.
- * @param {number}	[start=0]	The index at which the search for a consonant should begin.
+ * @param {string}	    word	    The word to check.
+ * @param {string[]}    vowels      The Portuguese vowels.
+ * @param {number}	    [start=0]	The index at which the search for a consonant should begin.
  *
  * @returns {number} The index of the character following the found consonant. If this is not found, the length of the word.
  */
-const nextConsonantPosition = function( word, start = 0 ) {
+const nextConsonantPosition = function( word, vowels, start = 0 ) {
 	const length = word.length;
 
 	for ( let position = start; position < length; position++ ) {
-		if ( ! isVowel( word[ position ] ) ) {
+		if ( ! isVowel( word[ position ], vowels ) ) {
 			return position;
 		}
 	}
@@ -103,108 +104,78 @@ const replaceCharacters = function( word, charactersToReplace, replacements ) {
  * For some of the suffix groups, replaces the suffix with another string after removing it (e.g. -logia is replaced with
  * -log).
  *
- * @param {string}	word	The word to check.
- * @param {string}	r1Text	The text in the R1 region.
- * @param {string}	r2Text	The text in the R2 region.
- * @param {string}	rvText	The text in the RV region.
+ * @param {string}	word	            The word to check.
+ * @param {Object}  standardSuffixData  The data for stemming standard suffixes.
+ * @param {string}	r1Text	            The text in the R1 region.
+ * @param {string}	r2Text	            The text in the R2 region.
+ * @param {string}	rvText	            The text in the RV region.
  *
  * @returns {string} The stemmed word or the original word if no suffix was removed.
  */
-const stemStandardSuffixes = function( word, r1Text, r2Text, rvText ) {
-	const suf1 = findMatchingEndingInArray( r2Text, [ "amentos", "imentos", "aço~es", "adoras", "adores", "amento",
-		"imento", "aça~o", "adora", "ância", "antes", "ismos", "istas", "ador", "ante", "ável", "ezas", "icas", "icos", "ismo",
-		"ista", "ível", "osas", "osos", "eza", "ica", "ico", "osa", "oso" ] );
-	const suf2 = findMatchingEndingInArray( r2Text, [ "logias", "logia" ] );
-	const suf3 = findMatchingEndingInArray( r2Text, [ "ências", "ência" ] );
-	const suf4 = findMatchingEndingInArray( r2Text, [ "ativamente", "icamente", "ivamente", "osamente", "adamente" ] );
-	const suf5 = findMatchingEndingInArray( r1Text, [ "amente" ] );
-	const suf6 = findMatchingEndingInArray( r2Text, [ "antemente", "avelmente", "ivelmente", "mente" ] );
-	const suf7 = findMatchingEndingInArray( r2Text, [ "abilidades", "abilidade", "icidades", "icidade", "ividades",
-		"ividade", "idades", "idade" ] );
-	const suf8 = findMatchingEndingInArray( r2Text, [ "ativas", "ativos", "ativa", "ativo", "ivas", "ivos", "iva", "ivo" ] );
-	const suf9 = findMatchingEndingInArray( rvText, [ "iras", "ira" ] );
+const stemStandardSuffixes = function( word, standardSuffixData, r1Text, r2Text, rvText ) {
+	const regions = {
+		r1: r1Text,
+		r2: r2Text,
+		rv: rvText,
+	};
 
-	if ( suf1 !== "" ) {
-		word = word.slice( 0, -suf1.length );
-	} else if ( suf2 !== "" ) {
-		word = word.slice( 0, -suf2.length ) + "log";
-	} else if ( suf3 !== "" ) {
-		word = word.slice( 0, -suf3.length ) + "ente";
-	} else if ( suf4 !== "" ) {
-		word = word.slice( 0, -suf4.length );
-	} else if ( suf5 !== "" ) {
-		word = word.slice( 0, -suf5.length );
-	} else if ( suf6 !== "" ) {
-		word = word.slice( 0, -suf6.length );
-	}  else if ( suf7 !== "" ) {
-		word = word.slice( 0, -suf7.length );
-	}  else if ( suf8 !== "" ) {
-		word = word.slice( 0, -suf8.length );
-	} else if ( word.endsWith( "eiras" ) || word.endsWith( "eira" ) ) {
-		if ( suf9 !== "" ) {
-			word = word.slice( 0, -suf9.length ) + "ir";
+	for ( const suffixGroup of standardSuffixData.standardGroups ) {
+		const foundSuffix = findMatchingEndingInArray( regions[ suffixGroup.region ], suffixGroup.suffixes );
+
+		if ( foundSuffix ) {
+			return word.slice( 0, -foundSuffix.length ) + suffixGroup.replacement;
 		}
 	}
+
+	const specialEnding = findMatchingEndingInArray( regions[ standardSuffixData.specialClass.region ], standardSuffixData.specialClass.suffixes );
+	if ( findMatchingEndingInArray( word, standardSuffixData.specialClass.wordEndingsToCheck ) && specialEnding  ) {
+		word = word.slice( 0, -specialEnding.length ) + standardSuffixData.specialClass.replacement;
+	}
+
 	return word;
 };
 
 /**
  * Stems verb suffixes.
  *
- * @param {string}  word                The original word.
- * @param {string}  rvText              The text of the RV.
+ * @param {string}      word            The original word.
+ * @param {string[]}    verbSuffixes    The verb suffixes to check.
+ * @param {string}      rvText          The text of the RV.
  *
  * @returns {string} The word with the verb suffixes removed (if applicable).
  */
-const stemVerbSuffixes = function( word, rvText ) {
-	const suf10 = findMatchingEndingInArray( rvText, [ "aríamos", "ássemos", "eríamos", "êssemos", "iríamos", "íssemos",
+const stemVerbSuffixes = function( word, verbSuffixes, rvText ) {
+	const verbSuffix = findMatchingEndingInArray( rvText, verbSuffixes );
 
-		"áramos", "aremos", "aríeis", "ásseis", "ávamos", "éramos", "eremos",
-		"eríeis", "ésseis", "íramos", "iremos", "iríeis", "ísseis",
-
-		"ara~o", "ardes", "areis", "áreis", "ariam", "arias", "armos", "assem",
-		"asses", "astes", "áveis", "era~o", "erdes", "ereis", "éreis", "eriam",
-		"erias", "ermos", "essem", "esses", "estes", "íamos", "ira~o", "irdes",
-		"ireis", "íreis", "iriam", "irias", "irmos", "issem", "isses", "istes",
-
-		"adas", "ados", "amos", "ámos", "ando", "aram", "aras", "arás", "arei",
-		"arem", "ares", "aria", "asse", "aste", "avam", "avas", "emos", "endo",
-		"eram", "eras", "erás", "erei", "erem", "eres", "eria", "esse", "este",
-		"idas", "idos", "íeis", "imos", "indo", "iram", "iras", "irás", "irei",
-		"irem", "ires", "iria", "isse", "iste",
-
-		"ada", "ado", "ais", "ara", "ará", "ava", "eis", "era", "erá", "iam",
-		"ias", "ida", "ido", "ira", "irá",
-
-		"am", "ar", "as", "ei", "em", "er", "es", "eu", "ia", "ir", "is", "iu", "ou" ] );
-
-	if ( suf10 !== "" ) {
-		word = word.slice( 0, -suf10.length );
+	if ( verbSuffix !== "" ) {
+		word = word.slice( 0, -verbSuffix.length );
 	}
+
 	return word;
 };
 
 /**
  * Stems residual suffixes.
  *
- * @param {string}	word	The word to check.
- * @param {string}	rvText	The text in the RV region.
+ * @param {string}	word	            The word to check.
+ * @param {Object}  residualSuffixData  The data used to stem residual suffixes.
+ * @param {string}	rvText	            The text in the RV region.
  *
  * @returns {string} The word with a removed suffix, or the original input word if no suffix was removed.
  */
-const stemResidualSuffixes = function( word, rvText ) {
-	const suf12 = findMatchingEndingInArray( rvText, [ "ue", "ué", "uê" ] );
-	const suf13 = findMatchingEndingInArray( rvText, [ "ie", "ié", "iê" ] );
-	const suf14 = findMatchingEndingInArray( rvText, [ "e", "é", "ê" ] );
+const stemResidualSuffixes = function( word, residualSuffixData, rvText ) {
+	const foundSuffixUe = findMatchingEndingInArray( rvText, residualSuffixData.groupUe.suffixes );
+	const foundSuffixIe = findMatchingEndingInArray( rvText, residualSuffixData.groupIe.suffixes );
+	const foundSuffixE = findMatchingEndingInArray( rvText, residualSuffixData.groupESuffixes );
 
-	if ( ( word.endsWith( "gue" ) || word.endsWith( "gué" ) || word.endsWith( "guê" ) ) && ( suf12 !== "" ) ) {
-		word = word.slice( 0, -suf12.length );
-	} else if ( ( word.endsWith( "cie" ) || word.endsWith( "cié" ) || word.endsWith( "ciê" ) ) && ( suf13 !== "" ) ) {
-		word = word.slice( 0, -suf13.length );
-	} else if ( suf14 !== "" ) {
-		word = word.slice( 0, -suf14.length );
-	} else if ( word.endsWith( "ç" ) ) {
-		word = word.replace( /ç$/, "c" );
+	if ( foundSuffixUe && findMatchingEndingInArray( word, residualSuffixData.groupUe.wordEndingsToCheck ) ) {
+		word = word.slice( 0, -foundSuffixUe.length );
+	} else if ( foundSuffixIe && findMatchingEndingInArray( word, residualSuffixData.groupIe.wordEndingsToCheck ) ) {
+		word = word.slice( 0, -foundSuffixIe.length );
+	} else if ( foundSuffixE ) {
+		word = word.slice( 0, -foundSuffixE.length );
+	} else if ( word.endsWith( residualSuffixData.cCedilla[ 0 ] ) ) {
+		word = word.slice( 0, -1 ) + residualSuffixData.cCedilla[ 1 ];
 	}
 
 	return word;
@@ -213,17 +184,19 @@ const stemResidualSuffixes = function( word, rvText ) {
 /**
  * Stems Portuguese words.
  *
- * @param {string} word   The word to stem.
+ * @param {string} word             The word to stem.
+ * @param {Object} morphologyData   The Portuguese morphology data.
  *
  * @returns {string} The stemmed word.
  */
-export default function stem( word ) {
+export default function stem( word, morphologyData ) {
 	word.toLowerCase();
+	const vowels = morphologyData.externalStemmer.vowels;
 
 	// Nasal vowels should be treated as a vowel followed by a consonant.
-	const nasalVowels = [ "ã", "õ" ];
-	const nasalVowelsReplacement = [ "a~", "o~" ];
-	word = replaceCharacters( word, nasalVowels, nasalVowelsReplacement  );
+	const nasalVowels = morphologyData.externalStemmer.nasalVowels.originals;
+	const nasalVowelsReplacement = morphologyData.externalStemmer.nasalVowels.replacements;
+	word = replaceCharacters( word, nasalVowels, nasalVowelsReplacement, );
 
 	const length = word.length;
 	if ( length < 2 ) {
@@ -239,7 +212,7 @@ export default function stem( word ) {
 	 * there is no such non-vowel.
 	 */
 	for ( let i = 0; i < ( length - 1 ) && r1 === length; i++ ) {
-		if ( isVowel( word[ i ] ) && ! isVowel( word[ i + 1 ] ) ) {
+		if ( isVowel( word[ i ], vowels ) && ! isVowel( word[ i + 1 ], vowels ) ) {
 			r1 = i + 2;
 		}
 	}
@@ -249,7 +222,7 @@ export default function stem( word ) {
 	 * word if there is no such non-vowel.
 	 */
 	for ( let i = r1; i < ( length - 1 ) && r2 === length; i++ ) {
-		if ( isVowel( word[ i ] ) && ! isVowel( word[ i + 1 ] ) ) {
+		if ( isVowel( word[ i ], vowels ) && ! isVowel( word[ i + 1 ], vowels ) ) {
 			r2 = i + 2;
 		}
 	}
@@ -260,10 +233,10 @@ export default function stem( word ) {
 	 * third letter. But RV is the end of the word if these positions cannot be found.
 	 */
 	if ( length > 3 ) {
-		if ( ! isVowel( word[ 1 ] ) ) {
-			rv = nextVowelPosition( word, 2 ) + 1;
-		} else if ( isVowel( word[ 0 ] ) && isVowel( word[ 1 ] ) ) {
-			rv = nextConsonantPosition( word, 2 ) + 1;
+		if ( ! isVowel( word[ 1 ], vowels ) ) {
+			rv = nextVowelPosition( word, vowels, 2 ) + 1;
+		} else if ( isVowel( word[ 0 ], vowels ) && isVowel( word[ 1 ], vowels ) ) {
+			rv = nextConsonantPosition( word, vowels, 2 ) + 1;
 		} else {
 			rv = 3;
 		}
@@ -274,13 +247,13 @@ export default function stem( word ) {
 	let rvText = word.slice( rv );
 
 	// Go through the first step of removing suffixes.
-	const wordAfterStep1 = stemStandardSuffixes( word, r1Text, r2Text, rvText  );
+	const wordAfterStep1 = stemStandardSuffixes( word, morphologyData.externalStemmer.standardSuffixes, r1Text, r2Text, rvText );
 
 	// If no suffixes were removed in the first step, search for an remove verb suffixes.
 	let wordAfterStep2 = "";
 
 	if ( word === wordAfterStep1 ) {
-		wordAfterStep2 = stemVerbSuffixes( word, rvText );
+		wordAfterStep2 = stemVerbSuffixes( word, morphologyData.externalStemmer.verbSuffixes, rvText );
 	}
 
 	// If suffixes were removed in one of the previous steps, replace the word with the de-suffixed word and adjust RV text.
@@ -297,20 +270,20 @@ export default function stem( word ) {
 	 * removed in one of the previous steps, remove -os, -a, -i, -o, -á, í, or ó if in RV.
 	 */
 	if ( wordAfterStep1 !== word || wordAfterStep2 !== word ) {
-		if ( word.endsWith( "ci" ) && rvText.endsWith( "i" ) ) {
+		if ( word.endsWith( morphologyData.externalStemmer.ciToC[ 0 ] ) && rvText.endsWith( morphologyData.externalStemmer.ciToC[ 1 ] ) ) {
 			word = word.slice( 0, -1 );
 			rvText = word.slice( rv );
 		}
 	} else {
-		const suf11 = findMatchingEndingInArray( rvText, [ "os", "a", "i", "o", "á", "í", "ó" ] );
-		if ( suf11 !== "" ) {
-			word = word.slice( 0, -suf11.length );
+		const foundGeneralSuffix = findMatchingEndingInArray( rvText, morphologyData.externalStemmer.generalSuffixes );
+		if ( foundGeneralSuffix !== "" ) {
+			word = word.slice( 0, -foundGeneralSuffix.length );
 			rvText = word.slice( rv );
 		}
 	}
 
 	// Stem residual suffixes, regardless of whether a suffix was removed in any of the previous steps or not.
-	word = stemResidualSuffixes( word, rvText );
+	word = stemResidualSuffixes( word, morphologyData.externalStemmer.residualSuffixes, rvText );
 
 	// Change the nasal vowel replacements back into the nasal vowels.
 	word = replaceCharacters( word, nasalVowelsReplacement, nasalVowels );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Moves the Portuguese stemming data to a newly created Portuguese morphology data file.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check the unit tests
  * Run `yarn test` and make sure that all tests still pass.
  * Make sure that the coverage is still the same as before the change.
* Test in the content analysis app
  * Start the content analysis app by going to `javascript/apps/content-analysis` and run `yarn start`.
  * In the content analysis app, make sure that the locale is set to the right language and that the toggle for morphology support is switched on.
  * Add a text of at least 150 words.
  * Set a keyphrase and use various (supported) forms of that keyphrase in the text.
  * Make sure that all forms get recognized in the keyphrase density assessment (click on the eye marker next to the result and confirm that you can see all forms marked below).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-397
