### PR TITLE
Remove the width styling from a Yoast Data Model

### DIFF
--- a/packages/components/src/data-model/data-model.css
+++ b/packages/components/src/data-model/data-model.css
@@ -1,7 +1,6 @@
 .yoast-data-model {
     padding: 0;
     list-style: none;
-    width: 275px;
 }
 
 .yoast-data-model li {


### PR DESCRIPTION
With the width it breaks out of the WP sidebar, causing a vertical scrollbar.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/components] Fixes a bug where the insights would cause a horizontal scrollbar in the Yoast sidebar.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Link this PR to the premium `feature/internal-linking-phase-2` branch.
* Edit a post.
* Open the Insights collapsible in the Yoast sidebar.
* Ensure there is no horizontal scrollbar, before there would be.

Before:
<img width="284" alt="insights too wide" src="https://user-images.githubusercontent.com/35524806/84753567-73860a00-afbf-11ea-848d-43c3f0e9680a.png">

Now:
<img width="287" alt="insights without yoast-data-model width" src="https://user-images.githubusercontent.com/35524806/84753577-77199100-afbf-11ea-90f3-0ea6ca110445.png">

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
