### PR TITLE
Add hasError prop to KeywordInput component.

### DIFF
--- a/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
+++ b/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
@@ -187,7 +187,7 @@ class KeywordInput extends React.Component {
 	 * @returns {ReactElement} The KeywordField react component including its label and eventual error message.
 	 */
 	render() {
-		const { id, showLabel, keyword, onRemoveKeyword, onBlurKeyword, onFocusKeyword } = this.props;
+		const { id, showLabel, keyword, onRemoveKeyword, onBlurKeyword, onFocusKeyword, hasError } = this.props;
 		const showErrorMessage = this.checkKeywordInput( keyword );
 
 		// The aria label should not be shown if there is a visible label.
@@ -205,7 +205,7 @@ class KeywordInput extends React.Component {
 						aria-label={ showAriaLabel ? this.props.label : null }
 						type="text"
 						id={ id }
-						className={ showErrorMessage ? "has-error" : null }
+						className={ ( showErrorMessage || hasError ) ? "has-error" : null }
 						onChange={ this.handleChange }
 						onFocus={ onFocusKeyword }
 						onBlur={ onBlurKeyword }
@@ -238,6 +238,7 @@ KeywordInput.propTypes = {
 	onFocusKeyword: PropTypes.func,
 	label: PropTypes.string.isRequired,
 	helpLink: PropTypes.node,
+	hasError: PropTypes.bool,
 };
 
 KeywordInput.defaultProps = {
@@ -247,6 +248,7 @@ KeywordInput.defaultProps = {
 	onBlurKeyword: noop,
 	onFocusKeyword: noop,
 	helpLink: null,
+	hasError: false,
 };
 
 export default KeywordInput;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Adds a `hasError` prop to the KeywordInput component

## Relevant technical choices:

- this PR is needed for https://yoast.atlassian.net/browse/P3-63
- the new `hasError` prop can be used to style the input field when there's an error e.g. no keyphrase has been entered

## Test instructions
- please refer to the test instructions for https://yoast.atlassian.net/browse/P3-63

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-63]
