### PR TITLE
Add Indonesian sentence beginning assessment

### DIFF
--- a/packages/yoastseo/spec/assessments/sentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/assessments/sentenceBeginningsSpec.js
@@ -52,6 +52,29 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!" );
 	} );
 
+	it( "scores one instance with 4 consecutive Indonesian sentences starting with the same word.", function() {
+		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "halo", count: 2 }, { word: "cangkir", count: 2 }, { word: "pisang", count: 1 },
+			{ word: "meja", count: 4 } ] ), i18n );
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: The text contains 4 consecutive sentences starting with the same word." +
+			" <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!" );
+	} );
+
+	it( "scores two instance with too many consecutive Indonesian sentences starting with the same word, 5 being the lowest count.", function() {
+		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "halo", count: 2 }, { word: "cangkir", count: 6 }, { word: "pisang", count: 1 },
+			{ word: "botol", count: 5 } ] ), i18n );
+		expect( assessment.getScore() ).toBe( 3 );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: " +
+			"The text contains 2 instances where 5 or more consecutive sentences start with the same word. <a href='https://yoa.st/35g' target='_blank'>Try to mix things up</a>!" );
+	} );
+
+	it( "scores zero instance with too many consecutive Indonesian sentences starting with the same word.", function() {
+		const assessment = sentenceBeginningsAssessment.getResult( paper, Factory.buildMockResearcher( [ { word: "halo", count: 1 }, { word: "pensil", count: 2 }, { word: "kopi", count: 2 },
+			{ word: "sofa", count: 1 } ] ), i18n );
+		expect( assessment.getScore() ).toBe( 9 );
+		expect( assessment.getText() ).toBe( "<a href='https://yoa.st/35f' target='_blank'>Consecutive sentences</a>: There is enough variety in your sentences. That's great!" );
+	} );
+
 	it( "is not applicable for a paper without text.", function() {
 		const assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "" ) );
 		expect( assessment ).toBe( false );

--- a/packages/yoastseo/spec/assessments/sentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/assessments/sentenceBeginningsSpec.js
@@ -160,6 +160,16 @@ describe( "An assessment for scoring repeated sentence beginnings.", function() 
 		expect( assessment ).toBe( true );
 	} );
 
