### PR TITLE
Use preview fallbacks and input placeholders

### DIFF
--- a/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
+++ b/packages/social-metadata-forms/src/SocialMetadataPreviewForm.js
@@ -153,8 +153,9 @@ class SocialMetadataPreviewForm extends Component {
 			onSelectImageClick,
 			onRemoveImageClick,
 			title,
+			titleInputPlaceholder,
 			description,
-			descriptionPlaceholder,
+			descriptionInputPlaceholder,
 			onTitleChange,
 			onDescriptionChange,
 			hoveredField,
@@ -193,6 +194,7 @@ class SocialMetadataPreviewForm extends Component {
 				<ReplacementVariableEditor
 					onChange={ onTitleChange }
 					content={ title }
+					placeholder={ titleInputPlaceholder }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					type="title"
@@ -209,7 +211,7 @@ class SocialMetadataPreviewForm extends Component {
 				<ReplacementVariableEditor
 					onChange={ onDescriptionChange }
 					content={ description }
-					placeholder={ descriptionPlaceholder }
+					placeholder={ descriptionInputPlaceholder }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					type="description"
@@ -245,7 +247,8 @@ SocialMetadataPreviewForm.propTypes = {
 	recommendedReplacementVariables: PropTypes.arrayOf( PropTypes.string ),
 	imageWarnings: PropTypes.array,
 	imageUrl: PropTypes.string,
-	descriptionPlaceholder: PropTypes.string,
+	titleInputPlaceholder: PropTypes.string,
+	descriptionInputPlaceholder: PropTypes.string,
 	setEditorRef: PropTypes.func,
 	onMouseHover: PropTypes.func,
 };
@@ -258,7 +261,8 @@ SocialMetadataPreviewForm.defaultProps = {
 	activeField: "",
 	onSelect: () => {},
 	imageUrl: "",
-	descriptionPlaceholder: "",
+	titleInputPlaceholder: "",
+	descriptionInputPlaceholder: "",
 	isPremium: false,
 	setEditorRef: () => {},
 	onMouseHover: () => {},

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -163,14 +163,14 @@ class SocialPreviewEditor extends Component {
 					onDescriptionChange={ onDescriptionChange }
 					socialMediumName={ socialMediumName }
 					title={ title }
-					titlePlaceholder={ titleInputPlaceholder }
+					titleInputPlaceholder={ titleInputPlaceholder }
 					onRemoveImageClick={ onRemoveImageClick }
 					imageSelected={ !! imageUrl }
 					imageUrl={ imageUrl }
 					onTitleChange={ onTitleChange }
 					onSelectImageClick={ onSelectImageClick }
 					description={ description }
-					descriptionPlaceholder={ descriptionInputPlaceholder }
+					descriptionInputPlaceholder={ descriptionInputPlaceholder }
 					imageWarnings={ imageWarnings }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }

--- a/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
+++ b/packages/social-metadata-previews/src/editor/SocialPreviewEditor.js
@@ -123,12 +123,14 @@ class SocialPreviewEditor extends Component {
 			siteUrl,
 			authorName,
 			description,
-			descriptionPlaceholder,
+			descriptionInputPlaceholder,
+			descriptionPreviewFallback,
 			imageUrl,
 			imageFallbackUrl,
 			alt,
 			title,
-			titlePlaceholder,
+			titleInputPlaceholder,
+			titlePreviewFallback,
 			replacementVariables,
 			recommendedReplacementVariables,
 			applyReplacementVariables,
@@ -136,11 +138,11 @@ class SocialPreviewEditor extends Component {
 			isLarge,
 		} = this.props;
 
-		// Preset a title fallback for the preview if title is empty.
-		const previewTitle = title === "" ? titlePlaceholder : title;
+		// Set fallbacks if title and/or description are empty.
+		const previewTitle = title || titlePreviewFallback;
+		const previewDescription = description || descriptionPreviewFallback;
 
-		const replacedVars = applyReplacementVariables( { title: previewTitle, description } );
-		const previewDescription = replacedVars.description === "" ? descriptionPlaceholder : replacedVars.description;
+		const replacedVars = applyReplacementVariables( { title: previewTitle, description: previewDescription } );
 
 		return (
 			<React.Fragment>
@@ -151,7 +153,7 @@ class SocialPreviewEditor extends Component {
 					siteUrl={ siteUrl }
 					authorName={ authorName }
 					title={ replacedVars.title }
-					description={ previewDescription }
+					description={ replacedVars.description }
 					imageUrl={ imageUrl }
 					imageFallbackUrl={ imageFallbackUrl }
 					alt={ alt }
@@ -161,13 +163,14 @@ class SocialPreviewEditor extends Component {
 					onDescriptionChange={ onDescriptionChange }
 					socialMediumName={ socialMediumName }
 					title={ title }
+					titlePlaceholder={ titleInputPlaceholder }
 					onRemoveImageClick={ onRemoveImageClick }
 					imageSelected={ !! imageUrl }
 					imageUrl={ imageUrl }
 					onTitleChange={ onTitleChange }
 					onSelectImageClick={ onSelectImageClick }
 					description={ description }
-					descriptionPlaceholder={ descriptionPlaceholder }
+					descriptionPlaceholder={ descriptionInputPlaceholder }
 					imageWarnings={ imageWarnings }
 					replacementVariables={ replacementVariables }
 					recommendedReplacementVariables={ recommendedReplacementVariables }
@@ -198,8 +201,10 @@ SocialPreviewEditor.propTypes = {
 	imageWarnings: PropTypes.array,
 	isLarge: PropTypes.bool,
 	siteUrl: PropTypes.string,
-	descriptionPlaceholder: PropTypes.string,
-	titlePlaceholder: PropTypes.string,
+	descriptionInputPlaceholder: PropTypes.string,
+	titleInputPlaceholder: PropTypes.string,
+	descriptionPreviewFallback: PropTypes.string,
+	titlePreviewFallback: PropTypes.string,
 	authorName: PropTypes.string,
 	replacementVariables: replacementVariablesShape,
 	recommendedReplacementVariables: recommendedReplacementVariablesShape,
@@ -213,8 +218,10 @@ SocialPreviewEditor.defaultProps = {
 	isPremium: false,
 	isLarge: true,
 	siteUrl: "",
-	descriptionPlaceholder: "",
-	titlePlaceholder: "",
+	descriptionInputPlaceholder: "",
+	titleInputPlaceholder: "",
+	descriptionPreviewFallback: "",
+	titlePreviewFallback: "",
 	alt: "",
 	authorName: "",
 	applyReplacementVariables: data => data,


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/social-metadata-forms] The SocialMetadaPreviewForm now accepts a placeholder for the title and description fields, as titleInputPlaceholder and descriptionInputPlaceholder, respectively.
* [@yoast/social-metadata-previews] The SocialPreviewEditor now accepts fallbacks for the title and description in the social preview, and placeholders for the title and description in the social input fields.

## Relevant technical choices:

* See https://github.com/Yoast/wordpress-seo/pull/15466

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Test together with https://github.com/Yoast/wordpress-seo/pull/15466 (free) and https://github.com/Yoast/wordpress-seo-premium/pull/2842 (premium)


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
