### PR TITLE
Remove the border-bottom and margin-top from Collapsible

### DIFF
--- a/packages/components/src/Collapsible.js
+++ b/packages/components/src/Collapsible.js
@@ -21,8 +21,6 @@ export const StyledContainer = styled.div`
 
 export const StyledContainerTopLevel = styled( StyledContainer )`
 	border-top: 1px solid rgba( 0,0,0,0.2 );
-	border-bottom: 1px solid rgba( 0,0,0,0.2 );
-	margin-top: -1px;
 `;
 
 export const StyledIconsButton = styled( IconsButton )`


### PR DESCRIPTION
The margin-top was a hack that prevented two borders from showing up when the collapsible were collapsed. With the changes to the tab container, this is no longer necessary.

The outermost border is now added by the container, while the border top ensures that the collapsibles have a border when collapsed.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:
* [@yoast/components] Remove border-bottom and margin-top hack from the collapsible.

## Relevant technical choices:
* We are adding the border bottom on the metabox container.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:
* See for https://github.com/Yoast/wordpress-seo/pull/15624 instructions.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-54
