### PR TITLE
Improve stemming of verb plurals on -ons

### DIFF
--- a/packages/yoastseo/spec/morphology/french/stemSpec.js
+++ b/packages/yoastseo/spec/morphology/french/stemSpec.js
@@ -129,6 +129,9 @@ const wordsToStem = [
 	// -Ons is not stemmed if preceded by i.
 	[ "questions", "question" ],
 	[ "stations", "station" ],
+	// Two-syllable verbs that start with a vowel and end on -ons.
+	[ "aidons", "aid" ],
+	[ "aimons", "aim" ],
 	// Non-verbs ending on -ons where only -s should be stemmed.
 	[ "chansons", "chanson" ],
 	[ "potirons", "potiron" ],

--- a/packages/yoastseo/spec/morphology/french/stemmerCoverage/goldStandardStems.json
+++ b/packages/yoastseo/spec/morphology/french/stemmerCoverage/goldStandardStems.json
@@ -682,7 +682,7 @@
 	["aimés", "aim"],
 	["aimez", "aim"],
 	["aimiez", "aim"],
-	["aimons", "aimon"],
+	["aimons", "aim"],
 	["aine", "ain"],
 	["aîné", "aîn"],
 	["aînée", "aîn"],

--- a/packages/yoastseo/src/morphology/french/stem.js
+++ b/packages/yoastseo/src/morphology/french/stem.js
@@ -305,13 +305,12 @@ const removeOtherVerbSuffixes = function( word, step2aDone, wordAfterStep1, r2In
 				return word.replace( regex, "" );
 			}
 		}
-		/*
-		 * Check for the verb suffix -ons and remove if in RV, unless it is preceded by -i. In most words ending in -ions,
-		 -ons is not a (full) suffix.
-		 */
+		// Check if a word ends in "ons" preceded by "i", if it is "ons" is not stemmed.
 		if ( word.endsWith( "ions" ) ) {
 			return word;
 		}
+
+		// Check if a word ends in "ons" preceded by other than "i" and stem it if it is in RV.
 		const verbSuffixOns = new RegExp( morphologyData.regularStemmer.verbSuffixOns );
 		if ( word.search( verbSuffixOns ) >= rvIndex ) {
 			word = word.replace( verbSuffixOns, "" );

--- a/packages/yoastseo/src/morphology/french/stem.js
+++ b/packages/yoastseo/src/morphology/french/stem.js
@@ -309,9 +309,12 @@ const removeOtherVerbSuffixes = function( word, step2aDone, wordAfterStep1, r2In
 		 * Check for the verb suffix -ons and remove if in RV, unless it is preceded by -i. In most words ending in -ions,
 		 -ons is not a (full) suffix.
 		 */
+		if ( word.endsWith( "ions" ) ) {
+			return word;
+		}
 		const verbSuffixOns = new RegExp( morphologyData.regularStemmer.verbSuffixOns );
 		if ( word.search( verbSuffixOns ) >= rvIndex ) {
-			word = word.replace( verbSuffixOns, "$1" );
+			word = word.replace( verbSuffixOns, "" );
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* [yoastseo] Adds check for verbs on -ions before stemming the verb suffix -ons and does not stem -ons if the word ends on -ions (for these words, the suffix is most likely -s, not -ons).
* [Yoast SEO Premium] Improves recognition of several French first person plural verb forms with suffix -ons (not -ions), e.g. _aimons_, _aidons_, _oisons_, _aerons_.

## Test instructions
This PR can be tested by following these steps:

### In French Premium

* Make sure all of the following forms are being recognised as forms of the same word when one of them is entered in the keyphrase and others in the title/text/meta-description: _aimons_, _aimez_, _aiment_
* Make sure all of the following forms are being recognised as forms of the same word when one of them is entered in the keyphrase and others in the title/text/meta-description: _aidons_, _aidez_, _aident_
* Make sure all of the following forms are being recognised as forms of the same word when one of them is entered in the keyphrase and others in the title/text/meta-description: _aerons_, _aerent_
* Make sure all of the following forms are being recognised as forms of the same word when one of them is entered in the keyphrase and others in the title/text/meta-description: -_oisons_, _oisez_, _oisent_

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/jira/software/projects/LIN/boards/4?selectedIssue=LIN-456
