### PR TITLE
P1-42 Fix choice component fragment key

### DIFF
--- a/packages/configuration-wizard/src/Choice.js
+++ b/packages/configuration-wizard/src/Choice.js
@@ -64,7 +64,7 @@ const Choice = ( props ) => {
 					const checked = ( props.value === choiceName );
 
 					return (
-						<Fragment key="fragment">
+						<Fragment key={ id }>
 							<Input
 								name={ fieldName } type="radio" label={ choice.label } onChange={ props.onChange }
 								value={ choiceName } optionalAttributes={ { id, checked } } className={ "visually-hidden" }

--- a/packages/configuration-wizard/src/Choice.js
+++ b/packages/configuration-wizard/src/Choice.js
@@ -64,7 +64,7 @@ const Choice = ( props ) => {
 					const checked = ( props.value === choiceName );
 
 					return (
-						<Fragment key={ id }>
+						<Fragment key={ `${ id }-key` }>
 							<Input
 								name={ fieldName } type="radio" label={ choice.label } onChange={ props.onChange }
 								value={ choiceName } optionalAttributes={ { id, checked } } className={ "visually-hidden" }


### PR DESCRIPTION
This fixes the following error: Warning: Encountered two children with the same key, `fragment`.

## Summary
<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/configuraton-wizard] Adds a unique key to the `Fragment` in `Choice` to fix a React Warning.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
1. :fire:-up the example components app
2. Check out the `release/14.6` branch
3. Go the `Wizard` tab and click continue until you are at step 9: `Title Settings`
4. Check your console. See that React is complaining about the duplicate usage of the key `fragment`
5. Checkout this nice little branch
6. Reload the page
7. Go the `Wizard` tab and click continue until you are at step 9: `Title Settings`
8. Check the console. See that React is happy about the key usage.

## Quality assurance

* [x] I have tested this code to the best of my abilities