### PR TITLE
Make 'Close' in Icon.js translatable

### DIFF
--- a/packages/components/src/button/Icon.js
+++ b/packages/components/src/button/Icon.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Button, { sharedButtonPropTypes, sharedButtonDefaultProps } from "./Button";
+import { __ } from "@wordpress/i18n";
 
 const closeIcon = <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512" role="img" aria-hidden="true" focusable="false">
 	{ /* eslint-disable-next-line max-len */ }
@@ -16,7 +17,7 @@ const closeIcon = <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 352 512" 
 export const CloseButton = ( props ) => {
 	return <Button
 		className="yoast-close"
-		aria-label="Close"
+		aria-label={ __( "Close", "yoast-components" ) }
 		{ ...props }
 	>
 		{ closeIcon }


### PR DESCRIPTION
## Summary
Split out from [this comment](https://github.com/Yoast/javascript/pull/707#issuecomment-641990833).

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/components] Makes 'Close' in Icon.js translatable. (non userfacing, because it's split out from https://github.com/Yoast/javascript/pull/707, which is in the same release)

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to the `Reactified components` tab of the example app.
* See no 
```
index.js?b19a:74 Jed localization error: 
Error: No translation key found.
```
(You'll see another, preexisting Jed error)

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
