### PR TITLE
Add handling for small prop

### DIFF
--- a/apps/components/ReactifiedComponentsWrapper.js
+++ b/apps/components/ReactifiedComponentsWrapper.js
@@ -22,20 +22,38 @@ function clickerDiClick() {
 }
 
 const buttonGrouping = <Fragment>
-	<h3>Buttons</h3>
+	<h3>"primary" variant (default)</h3>
 	<Button onClick={ clickerDiClick } title="Testing whether other props are also passed, like this tooltip">Default button</Button>
 	<Button variant="primary" onClick={ clickerDiClick }>Primary button</Button>
+	<Button variant="primary" disabled={ true } onClick={ clickerDiClick }>Primary disabled button</Button>
+	<Button variant="primary" small={ true } onClick={ clickerDiClick }>Primary small button</Button>
+	<Button variant="primary" small={ true } disabled={ true } onClick={ clickerDiClick }>Primary small disabled button</Button>
+	<ButtonStyledLink variant="primary" href={ "#" }>Primary link</ButtonStyledLink>
+	<ButtonStyledLink variant="primary" small={ true } href={ "#" }>Primary small link</ButtonStyledLink>
+
+	<h3>"secondary" variant</h3>
 	<Button variant="secondary" onClick={ clickerDiClick }>Secondary button</Button>
+	<Button variant="secondary" disabled={ true } onClick={ clickerDiClick }>Secondary disabled button</Button>
+	<Button variant="secondary" small={ true } onClick={ clickerDiClick }>Secondary small button</Button>
+	<Button variant="secondary" small={ true }  disabled={ true } onClick={ clickerDiClick }>Secondary small disabled button</Button>
+	<ButtonStyledLink variant="secondary" href={ "#" }>Secondary link</ButtonStyledLink>
+	<ButtonStyledLink variant="secondary" small={ true } href={ "#" }>Secondary small link</ButtonStyledLink>
+
+	<h3>"buy" variant (or "upsell")</h3>
 	<Button variant="upsell" onClick={ clickerDiClick }>Buy button</Button>
+	<Button variant="upsell" disabled={ true } onClick={ clickerDiClick }>Buy disabled button</Button>
+	<Button variant="upsell" small={ true } onClick={ clickerDiClick }>Buy small button</Button>
+	<Button variant="upsell" small={ true } disabled={ true } onClick={ clickerDiClick }>Buy small disabled button</Button>
+	<ButtonStyledLink variant="upsell" href="#">Buy Link</ButtonStyledLink>
+	<ButtonStyledLink variant="upsell" small={ true } href="#">Buy small Link</ButtonStyledLink>
+
+	<h3>"hide" and "remove" variants</h3>
 	<Button variant="hide" onClick={ clickerDiClick }>Hide button</Button>
 	<Button variant="remove" onClick={ clickerDiClick }>Remove button</Button>
-	<h3>Links</h3>
-	<ButtonStyledLink variant="primary" href={ "#" }>Primary link</ButtonStyledLink>
-	<ButtonStyledLink variant="secondary" href={ "#" }>Secondary link</ButtonStyledLink>
-	<ButtonStyledLink variant="upsell" href="#">Buy Link</ButtonStyledLink>
 	<ButtonStyledLink variant="hide" href="#">Hide Link</ButtonStyledLink>
 	<ButtonStyledLink variant="remove" href="#">Remove Link</ButtonStyledLink>
-	<h3>Icons</h3>
+
+	<h3>CloseButton (not a variant due its different characteristics)</h3>
 	<CloseButton onClick={ clickerDiClick } />
 </Fragment>;
 
