### PR TITLE
Always show enabled toggle right

### DIFF
--- a/packages/components/src/toggle/toggle.css
+++ b/packages/components/src/toggle/toggle.css
@@ -93,7 +93,8 @@ input[type=checkbox].yoast-toggle__checkbox:checked::before {
 	grid-row: 1;
 }
 
-.yoast-toggle--inactive {
+.yoast-toggle--inactive,
+.yoast-toggle--inverse .yoast-toggle--active {
 	grid-column: 1;
 }
 
@@ -105,7 +106,8 @@ input[type=checkbox].yoast-toggle__checkbox:checked::before {
 	grid-column: 2;
 }
 
-.yoast-toggle--active {
+.yoast-toggle--active,
+.yoast-toggle--inverse .yoast-toggle--inactive{
 	grid-column: 3;
 }
 
@@ -114,21 +116,16 @@ input[type=checkbox].yoast-toggle__checkbox:checked::before {
 	background-color: var(--yoast-color-active-light);
 }
 
-.yoast-toggle .yoast-toggle__checkbox:checked ~ .yoast-toggle__switch::before {
+.yoast-toggle .yoast-toggle__checkbox:checked ~ .yoast-toggle__switch::before,
+.yoast-toggle--inverse .yoast-toggle__checkbox:not(:checked) ~ .yoast-toggle__switch::before{
 	background-color: var(--yoast-color-active);
 	right: 0;
 	left: initial;
-}
-
-.yoast-toggle--inverse .yoast-toggle__checkbox:not(:checked) ~ .yoast-toggle__switch::before {
-	background-color: var(--yoast-color-active);
-	right: initial;
-	left: 0;
 }
 
 .yoast-toggle--inverse .yoast-toggle__checkbox:checked ~ .yoast-toggle__switch::before {
-	right: 0;
-	left: initial;
+	right: initial;
+	left: 0;
 }
 
 .yoast-toggle .yoast-toggle__checkbox ~ .yoast-toggle--inactive,


### PR DESCRIPTION
## Summary

This PR can be summarized in the following changelog entry:

* Flip the order of the labels for inverse toggles. To make sure the active state is always on the right.

## Relevant technical choices:

* N/A

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* [components] Light switch toggle; makes the inverse toggles have their active state point to the right as well. To ensure consistency.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Any settings toggle visual styles.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes FRO-158
