### PR TITLE
P3-91 update error styling of keyphrase input

### DIFF
--- a/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
+++ b/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
@@ -43,6 +43,10 @@ const KeywordField = styled( InputField )`
 	&.has-error {
 		border-color: ${ errorColor } !important;
 		background-color: ${ backgroundErrorColor } !important;
+
+		&:focus {
+			box-shadow: 0 0 2px ${ errorColor } !important;
+		}
 	}
 `;
 

--- a/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
+++ b/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
@@ -188,7 +188,7 @@ class KeywordInput extends React.Component {
 	 * @returns {ReactElement} The KeywordField react component including its label and eventual error message.
 	 */
 	render() {
-		const { id, showLabel, keyword, onRemoveKeyword, onBlurKeyword, onFocusKeyword } = this.props;
+		const { id, showLabel, keyword, onRemoveKeyword, onBlurKeyword, onFocusKeyword, hasError } = this.props;
 		const showErrorMessage = this.checkKeywordInput( keyword );
 
 		// The aria label should not be shown if there is a visible label.
@@ -206,7 +206,7 @@ class KeywordInput extends React.Component {
 						aria-label={ showAriaLabel ? this.props.label : null }
 						type="text"
 						id={ id }
-						className={ showErrorMessage ? "has-error" : null }
+						className={ ( showErrorMessage || hasError ) ? "has-error" : null }
 						onChange={ this.handleChange }
 						onFocus={ onFocusKeyword }
 						onBlur={ onBlurKeyword }
@@ -239,6 +239,7 @@ KeywordInput.propTypes = {
 	onFocusKeyword: PropTypes.func,
 	label: PropTypes.string.isRequired,
 	helpLink: PropTypes.node,
+	hasError: PropTypes.bool,
 };
 
 KeywordInput.defaultProps = {
@@ -248,6 +249,7 @@ KeywordInput.defaultProps = {
 	onBlurKeyword: noop,
 	onFocusKeyword: noop,
 	helpLink: null,
+	hasError: false,
 };
 
 export default KeywordInput;

--- a/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
+++ b/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
@@ -10,7 +10,8 @@ import { addFocusStyle, SvgIcon, InputField } from "@yoast/components";
 import { getDirectionalStyle } from "@yoast/helpers";
 import { colors } from "@yoast/style-guide";
 
-const errorColor = colors.$color_red;
+const errorColor = colors.$color_bad;
+const backgroundErrorColor = colors.$palette_error_background;
 const greyColor = colors.$color_grey_text_light;
 
 const KeywordInputContainer = styled.div`
@@ -41,7 +42,7 @@ const KeywordField = styled( InputField )`
 
 	&.has-error {
 		border-color: ${ errorColor } !important;
-		box-shadow: 0 0 2px ${ errorColor } !important;
+		background-color: ${ backgroundErrorColor } !important;
 	}
 `;
 

--- a/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
+++ b/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
@@ -79,7 +79,7 @@ BorderlessButton.propTypes = {
 BorderlessButton.defaultProps = {
 	type: "button",
 	focusColor: colors.$color_button_text_hover,
-	focusBackgroundColor: colors.$color_white,
+	focusBackgroundColor: "transparent",
 	focusBorderColor: colors.$color_blue,
 };
 

--- a/packages/yoast-components/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
@@ -22,7 +22,7 @@ exports[`KeywordInput matches the snapshot by default 1`] = `
   outline: none;
   border-color: #0066cd;
   color: #000;
-  background-color: #fff;
+  background-color: transparent;
   box-shadow: 0 0 3px rgba( 8,74,103,0.8 );
 }
 
@@ -76,6 +76,10 @@ exports[`KeywordInput matches the snapshot by default 1`] = `
 .c5.has-error {
   border-color: #dc3232 !important;
   background-color: #f9dcdc !important;
+}
+
+.c5.has-error:focus {
+  box-shadow: 0 0 2px #dc3232 !important;
 }
 
 .c8 {

--- a/packages/yoast-components/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
@@ -75,7 +75,7 @@ exports[`KeywordInput matches the snapshot by default 1`] = `
 
 .c5.has-error {
   border-color: #dc3232 !important;
-  box-shadow: 0 0 2px #dc3232 !important;
+  background-color: #f9dcdc !important;
 }
 
 .c8 {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Change error styling for the keyphrase input component, to add a background and change the border color, according to the SEMrush integration design.

## Relevant technical choices:

* The :x: icon that was initially planned in the design has been scrapped (see [this conversation](https://yoast.slack.com/archives/C07UJ4RHP/p1595923172044800))
* This PR is expected to merged on the `feature/semrush` branch since the change of style may affect other parts of the plugin where the component is used. Moreover, a change in the implementation of the component is pending to harmonize the display of the different error messages.
* The PR cherry-picks [this commit](https://github.com/Yoast/javascript/commit/5c76d175e51962d02fb275a9d57abce4a525b6aa) from `develop` branch to make sure the error style is displayed when the keyphrase is empty.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout the `feature/semrush` branch of `wordpress-seo`
* Make sure to have run `yarn link-monorepo` before building
* Create a new post, look at the Yoast metabox and/or sidebar
* Do not enter a keyphrase, and click on the "Get related keyphrases" button
* Observe that the keyphrase input style matches the design, except for the :x: icon:
![design](https://user-images.githubusercontent.com/15989132/88817531-e937e500-d1bd-11ea-8be0-4e250ca53080.png)
* background color code should be `#f9dcdc` and border color code should be `#dc3232`

* Fill the input with a comma-separated list of words to see it uses the same style for that error
* Do the above with `wordpress-seo-premium` to check that the "Add related keyphrase" input boxes have the same style when filed with a comma-separated list of words.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-91]