+	it( "is not applicable for an Indonesian paper without text.", function() {
+		const assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "", { locale: "id_ID" } ) );
+		expect( assessment ).toBe( false );
+	} );
+
+	it( "is applicable for an Indonesian paper with text.", function() {
+		const assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "hai", { locale: "id_ID" } ) );
+		expect( assessment ).toBe( true );
+	} );
+
 	it( "is not applicable for a paper with text and a non-existing locale.", function() {
 		const assessment = sentenceBeginningsAssessment.isApplicable( new Paper( "hello", { locale: "xx_YY" } ) );
 		expect( assessment ).toBe( false );

--- a/packages/yoastseo/spec/helpers/getFirstWordExceptionsSpec.js
+++ b/packages/yoastseo/spec/helpers/getFirstWordExceptionsSpec.js
@@ -37,6 +37,10 @@ describe( "a test for getting the correct first word exception array", function(
 		expect( firstWordExceptions( "sv_SE" )() ).toEqual( [ "ett", "det", "den", "de", "en", "två", "tre", "fyra", "fem", "sex", "sju", "åtta", "nio", "tio", "denne", "denna", "detta", "dessa" ] );
 	} );
 
+	it( "returns the Indonesian first word exception array in case of id_ID locale", function() {
+		expect( firstWordExceptions( "id_ID" )() ).toEqual( [  "sebuah", "seorang", "sang", "si", "satu", "dua", "tiga", "empat", "lima", "enam", "tujuh", "delapan", "sembilan", "sepuluh", "sebelas", "seratus", "seribu", "sejuta", "semiliar", "setriliun", "ini", "itu", "hal", "ia" ] );
+	} );
+
 	it( "returns the English first word exception array in case of empty locale", function() {
 		expect( firstWordExceptions( "" )() ).toEqual( [ "the", "a", "an", "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten", "this", "that", "these", "those" ] );
 	} );

--- a/packages/yoastseo/spec/researches/getSentenceBeginningsSpec.js
+++ b/packages/yoastseo/spec/researches/getSentenceBeginningsSpec.js
@@ -286,6 +286,26 @@ describe( "gets the sentence beginnings and the count of consecutive duplicates.
 		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
 	} );
 
+	it( "returns an object with sentence beginnings and counts for two sentences in Indonesian starting with different words.", function() {
+		changePaper( { text: "Halo dunia!. Apa kabarmu? ", locale: "id_ID" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "halo" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 1 );
+		expect( getSentenceBeginnings()[ 1 ].word ).toBe( "apa" );
+		expect( getSentenceBeginnings()[ 1 ].count ).toBe( 1 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for two sentences in Indonesian starting with the same word.", function() {
+		changePaper( { text: "Bukunya murah. Bukunya mahal.", locale: "id_ID" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "bukunya" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 2 );
+	} );
+
+	it( "returns an object with sentence beginnings and counts for three sentences in Indonesian all starting with one of the exception words.", function() {
+		changePaper( { text: "Seorang pemimpin seharusnya bijaksana. Seorang pemimpin seharusnya memberi contoh yang baik. Seorang pemimpin seharusnya memikirkan rakyatnya", locale: "id_ID" } );
+		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "seorang pemimpin" );
+		expect( getSentenceBeginnings()[ 0 ].count ).toBe( 3 );
+	} );
+
 	it( "returns an object with English sentence beginnings in lists", function() {
 		changePaper( { text: "<ul><li>item 1</li><li>item 2</li><li>item 3</li><li>item 4</li></ul>" } );
 		expect( getSentenceBeginnings()[ 0 ].word ).toBe( "item", { locale: "en_US" } );

--- a/packages/yoastseo/src/assessments/readability/sentenceBeginningsAssessment.js
+++ b/packages/yoastseo/src/assessments/readability/sentenceBeginningsAssessment.js
@@ -9,7 +9,7 @@ import Mark from "../../values/Mark";
 const maximumConsecutiveDuplicates = 2;
 
 import getLanguageAvailability from "../../helpers/getLanguageAvailability.js";
-const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru", "pl", "sv", "pt" ];
+const availableLanguages = [ "en", "de", "es", "fr", "nl", "it", "ru", "pl", "sv", "pt", "id" ];
 
 /**
  * Counts and groups the number too often used sentence beginnings and determines the lowest count within that group.

--- a/packages/yoastseo/src/helpers/getFirstWordExceptions.js
+++ b/packages/yoastseo/src/helpers/getFirstWordExceptions.js
@@ -8,6 +8,7 @@ import firstWordExceptionsRussian from "../researches/russian/firstWordException
 import firstWordExceptionsPolish from "../researches/polish/firstWordExceptions.js";
 import firstWordExceptionsSwedish from "../researches/swedish/firstWordExceptions.js";
 import firstWordExceptionsPortuguese from "../researches/portuguese/firstWordExceptions.js";
+import firstWordExceptionsIndonesian from "../researches/indonesian/firstWordExceptions.js";
 import getLanguage from "./getLanguage.js";
 
 /**
@@ -29,6 +30,7 @@ export default function( locale ) {
 		pl: firstWordExceptionsPolish,
 		sv: firstWordExceptionsSwedish,
 		pt: firstWordExceptionsPortuguese,
+		id: firstWordExceptionsIndonesian,
 	};
 
 	// If available, return the language-specific first word exceptions.

--- a/packages/yoastseo/src/researches/indonesian/firstWordExceptions.js
+++ b/packages/yoastseo/src/researches/indonesian/firstWordExceptions.js
@@ -1,0 +1,15 @@
+/**
+ * Returns an array with exceptions for the sentence beginning researcher.
+ * @returns {Array} The array filled with exceptions.
+ */
+export default function() {
+	return [
+		// Indefinite articles:
+		"sebuah", "seorang", "sang", "si",
+		// Numbers 1-10:
+		"satu", "dua", "tiga", "empat", "lima", "enam", "tujuh", "delapan", "sembilan",
+		"sepuluh", "sebelas", "seratus", "seribu", "sejuta", "semiliar", "setriliun",
+		// Demonstrative pronouns:
+		"ini", "itu", "hal", "ia",
+	];
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Implements the sentence beginning assessment that checks whether multiple sentences begin with the same word in Indoensian.
* [Yoast SEO Free] Adds the assessment that checks whether multiple sentences begin with the same word for Indonesian.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* run yarn test and make sure that all tests pass. 

## QA test Instructions
* In your WordPress testing environment, set the language to Indonesian.
* Open a new post or page.
* Write three or more Indonesian sentences for which the sentence beginning readability assessment should read: `Consecutive sentences: There is enough variety in your sentences. That's great!`

  Examples are sentences like the followings: 
    * sentences that all begin with the same written-out number, like `satu` (one), `dua` (two) or `enam` (six).
    * E.g. `Enam orang memakai baju yang sama. Enam laki-laki duduk bersama-sama. Enam politikus  berbincang 
       tentang politik. Enam aktivis mengkritik pemerintah.`
    * sentences that all begin with the same demonstrative pronoun, like `ini` or `itu`.
    * E.g. `Itu adalah sebuah hal yang menarik. Itu merupakan kebahagian yang hakiki. Itu adalah kesalahan yang 
       terindah.`
    * sentences that all begin with the same indefinite article, like `si`.
    * E.g. `Si kecil harus mendapatkan perhatian yang cukup. Si anak diajari untuk saling menghormati sesama. Si kecil 
      lebih baik mendapatkan kasih sayang yang melimpah.`
    * sentences that begins with three different words.
    * E.g. `Selamat datang!. Silakan memilih produk yang Anda inginkan. Setelah itu Anda bisa klik 'bayar sekarang'`.

 * Write three or more Indonesian sentences that begin with the same word for which the sentence beginning readability assessment should read: `Consecutive sentences: The text contains 3 consecutive sentences starting with the same word. Try to mix things up!`

 * E.g. `Rumahnya mewah. Rumahnya nyaman. Rumahnya mahal.`
## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-482
