### PR TITLE
Remove the MentionSuggestion ref since this does not work

### DIFF
--- a/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
@@ -126,10 +126,8 @@ class ReplacementVariableEditorStandalone extends React.Component {
 		this.onChange = this.onChange.bind( this );
 		this.onSearchChange = this.onSearchChange.bind( this );
 		this.setEditorRef = this.setEditorRef.bind( this );
-		this.setMentionSuggestionsRef = this.setMentionSuggestionsRef.bind( this );
 		this.handleCopyCutEvent = this.handleCopyCutEvent.bind( this );
 		this.debouncedA11ySpeak = debounce( a11ySpeak.bind( this ), 500 );
-		this.debouncedUpdateMentionSuggestions = debounce( this.updateMentionSuggestions.bind( this ), 100 );
 	}
 
 	/**
@@ -321,15 +319,6 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	}
 
 	/**
-	 * Update the mention suggestions to trigger the repositioning of the popover.
-	 *
-	 * @returns {void}
-	 */
-	updateMentionSuggestions() {
-		this.mentionSuggestions.forceUpdate();
-	}
-
-	/**
 	 * Focuses the editor.
 	 *
 	 * @returns {void}
@@ -358,17 +347,6 @@ class ReplacementVariableEditorStandalone extends React.Component {
 		const editorField = get( this.editor, "editor.editor" );
 
 		editorField.id = this.props.fieldId;
-	}
-
-	/**
-	 * Sets the mention reference on this component instance.
-	 *
-	 * @param {Object} mentionSuggestions The mentionSuggestions React reference.
-	 *
-	 * @returns {void}
-	 */
-	setMentionSuggestionsRef( mentionSuggestions ) {
-		this.mentionSuggestions = mentionSuggestions;
 	}
 
 	/**
@@ -483,7 +461,6 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	 * @returns {void}
 	 */
 	componentDidMount() {
-		window.addEventListener( "scroll", this.debouncedUpdateMentionSuggestions );
 		document.addEventListener( "copy", this.handleCopyCutEvent );
 		document.addEventListener( "cut", this.handleCopyCutEvent );
 		this.setEditorFieldId();
@@ -496,7 +473,6 @@ class ReplacementVariableEditorStandalone extends React.Component {
 	 */
 	componentWillUnmount() {
 		this.debouncedA11ySpeak.cancel();
-		window.removeEventListener( "scroll", this.debouncedUpdateMentionSuggestions );
 		document.removeEventListener( "copy", this.handleCopyCutEvent );
 		document.removeEventListener( "cut", this.handleCopyCutEvent );
 	}
@@ -529,7 +505,6 @@ class ReplacementVariableEditorStandalone extends React.Component {
 					<MentionSuggestions
 						onSearchChange={ this.onSearchChange }
 						suggestions={ suggestions }
-						ref={ this.setMentionSuggestionsRef }
 					/>
 				</ZIndexOverride>
 			</React.Fragment>


### PR DESCRIPTION
React gives an error message that ref cannot be set on a functional component. As far as I can tell, this has never worked. I have tested the functionality of the mention plugin (it is the part that replaces %word%) and everything seems to work fine.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:
* [@yoast/replacement-variable-editor] Removes the ref from the mention plugin.

## Relevant technical choices:
* Refs do not work on functional components. It seems like this has never worked.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
1. Go to the social previews
2. Add a replacement variable via the button in the replacement variable editor. Make sure this works as expected (variable is added in a purple oval).
3. Save the page and see that the the variable is replaced on the frontend.
4. Go back to the social previews.
5. Add a replacement variable via typing. Typing `%` should trigger the popover. Try to add the variable by typing it completely and by selecting one via the popover.
6. Check that the variables are replaced on the frontend.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Check the Edit Snippet Preview functionality as well.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-45.
