### PR TITLE
Introduce IDs for QA

### DIFF
--- a/packages/social-metadata-forms/src/ImageSelect.js
+++ b/packages/social-metadata-forms/src/ImageSelect.js
@@ -48,14 +48,17 @@ const DivWithMargin = styled.div`
  * @param {function} 	onClick				Callback called when the "Select image" or "Replace image" button is clicked.
  * @param {bool}		imageSelected		Is there already an image slected.
  * @param {function}	onRemoveImageClick 	Callback called when the "Remove image" button is clicked.
+ * @param {string}		socialMediumName	The name of the Social Medium for which the buttons are rendered.
  *
  * @returns {Components} The buttons to render for the ImageSelect.
  */
-const renderButtons = ( onClick, imageSelected, onRemoveImageClick ) => {
+const renderButtons = ( onClick, imageSelected, onRemoveImageClick, socialMediumName ) => {
+	const buttonId = imageSelected ? `${ socialMediumName }-replace-button` : `${ socialMediumName }-select-button`;
 	return (
 		<Fragment>
 			<StandardButton
 				onClick={ onClick }
+				id={ buttonId }
 			>
 				{
 					imageSelected
@@ -67,6 +70,7 @@ const renderButtons = ( onClick, imageSelected, onRemoveImageClick ) => {
 			{
 				imageSelected && <UndoButton
 					onClick={ onRemoveImageClick }
+					id={ `${ socialMediumName }-remove-button`  }
 				>
 					{ __( "Remove image", "yoast-components" ) }
 				</UndoButton>
@@ -86,6 +90,7 @@ const renderButtons = ( onClick, imageSelected, onRemoveImageClick ) => {
  * @param {function} props.onRemoveImageClick Callback called when the "Remove image" button is clicked.
  * @param {string}   props.imageUrl           The Url adress of the image
  * @param {bool}     props.isPremium          States if premium is installed.
+ * @param {string}   props.socialMediumName   The name of the social medium for which this component is rendered.
  *
  * @returns {React.Component} The ImageSelect component with a title, optional warnings and an image selection button.
  */
@@ -99,6 +104,7 @@ const ImageSelect = ( {
 	isPremium,
 	onMouseEnter,
 	onMouseLeave,
+	socialMediumName,
 } ) =>
 	<DivWithMargin
 		onMouseEnter={ onMouseEnter }
@@ -114,11 +120,11 @@ const ImageSelect = ( {
 			</Alert> )
 		}
 		{
-			isPremium ? renderButtons( onClick, imageSelected, onRemoveImageClick )
+			isPremium ? renderButtons( onClick, imageSelected, onRemoveImageClick, socialMediumName )
 				:	<ColumnWrapper>
-					<UrlInputField disabled={ "disabled" } value={ imageUrl } />
+					<UrlInputField disabled={ "disabled" } value={ imageUrl } id={ `${ socialMediumName }-url-input` } />
 					<RowWrapper>
-						{ renderButtons( onClick, imageSelected, onRemoveImageClick ) }
+						{ renderButtons( onClick, imageSelected, onRemoveImageClick, socialMediumName ) }
 					</RowWrapper>
 				</ColumnWrapper>
 		}
@@ -135,6 +141,7 @@ ImageSelect.propTypes = {
 	imageUrl: PropTypes.string,
 	onMouseEnter: PropTypes.func,
 	onMouseLeave: PropTypes.func,
+	socialMediumName: PropTypes.oneOf( [ "twitter", "facebook" ] ).isRequired,
 };
 
 ImageSelect.defaultProps = {

--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -189,6 +189,7 @@ class SocialMetadataPreviewForm extends Component {
 					isHovered={ hoveredField === "image" }
 					imageUrl={ imageUrl }
 					isPremium={ isPremium }
+					socialMediumName={ socialMediumName.toLowerCase() }
 				/>
 				<ReplacementVariableEditor
 					onChange={ onTitleChange }
@@ -196,6 +197,7 @@ class SocialMetadataPreviewForm extends Component {
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					type="title"
+					fieldId={ `${ socialMediumName.toLowerCase() }-title-input` }
 					label={ titleEditorTitle }
 					onMouseEnter={ this.onTitleEnter }
 					onMouseLeave={ this.onLeave }
@@ -213,6 +215,7 @@ class SocialMetadataPreviewForm extends Component {
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					type="description"
+					fieldId={ `${ socialMediumName.toLowerCase() }-description-input` }
 					label={ descEditorTitle }
 					onMouseEnter={ this.onDescriptionEnter }
 					onMouseLeave={ this.onLeave }

--- a/packages/social-metadata-forms/tests/ImageSelectTest.js
+++ b/packages/social-metadata-forms/tests/ImageSelectTest.js
@@ -10,6 +10,7 @@ describe( "The ImageSelect component", () => {
 			<ImageSelect
 				imageSelected={ false }
 				title="Facebook image"
+				socialMediumName="facebook"
 				isPremium={ true }
 			/>,
 		).toJSON();
@@ -22,6 +23,7 @@ describe( "The ImageSelect component", () => {
 				title="Facebook image"
 				imageSelected={ true }
 				isPremium={ false }
+				socialMediumName="twitter"
 				warnings={ [
 					"Your image is too small",
 					"Wow, I like writing tests",

--- a/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
+++ b/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
@@ -338,6 +338,7 @@ exports[`The ImageSelect component displays warnings 1`] = `
     <input
       className="c6"
       disabled="disabled"
