### PR TITLE
P1 76 Fix site url in social preview

### DIFF
--- a/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
+++ b/packages/search-metadata-previews/src/snippet-editor/SnippetEditor.js
@@ -417,7 +417,7 @@ class SnippetEditor extends React.Component {
 		// Strip multiple spaces and spaces at the beginning and end.
 		description = string.stripSpaces( description );
 
-		const shortenedBaseUrl = baseUrl.replace( /^http:\/\//i, "" );
+		const shortenedBaseUrl = baseUrl.replace( /^https?:\/\//i, "" );
 
 		const mappedData = {
 			title: this.processReplacementVariables( originalData.title, replacementVariables ),


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/search-metadata-previews] Fixes a bug where the Google and social previews would not strip the HTTPS protocol.
* [Yoast SEO Free] Fixes a bug where the Google preview would incorrectly show `https://` on the URL when using the HTTPS protocol.
* [non-user-facing] Fixes an unreleased bug where the Facebook and Twitter preview would only show `HTTPS:` as URL when using the HTTPS protocol.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test with premium `release/14.6`.
* You should either have a test site that is on the https protocol or you can edit `admin/formatter/class-post-metabox-formatter.php` on line 56. Change the line to:
  * `'base_url'            => str_replace( 'http://', 'https://', $this->base_url_for_js() ),`
* Edit a post.
* Check the Google preview.
  * There should no longer be a `https://` part in front of the url in the preview.
* Check the social previews: Facebook and Twitter.
  * There should no longer be just `HTTPS:` in the preview.

### Screenshots
Before
<img width="420" alt="googlepreview-before" src="https://user-images.githubusercontent.com/35524806/87532658-c244c380-c693-11ea-9f4c-986526dad28d.png">
After
<img width="409" alt="googlepreview-after" src="https://user-images.githubusercontent.com/35524806/87532879-13ed4e00-c694-11ea-9cfb-9b960dbda5aa.png">

Before
<img width="224" alt="facebookpreview-before" src="https://user-images.githubusercontent.com/35524806/87532665-c670e100-c693-11ea-857a-1cef5d0129c0.png">
After
<img width="380" alt="facebookpreview-after" src="https://user-images.githubusercontent.com/35524806/87532945-2cf5ff00-c694-11ea-8396-0d1706e8aad3.png">

Before
<img width="133" alt="twitterpreview-before" src="https://user-images.githubusercontent.com/35524806/87532669-c83aa480-c693-11ea-8525-9e3ab996b6de.png">
After
<img width="343" alt="twitterpreview-after" src="https://user-images.githubusercontent.com/35524806/87532953-31221c80-c694-11ea-8ad8-162785eb916e.png">

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-76
