### PR TITLE
Define property Type on ReplacementVariableEditor

### DIFF
--- a/packages/search-metadata-previews/src/snippet-editor/SettingsSnippetEditorFields.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SettingsSnippetEditorFields.js
@@ -132,6 +132,7 @@ class SettingsSnippetEditorFields extends React.Component {
 				padding={ containerPadding }
 			>
 				<ReplacementVariableEditor
+					type="title"
 					label={ __( "SEO title", "yoast-components" ) }
 					onFocus={ () => onFocus( "title" ) }
 					onBlur={ onBlur }


### PR DESCRIPTION
The "type" property became required, so it should be set explicitly.

## Summary

This PR can be summarized in the following changelog entry:

* [non-user-facing] Fixes a React error in the development build

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://github.com/Yoast/wordpress-seo/issues/15459
