### PR TITLE
Remove react and react-dom aliases from content analysis app webpack config

### DIFF
--- a/apps/content-analysis/config/paths.js
+++ b/apps/content-analysis/config/paths.js
@@ -86,8 +86,6 @@ module.exports = {
 	yoastSpec: resolveApp( "../../packages/yoastseo/spec" ),
 	yoastPackages: resolveApp( "../../packages" ),
 	wpI18n: resolveApp( "node_modules/@wordpress/i18n" ),
-	react: resolveApp( "node_modules/react" ),
-	reactDom: resolveApp( "node_modules/react-dom" ),
 };
 
 

--- a/apps/content-analysis/config/webpack.config.js
+++ b/apps/content-analysis/config/webpack.config.js
@@ -292,10 +292,6 @@ module.exports = function( webpackEnv ) {
 				.map( ext => `.${ext}` )
 				.filter( ext => useTypeScript || ! ext.includes( "ts" ) ),
 			alias: {
-				// This prevents loading multiple versions of React:
-				react: paths.react,
-				"react-dom": paths.reactDom,
-
 				// This prevents multiple instances of i18n.
 				"@wordpress/i18n": paths.wpI18n,
 


### PR DESCRIPTION
Remove react and react-dom aliases in the webpack config of the content analysis app

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [n/a] Fixes an error in the content analysis app.

## Relevant technical choices:
(Summary of the issue props to Bram)
* The path to the react dependency was hardcoded to the local `node_modules/react`. This used to be fine because the react dependency wasn't hoisted, presumably because the same react version wasn't used anywhere else in the Javascript monorepo. What probably changed is that one of the other packages was upgraded to the same react version, resulting in lerna hoisting that package to the root. This is fine most of the times, since yarn will automatically check in higher directories to find dependencies. However, since the path was hardcoded in the content analysis webpack config, yarn wouldn't check in higher repositories, resulting in the error.
* It could be that the app starts to use a different react version when react is upgraded in an other package. But this would only apply for minor versions so that should not matter too much. Also, the app is only for internal use, so the consequences would be minor.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Go to `apps/content-analysis` and run `yarn` and `yarn start`. The content analysis app should open.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
