### PR TITLE
P3-90 Refactored error messages to be displayed as unordered list

### DIFF
--- a/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
+++ b/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
@@ -50,10 +50,16 @@ const KeywordField = styled( InputField )`
 	}
 `;
 
-const ErrorText = styled.p`
+const ErrorList = styled.ul`
 	color: ${ errorColor };
-	margin: 0.5em 0 0 0;
-	min-height: 1.8em;
+	list-style-type: disc;
+	list-style-position: inside;
+	margin: 0;
+`;
+
+const ErrorText = styled.li`
+	color: ${ errorColor };
+	margin: 0 0 0.5em 0;
 `;
 
 const BorderlessButton = addFocusStyle(
@@ -187,13 +193,44 @@ class KeywordInput extends React.Component {
 	}
 
 	/**
+	 * Renders the input's error message list.
+	 *
+	 * @param {boolean} showMultipleKeyphrasesErrorMessage Whether or not the multiple keyphrases error message has to be shown.
+	 *
+	 * @returns {ReactElement} The input label.
+	 */
+	renderErrorMessages( showMultipleKeyphrasesErrorMessage ) {
+		const { errorMessages } = this.props;
+		return (
+			<ErrorList>
+				{ errorMessages.map( ( message, index ) =>
+					<ErrorText
+						key={ index }
+						role={ "alert" }
+					>
+						{ message }
+					</ErrorText>
+				) }
+				{ ( showMultipleKeyphrasesErrorMessage && this.props.keyword !== "" ) &&
+					<ErrorText
+						key={ "-1" }
+						role="alert"
+					>
+						{ __( "Are you trying to use multiple keyphrases? You should add them separately below.", "yoast-components" ) }
+					</ErrorText>
+				}
+			</ErrorList>
+		);
+	}
+
+	/**
 	 * Renders an input field, a label, and if the condition is met, an error message.
 	 *
 	 * @returns {ReactElement} The KeywordField react component including its label and eventual error message.
 	 */
 	render() {
 		const { id, showLabel, keyword, onRemoveKeyword, onBlurKeyword, onFocusKeyword, hasError } = this.props;
-		const showErrorMessage = this.checkKeywordInput( keyword );
+		const showMultipleKeyphrasesErrorMessage = this.checkKeywordInput( keyword );
 
 		// The aria label should not be shown if there is a visible label.
 		const showAriaLabel = ! showLabel;
@@ -203,6 +240,7 @@ class KeywordInput extends React.Component {
 		return (
 			<KeywordInputContainer>
 				{ showLabel && this.renderLabel() }
+				{ ( showMultipleKeyphrasesErrorMessage || hasError ) &&  this.renderErrorMessages( showMultipleKeyphrasesErrorMessage ) }
 				<YoastInputButtonContainer
 					className={ showRemoveKeywordButton ? "has-remove-keyword-button" : null }
 				>
@@ -210,7 +248,7 @@ class KeywordInput extends React.Component {
 						aria-label={ showAriaLabel ? this.props.label : null }
 						type="text"
 						id={ id }
-						className={ ( showErrorMessage || hasError ) ? "has-error" : null }
+						className={ ( showMultipleKeyphrasesErrorMessage || hasError ) ? "has-error" : null }
 						onChange={ this.handleChange }
 						onFocus={ onFocusKeyword }
 						onBlur={ onBlurKeyword }
@@ -227,7 +265,6 @@ class KeywordInput extends React.Component {
 						</BorderlessButton>
 					) }
 				</YoastInputButtonContainer>
-				{ this.displayErrorMessage( showErrorMessage ) }
 			</KeywordInputContainer>
 		);
 	}
@@ -244,6 +281,9 @@ KeywordInput.propTypes = {
 	label: PropTypes.string.isRequired,
 	helpLink: PropTypes.node,
 	hasError: PropTypes.bool,
+	errorMessages: PropTypes.arrayOf(
+		PropTypes.string
+	),
 };
 
 KeywordInput.defaultProps = {
@@ -254,6 +294,7 @@ KeywordInput.defaultProps = {
 	onFocusKeyword: noop,
 	helpLink: null,
 	hasError: false,
+	errorMessages: [],
 };
 
 export default KeywordInput;

--- a/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
+++ b/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
@@ -197,10 +197,13 @@ class KeywordInput extends React.Component {
 	 *
 	 * @param {boolean} showMultipleKeyphrasesErrorMessage Whether or not the multiple keyphrases error message has to be shown.
 	 *
-	 * @returns {ReactElement} The input label.
+	 * @returns {ReactElement} The error list.
 	 */
 	renderErrorMessages( showMultipleKeyphrasesErrorMessage ) {
-		const { errorMessages } = this.props;
+		const errorMessages = [ ...this.props.errorMessages ];
+		if ( showMultipleKeyphrasesErrorMessage && this.props.keyword !== "" ) {
+			errorMessages.push( __( "Are you trying to use multiple keyphrases? You should add them separately below.", "yoast-components" ) );
+		}
 		return (
 			<ErrorList>
 				{ errorMessages.map( ( message, index ) =>
@@ -211,14 +214,6 @@ class KeywordInput extends React.Component {
 						{ message }
 					</ErrorText>
 				) }
-				{ ( showMultipleKeyphrasesErrorMessage && this.props.keyword !== "" ) &&
-					<ErrorText
-						key={ "-1" }
-						role="alert"
-					>
-						{ __( "Are you trying to use multiple keyphrases? You should add them separately below.", "yoast-components" ) }
-					</ErrorText>
-				}
 			</ErrorList>
 		);
 	}
@@ -240,7 +235,7 @@ class KeywordInput extends React.Component {
 		return (
 			<KeywordInputContainer>
 				{ showLabel && this.renderLabel() }
-				{ ( showMultipleKeyphrasesErrorMessage || hasError ) &&  this.renderErrorMessages( showMultipleKeyphrasesErrorMessage ) }
+				{ ( showMultipleKeyphrasesErrorMessage || hasError ) && this.renderErrorMessages( showMultipleKeyphrasesErrorMessage ) }
 				<YoastInputButtonContainer
 					className={ showRemoveKeywordButton ? "has-remove-keyword-button" : null }
 				>

--- a/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
+++ b/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
@@ -2,7 +2,6 @@
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import { __ } from "@wordpress/i18n";
 import noop from "lodash/noop";
 
 /* Yoast dependencies */
@@ -129,7 +128,6 @@ class KeywordInput extends React.Component {
 		super( props );
 
 		this.handleChange = this.handleChange.bind( this );
-		this.displayErrorMessage = this.displayErrorMessage.bind( this );
 	}
 
 	/**
@@ -141,23 +139,6 @@ class KeywordInput extends React.Component {
 	 */
 	checkKeywordInput( keywordText ) {
 		return keywordText.includes( "," );
-	}
-
-	/**
-	 * Displays the error message
-	 *
-	 * @param {boolean} showErrorMessage Whether or not the error message has to be shown.
-	 *
-	 * @returns {ReactElement} ErrorText The error message element.
-	 */
-	displayErrorMessage( showErrorMessage ) {
-		if ( showErrorMessage && this.props.keyword !== "" ) {
-			return (
-				<ErrorText role="alert">
-					{ __( "Are you trying to use multiple keyphrases? You should add them separately below.", "yoast-components" ) }
-				</ErrorText>
-			);
-		}
 	}
 
 	/**
@@ -195,15 +176,10 @@ class KeywordInput extends React.Component {
 	/**
 	 * Renders the input's error message list.
 	 *
-	 * @param {boolean} showMultipleKeyphrasesErrorMessage Whether or not the multiple keyphrases error message has to be shown.
-	 *
 	 * @returns {ReactElement} The error list.
 	 */
-	renderErrorMessages( showMultipleKeyphrasesErrorMessage ) {
+	renderErrorMessages() {
 		const errorMessages = [ ...this.props.errorMessages ];
-		if ( showMultipleKeyphrasesErrorMessage && this.props.keyword !== "" ) {
-			errorMessages.push( __( "Are you trying to use multiple keyphrases? You should add them separately below.", "yoast-components" ) );
-		}
 		return (
 			<ErrorList>
 				{ errorMessages.map( ( message, index ) =>
@@ -225,8 +201,6 @@ class KeywordInput extends React.Component {
 	 */
 	render() {
 		const { id, showLabel, keyword, onRemoveKeyword, onBlurKeyword, onFocusKeyword, hasError } = this.props;
-		const showMultipleKeyphrasesErrorMessage = this.checkKeywordInput( keyword );
-
 		// The aria label should not be shown if there is a visible label.
 		const showAriaLabel = ! showLabel;
 
@@ -235,7 +209,7 @@ class KeywordInput extends React.Component {
 		return (
 			<KeywordInputContainer>
 				{ showLabel && this.renderLabel() }
-				{ ( showMultipleKeyphrasesErrorMessage || hasError ) && this.renderErrorMessages( showMultipleKeyphrasesErrorMessage ) }
+				{ hasError && this.renderErrorMessages() }
 				<YoastInputButtonContainer
 					className={ showRemoveKeywordButton ? "has-remove-keyword-button" : null }
 				>
@@ -243,7 +217,7 @@ class KeywordInput extends React.Component {
 						aria-label={ showAriaLabel ? this.props.label : null }
 						type="text"
 						id={ id }
-						className={ ( showMultipleKeyphrasesErrorMessage || hasError ) ? "has-error" : null }
+						className={ hasError ? "has-error" : null }
 						onChange={ this.handleChange }
 						onFocus={ onFocusKeyword }
 						onBlur={ onBlurKeyword }

--- a/packages/yoast-components/composites/Plugin/Shared/tests/KeywordInputTest.js
+++ b/packages/yoast-components/composites/Plugin/Shared/tests/KeywordInputTest.js
@@ -40,7 +40,7 @@ describe( KeywordInput, () => {
 				value: "Keyword",
 			},
 		} );
-		expect( wrapper.find( "p[role=\"alert\"]" ).length ).toBe( 0 );
+		expect( wrapper.find( "li[role=\"alert\"]" ).length ).toBe( 0 );
 	} );
 
 	it( "does not display the error message for two words separated by whitespace", () => {
@@ -60,7 +60,7 @@ describe( KeywordInput, () => {
 				value: "Keyword1 Keyword2",
 			},
 		} );
-		expect( wrapper.find( "p[role=\"alert\"]" ).length ).toBe( 0 );
+		expect( wrapper.find( "li[role=\"alert\"]" ).length ).toBe( 0 );
 	} );
 
 	it( "displays the error message for comma-separated words", () => {
@@ -80,6 +80,6 @@ describe( KeywordInput, () => {
 				value: "Keyword1, Keyword2",
 			},
 		} );
-		expect( wrapper.find( "p[role=\"alert\"]" ).length ).toBe( 1 );
+		expect( wrapper.find( "li[role=\"alert\"]" ).length ).toBe( 1 );
 	} );
 } );

--- a/packages/yoast-components/composites/Plugin/Shared/tests/KeywordInputTest.js
+++ b/packages/yoast-components/composites/Plugin/Shared/tests/KeywordInputTest.js
@@ -63,7 +63,7 @@ describe( KeywordInput, () => {
 		expect( wrapper.find( "li[role=\"alert\"]" ).length ).toBe( 0 );
 	} );
 
-	it( "displays the error message for comma-separated words", () => {
+	it( "does not displays the error message for comma-separated words", () => {
 		const wrapper = Enzyme.mount(
 			<KeywordInput
 				id="test-id"
@@ -73,6 +73,28 @@ describe( KeywordInput, () => {
 				onRemoveKeyword={ () => {} }
 				label="test label"
 				ariaLabel="test"
+			/>
+		);
+		wrapper.find( "input" ).simulate( "change", {
+			target: {
+				value: "Keyword1, Keyword2",
+			},
+		} );
+		expect( wrapper.find( "li[role=\"alert\"]" ).length ).toBe( 0 );
+	} );
+
+	it( "does displays the error message if submitted as prop", () => {
+		const wrapper = Enzyme.mount(
+			<KeywordInput
+				id="test-id"
+				onChange={ ( value ) => {
+					wrapper.setProps( { keyword: value } );
+				} }
+				onRemoveKeyword={ () => {} }
+				label="test label"
+				ariaLabel="test"
+				hasError={ true }
+				errorMessages={ [ "Testing error message" ] }
 			/>
 		);
 		wrapper.find( "input" ).simulate( "change", {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Display errors in an unordered list above the keyphrase textbox.

## Relevant technical choices:

* Ported changes from #811 (P3-91 update error styling of keyphrase input) to have a light red background on error
* The component accepts as prop an array of strings → error messages to show when the `hasError` prop is set to true.
* The check for a comma in the keyphrase, that was performed internally by the component, has been removed and it will be added to the calling component in a different issue.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout the `feature/semrush` branch of `wordpress-seo`.
* make sure you have the `javascript` monorepo linked
* edit the `js/src/components/contentAnalysis/KeywordInput.js`:
  * set `hasError` to `true` at line 72
  * add a `errorMessages` prop to `KeywordInputComponent`:
```
			hasError={ true || this.props.displayNoKeyphraseMessage }
			errorMessages={ [ "this is an error", "this is another error" ] }
```
* build
* start writing a new post
* observe that the error messages are displayed in an unodered list matching the design.
![Screenshot_2020-07-31 Add New Post ‹ Basic — WordPress(1)](https://user-images.githubusercontent.com/15989132/89044096-c9352c80-d349-11ea-97f9-30a4ba4faf06.png)
* background color code should be #f9dcdc and border color code should be #dc3232
* The same should happen in the Yoast metabox as well as in the Yoast sidebar.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-90]
