### PR TITLE
Make the post label fit in container

### DIFF
--- a/packages/yoast-components/composites/LinkSuggestions/LinkSuggestion.js
+++ b/packages/yoast-components/composites/LinkSuggestions/LinkSuggestion.js
@@ -35,6 +35,10 @@ const Link = makeOutboundLink( styled.a`
 ` );
 
 const Badge = styled.span`
+	max-width: 75px;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	text-align: center;
 	display: block;
 	padding: 3px 8px;

--- a/packages/yoast-components/composites/LinkSuggestions/LinkSuggestion.js
+++ b/packages/yoast-components/composites/LinkSuggestions/LinkSuggestion.js
@@ -30,6 +30,7 @@ const LinkSuggestionIcon = styled.button`
 `;
 
 const Link = makeOutboundLink( styled.a`
+	max-width: 128px;
 	padding: 6px 0;
 	margin-right: 8px;
 ` );

--- a/packages/yoast-components/composites/LinkSuggestions/LinkSuggestion.js
+++ b/packages/yoast-components/composites/LinkSuggestions/LinkSuggestion.js
@@ -21,7 +21,7 @@ const LinkSuggestionIcon = styled.button`
 	border-radius: 5px;
 	cursor: pointer;
 	outline:none;
-	margin-right: 5px;
+	margin-right: 8px;
 	border: 1px solid ${ colors.$color_button_border };
 
 	&:focus {
@@ -31,21 +31,15 @@ const LinkSuggestionIcon = styled.button`
 
 const Link = makeOutboundLink( styled.a`
 	padding: 6px 0;
-	margin-right: 5px;
+	margin-right: 8px;
 ` );
 
 const Badge = styled.span`
-	min-width: 32px;
-	max-width: 64px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
 	text-align: center;
-
 	display: block;
 	padding: 3px 8px;
 	margin-left: auto;
-	font-size: 0.9em;
+	font-size: 0.85em;
 	background-color: #f3f4f5;
 	border-radius: 2px;
 `;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* N/A - Not released yet. Fixes a bug where the text in the label is cut off and won't fit its container. 

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test this together with Yoast SEO Premium (`release/14.7`)


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
* Link the monorepo and build all files
* Visit a post and see 
* Check the link suggestions in the document sidebar. They should look something like this:
![Edit_Page_‹_Basic_—_WordPress](https://user-images.githubusercontent.com/325040/88032985-0c6bf000-cb3f-11ea-9940-7767532822a1.png)
* Check the link suggestions in the Yoast SEO sidebar. They should look the same and short post type labels should not be cut off (for example `P...` for posts).


## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