+      id="undefined-url-input"
       value=""
     />
     <div
@@ -345,6 +346,7 @@ exports[`The ImageSelect component displays warnings 1`] = `
     >
       <button
         className="c8"
+        id="undefined-replace-button"
         onClick={[Function]}
         type="button"
       >
@@ -352,6 +354,7 @@ exports[`The ImageSelect component displays warnings 1`] = `
       </button>
       <button
         className="c9"
+        id="undefined-remove-button"
         onClick={[Function]}
         type="button"
       >
@@ -478,6 +481,7 @@ exports[`The ImageSelect component renders 1`] = `
   </div>
   <button
     className="c2"
+    id="undefined-select-button"
     onClick={[Function]}
     type="button"
   >

--- a/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
+++ b/packages/social-metadata-forms/tests/__snapshots__/ImageSelectTest.js.snap
@@ -338,7 +338,7 @@ exports[`The ImageSelect component displays warnings 1`] = `
     <input
       className="c6"
       disabled="disabled"
-      id="undefined-url-input"
+      id="twitter-url-input"
       value=""
     />
     <div
@@ -346,7 +346,7 @@ exports[`The ImageSelect component displays warnings 1`] = `
     >
       <button
         className="c8"
-        id="undefined-replace-button"
+        id="twitter-replace-button"
         onClick={[Function]}
         type="button"
       >
@@ -354,7 +354,7 @@ exports[`The ImageSelect component displays warnings 1`] = `
       </button>
       <button
         className="c9"
-        id="undefined-remove-button"
+        id="twitter-remove-button"
         onClick={[Function]}
         type="button"
       >
@@ -481,7 +481,7 @@ exports[`The ImageSelect component renders 1`] = `
   </div>
   <button
     className="c2"
-    id="undefined-select-button"
+    id="facebook-select-button"
     onClick={[Function]}
     type="button"
   >


### PR DESCRIPTION
## Summary
QA needs IDs on the inputs/button in order to use them in automated tests. This PR adds them for the Social Preview form in Free and Premium.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:
* [@yoast/social-metadata-forms] Adds IDs to the components for automated testing.

## Relevant technical choices:
* Non-userfacing: only adds IDs (in an unreleased package).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* Check that form elements in the social preview tab have IDs. They should be as follows.
**Facebook:**
- `facebook-replace-button` (only available after an image has been selected)
- `facebook-select-button` (only available before an image is selected)
- `facebook-remove-button` (only available after an image has been selected)
- `facebook-description-input`
- `facebook-title-input`
- `facebook-url-input`
**Twitter:**
- `twitter-replace-button` (only available after an image has been selected)
- `twitter-select-button` (only available before an image is selected)
- `twitter-remove-button` (only available after an image has been selected)
- `twitter-description-input`
- `twitter-title-input`
- `twitter-url-input`

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-24
