### PR TITLE
Fix inconsistency in feedback strings in the Keyphrase in Title assessment

### DIFF
--- a/packages/yoastseo/spec/assessments/TitleKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/assessments/TitleKeywordAssessmentSpec.js
@@ -88,7 +88,7 @@ describe( "an assessment to check if the keyword is in the pageTitle", function(
 		expect( assessment.getScore() ).toBe( 2 );
 		expect( assessment.getText() ).toBe(
 			"<a href='https://yoa.st/33g' target='_blank'>Keyphrase in title</a>: Does not contain the exact match. " +
-			"<a href='https://yoa.st/33h' target='_blank'>Try to write the exact match of your keyphrase in the SEO title and put the keyphrase at the beginning of the title</a>."
+			"<a href='https://yoa.st/33h' target='_blank'>Try to write the exact match of your keyphrase in the SEO title and put it at the beginning of the title</a>."
 		);
 	} );
 

--- a/packages/yoastseo/src/assessments/seo/TitleKeywordAssessment.js
+++ b/packages/yoastseo/src/assessments/seo/TitleKeywordAssessment.js
@@ -150,7 +150,7 @@ class TitleKeywordAssessment extends Assessment {
 					i18n.dgettext(
 						"js-text-analysis",
 						"%1$sKeyphrase in title%3$s: Does not contain the exact match. %2$sTry to write the exact match of " +
-						"your keyphrase in the SEO title and put the keyphrase at the beginning of the title%3$s."
+						"your keyphrase in the SEO title and put it at the beginning of the title%3$s."
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,


### PR DESCRIPTION


## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Fixes inconsistency in feedback strings that are produced by the Keyphrase in SEO Title assessment.
* [Yoast SEO Free] Fixes inconsistency in feedback strings that are produced by the Keyphrase in SEO Title assessment.

## Relevant technical choices:

* I've also updated [the wiki page](https://github.com/Yoast/javascript/wiki/Scoring-SEO-analysis#8-page-title-keyword-assessment) to reflect this change.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use a keyphrase that is enclosed in quotation marks (e.g., `"cats and dogs"`)
* Use an SEO title that does not contain an exact match of the keyphrase (e.g., `Dogs and cats`)
* The Keyphrase in Title assessment should return `Keyphrase in title: Does not contain the exact match. Try to write the exact match of your keyphrase in the SEO title and put it at the beginning of the title.`

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
