### PR TITLE
Same color for placeholder in title and description inputs

### DIFF
--- a/packages/replacement-variable-editor/src/shared.js
+++ b/packages/replacement-variable-editor/src/shared.js
@@ -3,10 +3,20 @@ import { getDirectionalStyle } from "@yoast/helpers";
 import { colors } from "@yoast/style-guide";
 import { Button, VariableEditorInputContainer } from "@yoast/components";
 
+const greyPlaceholderColor = "#707070";
+
 export const TitleInputContainer = styled( VariableEditorInputContainer )`
 	.public-DraftStyleDefault-block {
 		// Don't use properties that trigger hasLayout in IE11.
 		line-height: 24px;
+	}
+
+	.public-DraftEditorPlaceholder-root {
+		color: ${greyPlaceholderColor};
+	}
+
+	.public-DraftEditorPlaceholder-hasFocus {
+		color: ${greyPlaceholderColor};
 	}
 `;
 
@@ -16,12 +26,12 @@ export const DescriptionInputContainer = styled( VariableEditorInputContainer )`
 	line-height: 24px;
 
 	.public-DraftEditorPlaceholder-root {
-		color: ${colors.$color_grey_text};
+		color: ${greyPlaceholderColor};
 		position: absolute;
 	}
 
 	.public-DraftEditorPlaceholder-hasFocus {
-		color: ${colors.$color_grey_text};
+		color: ${greyPlaceholderColor};
 		position: absolute;
 	}
 `;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/replacement-variable-editor] Fixes a bug where the placeholder text in the title input field was a different color than the one in the description input field.

## Relevant technical choices:

* Hard coded the `#707070` color to the settings, as that is the color the `var( --yoast-inactive-test )` has in the `:root` of wordpress-seo, but we cannot be sure that is available.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Link `wordpress-seo` on `release/14.6`.
* Go to the social tab (there is no placeholder in the Snippet Editor title input).
* Clear any input in the social title and social preview, and verify that the placeholders have the same color.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-64