@@ -48,21 +66,14 @@ const ReactifiedComponentsWrapper = () => {
 	return (
 		<div className="yoast">
 
-			<h2>Buttons</h2>
-			<h3>Row</h3>
+			<h2>Buttons and ButtonStyledLinks</h2>
+			<p>
+				The buttons come in some variants, and can be a Button or a link styled as a button.
+				They can also be big, or small, and can contain icons before and/or after.
+				They also pass regular props, like disabled for buttons.
+			</p>
 			<div
 				style={ {
-					padding: "24px",
-				} }
-			>
-				{ buttonGrouping }
-			</div>
-
-			<h3>Column</h3>
-			<div
-				style={ {
-					display: "flex",
-					flexDirection: "column",
 					padding: "24px",
 				} }
 			>

--- a/packages/components/src/button/Button.js
+++ b/packages/components/src/button/Button.js
@@ -32,10 +32,17 @@ const variantToClassName = {
  * A function that looks up the correct className that belongs to a certain variant.
  *
  * @param {string} variant The variant for which to lookup the className.
+ * @param {Boolean} small  Whether or we should return the small variant of a button.
  *
  * @returns {string} The className that contains the css for the requested variant.
  */
-const getClassName = variant => variantToClassName[ variant ];
+const getClassName = ( variant, small ) => {
+	let className = variantToClassName[ variant ];
+	if ( small ) {
+		className += " yoast-button--small";
+	}
+	return className;
+};
 
 /**
  * A function that looks up the correct icons that belong to a certain variant.
@@ -66,6 +73,7 @@ export const Button = ( props ) => {
 		children,
 		className,
 		variant,
+		small,
 		type,
 		...restProps
 	} = props;
@@ -75,7 +83,7 @@ export const Button = ( props ) => {
 	const iconAfter = variantIcons && variantIcons.iconAfter;
 
 	return <button
-		className={ className || getClassName( variant ) }
+		className={ className || getClassName( variant, small ) }
 		type={ type }
 		{ ...restProps }
 	>
@@ -89,6 +97,7 @@ Button.propTypes = {
 	onClick: PropTypes.func,
 	type: PropTypes.string,
 	className: PropTypes.string,
+	small: PropTypes.bool,
 	variant: PropTypes.oneOf( Object.keys( variantToClassName ) ),
 	children: PropTypes.oneOfType(
 		[
@@ -102,6 +111,7 @@ Button.defaultProps = {
 	className: "",
 	type: "button",
 	variant: "primary",
+	small: false,
 	children: null,
 	onClick: null,
 };
@@ -123,6 +133,7 @@ export const ButtonStyledLink = ( props ) => {
 		children,
 		className,
 		variant,
+		small,
 		...restProps
 	} = props;
 
@@ -131,7 +142,7 @@ export const ButtonStyledLink = ( props ) => {
 	const iconAfter = variantIcons && variantIcons.iconAfter;
 
 	return <a
-		className={ className || getClassName( variant ) }
+		className={ className || getClassName( variant, small ) }
 		{ ...restProps }
 	>
 		{ ! ! iconBefore && <span className={ iconBefore } /> }
@@ -143,6 +154,7 @@ export const ButtonStyledLink = ( props ) => {
 ButtonStyledLink.propTypes = {
 	href: PropTypes.string.isRequired,
 	variant: PropTypes.oneOf( Object.keys( variantToClassName ) ),
+	small: PropTypes.bool,
 	className: PropTypes.string,
 	children: PropTypes.oneOfType(
 		[
@@ -155,5 +167,6 @@ ButtonStyledLink.propTypes = {
 ButtonStyledLink.defaultProps = {
 	className: "",
 	variant: "primary",
+	small: false,
 	children: null,
 };

--- a/packages/components/tests/button/ButtonsTest.js
+++ b/packages/components/tests/button/ButtonsTest.js
@@ -33,6 +33,38 @@ describe( "Button", () => {
 		expect( result.type ).toBe( "button" );
 	} );
 
+	it( "should render a small button based on the provided 'small' prop", () => {
+		shallowRenderer.render(
+			<Button
+				onClick={ ()=>{} }
+				id="very-nice-id"
+				variant="buy"
+				small={ true }
+			/>
+		);
+
+		const result = shallowRenderer.getRenderOutput();
+
+		expect( result ).toBeDefined();
+		expect( result.props.className ).toBe( "yoast-button yoast-button--buy yoast-button--small" );
+	} );
+
+	it( "should render a small button based on the provided 'disabled' prop", () => {
+		shallowRenderer.render(
+			<Button
+				onClick={ ()=>{} }
+				id="very-nice-id"
+				variant="secondary"
+				disabled={ true }
+			/>
+		);
+
+		const result = shallowRenderer.getRenderOutput();
+
+		expect( result ).toBeDefined();
+		expect( result.props.className ).toBe( "yoast-button yoast-button--secondary" );
+	} );
+
 	it( "generates an error if wrong props are provided", () => {
 		console.error = jest.genMockFn();
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Passing a "small" prop (boolean) to the Button and ButtonStyledLink components will render a variant with a lower profile.

## Relevant technical choices:

* Devteam special projects required lower profile buttons that could be disabled. The styling for this was added by the frontend team in https://github.com/Yoast/javascript/pull/759.
* To get the smaller styling we need to add `yoast-button--small` to the classNames. I was doubting whether we should add more variants (e.g. `secondarySmall` ) and map them to classNames with small included, or use a `small` prop that (when `true`) would add the small class.

The choice is then, what is more intuitive for the programmer:
`<Button variant="upsellSmall" />` with a bigger `variantToClassName` object
```js
	const variantToClassName = {
		primary: buttonClasses + "primary",
		primarySmall: buttonClasses + "primary yoast-button--small",
		secondary: buttonClasses + "secondary",
		secondarySmall: buttonClasses + "secondary yoast-button--small",
...
```

Or

`<Button variant="upsell" small={ true } />` with a neater `variantToClassName`:
```js
	const variantToClassName = {
		primary: buttonClasses + "primary",
		secondary: buttonClasses + "secondary",
...
```
In the end I felt the prop way was more intuitive so I went with that. Let me know what you think in the comments 😅 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout branch and see the ReactifiedComponents tab in the components app. Also check the code to see whether you think it's intuitive.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-50
