### PR TITLE
Add a dependency on the replacement variable editor in search metadata

### DIFF
--- a/packages/search-metadata-previews/package.json
+++ b/packages/search-metadata-previews/package.json
@@ -21,6 +21,7 @@
     "@yoast/components": "^2.5.0-rc.3",
     "@yoast/helpers": "^0.13.0-rc.3",
     "@yoast/style-guide": "^0.12.0-rc.3",
+    "@yoast/replacement-variable-editor": "1.0.0-rc.3",
     "draft-js": "^0.10.5",
     "draft-js-mention-plugin": "^3.0.4",
     "draft-js-plugins-editor": "^2.0.4",


### PR DESCRIPTION
## Summary
Without a dependency on the Replacement variable editor package, search metadata preview will not work without a linked monorepo.
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:
* [@yoast/search-metadata-previews] Fixes a bug where search-metadata-previews did not work when the monorepo was not linked.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* N/A