### PR TITLE
Don't treat ) followed by upper-case letter as sentence ending

### DIFF
--- a/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper1.js
@@ -105,7 +105,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 52.6 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability</a>.",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 52.4 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability</a>.",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -125,7 +125,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 18.8% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 19.3% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper2.js
@@ -103,7 +103,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 47.5 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>.",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 46.8 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>.",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -123,12 +123,12 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 28% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 29.9% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 11% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 11.7% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper3.js
@@ -105,7 +105,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 51.8 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability</a>.",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 51.3 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability</a>.",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -125,7 +125,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 16.7% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 17.5% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper4.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper4.js
@@ -105,7 +105,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 67.1 in the test, which is considered ok to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 67 in the test, which is considered ok to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -125,12 +125,12 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 27.1% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 27.4% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 14.6% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 14.7% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		score: 0,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper1.js
@@ -102,7 +102,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 82.9 in the test, which is considered easy to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 79.9 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -121,8 +121,8 @@ const expectedResults = {
 	},
 	textTransitionWords: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 29.3% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper2.js
@@ -102,7 +102,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 74 in the test, which is considered fairly easy to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 73.5 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -121,8 +121,8 @@ const expectedResults = {
 	},
 	textTransitionWords: {
 		isApplicable: true,
-		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 19% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		score: 6,
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 20.2% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper3.js
@@ -103,7 +103,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 59.7 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability</a>.",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 58.1 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability</a>.",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper1.js
@@ -104,8 +104,8 @@ const expectedResults = {
 	},
 	fleschReadingEase: {
 		isApplicable: true,
-		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 65.4 in the test, which is considered ok to read. Good job!",
+		score: 6,
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 59.4 in the test, which is considered fairly difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences to improve readability</a>.",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -120,7 +120,7 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 57.7% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 72.7% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,
@@ -128,9 +128,9 @@ const expectedResults = {
 		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Well done!",
 	},
 	passiveVoice: {
-		score: 6,
+		score: 3,
 		isApplicable: true,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 12.5% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 16.7% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper2.js
@@ -102,7 +102,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 75.7 in the test, which is considered fairly easy to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 72.6 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -117,17 +117,17 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 35.2% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 38% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 20.6% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 25.5% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 17.5% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 21.6% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper3.js
@@ -101,7 +101,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 77.5 in the test, which is considered fairly easy to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 75.4 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -121,12 +121,12 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 11.6% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 14.5% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
-		score: 9,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: You're using enough active voice. That's great!",
+		score: 6,
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 11.6% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper1.js
@@ -104,7 +104,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 76.5 in the test, which is considered fairly easy to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 76.4 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -124,7 +124,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 16.6% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 16.9% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper2.js
@@ -102,7 +102,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 75.6 in the test, which is considered fairly easy to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 75.2 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -122,7 +122,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 18% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 18.6% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper3.js
@@ -103,7 +103,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 61.1 in the test, which is considered ok to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 60.5 in the test, which is considered ok to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -117,8 +117,8 @@ const expectedResults = {
 	},
 	textSentenceLength: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 28.2% of the sentences contain more than 25 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		score: 3,
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 32.4% of the sentences contain more than 25 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper1.js
@@ -118,17 +118,17 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 43.3% of the sentences contain more than 20 words, which is more than the recommended maximum of 15%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 45.9% of the sentences contain more than 20 words, which is more than the recommended maximum of 15%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 20.6% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 25.9% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 10.3% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 13.6% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper2.js
@@ -121,7 +121,7 @@ const expectedResults = {
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 13.4% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 14.9% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper3.js
@@ -116,7 +116,7 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 31.4% of the sentences contain more than 20 words, which is more than the recommended maximum of 15%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 38.4% of the sentences contain more than 20 words, which is more than the recommended maximum of 15%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,
@@ -125,8 +125,8 @@ const expectedResults = {
 	},
 	passiveVoice: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 13.1% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		score: 3,
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 17.4% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper1.js
@@ -102,7 +102,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 33.4 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>.",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 33.1 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>.",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -117,12 +117,12 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 38.6% of the sentences contain more than 15 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 39.1% of the sentences contain more than 15 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 15.2% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 15.7% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper2.js
@@ -29,7 +29,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 9,
 		resultText: "<a href='https://yoa.st/33v' target='_blank'>Keyphrase density</a>: " +
-			"The focus keyphrase was found 8 times. This is great!",
+			"The focus keyphrase was found 9 times. This is great!",
 	},
 	metaDescriptionKeyword: {
 		isApplicable: true,
@@ -100,7 +100,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 31.7 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>.",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 30.8 in the test, which is considered difficult to read. <a href='https://yoa.st/34s' target='_blank'>Try to make shorter sentences, using less difficult words to improve readability</a>.",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -115,12 +115,12 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 39% of the sentences contain more than 15 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 47.4% of the sentences contain more than 15 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 24% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 25.5% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper3.js
@@ -104,7 +104,7 @@ const expectedResults = {
 	fleschReadingEase: {
 		isApplicable: true,
 		score: 9,
-		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 62.9 in the test, which is considered fairly easy to read. Good job!",
+		resultText: "<a href='https://yoa.st/34r' target='_blank'>Flesch Reading Ease</a>: The copy scores 62.1 in the test, which is considered fairly easy to read. Good job!",
 	},
 	subheadingsTooLong: {
 		isApplicable: true,
@@ -119,12 +119,12 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 36.7% of the sentences contain more than 15 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 42.2% of the sentences contain more than 15 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 15% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 15.5% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/sv/swedishPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/sv/swedishPaper1.js
@@ -113,17 +113,17 @@ const expectedResults = {
 	textSentenceLength: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 30.4% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 36.6% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
 	},
 	textTransitionWords: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 20% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 25.5% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 10.8% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 13.7% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		score: 0,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/sv/swedishPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/sv/swedishPaper2.js
@@ -119,13 +119,13 @@ const expectedResults = {
 	},
 	textTransitionWords: {
 		isApplicable: true,
-		score: 3,
-		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 18.3% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
+		score: 6,
+		resultText: "<a href='https://yoa.st/34z' target='_blank'>Transition words</a>: Only 24.3% of the sentences contain transition words, which is not enough. <a href='https://yoa.st/35a' target='_blank'>Use more of them</a>.",
 	},
 	passiveVoice: {
 		isApplicable: true,
 		score: 6,
-		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 10.8% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
+		resultText: "<a href='https://yoa.st/34t' target='_blank'>Passive voice</a>: 14.3% of the sentences contain passive voice, which is more than the recommended maximum of 10%. <a href='https://yoa.st/34u' target='_blank'>Try to use their active counterparts</a>.",
 	},
 	textPresence: {
 		score: 0,

--- a/packages/yoastseo/spec/stringProcessing/getSentencesSpec.js
+++ b/packages/yoastseo/spec/stringProcessing/getSentencesSpec.js
@@ -283,27 +283,75 @@ describe( "Get sentences from text", function() {
 
 		testGetSentences( testCases );
 	} );
-	it( "", function() {
+
+	it( "can deal with brackets", function() {
 		var testCases = [
+			{
+				input: "This is a sentence (with blockends) and is still one sentence.",
+				expected: [ "This is a sentence (with blockends) and is still one sentence." ],
+			},
 			{
 				input: "This is a sentence (with blockends.) and is still one sentence.",
 				expected: [ "This is a sentence (with blockends.) and is still one sentence." ],
+			},
+			{
+				input: "This is a sentence (with blockends?) and is still one sentence.",
+				expected: [ "This is a sentence (with blockends?) and is still one sentence." ],
+			},
+			{
+				input: "This is a sentence (with blockends). this is still one sentence.",
+				expected: [ "This is a sentence (with blockends). this is still one sentence." ],
+			},
+			// Second sentence starts with lower-case letter, but unlike a full stop, a ? is an unambiguosu sentence ending
+
+			{
+				input: "This is a sentence (with blockends)? this is still one sentence.",
+				expected: [ "This is a sentence (with blockends)?", "this is still one sentence." ],
 			},
 			{
 				input: "This is a sentence (with blockends.). This is a second sentence.",
 				expected: [ "This is a sentence (with blockends.).", "This is a second sentence." ],
 			},
 			{
+				input: "This is a sentence (with blockends.)? This is a second sentence.",
+				expected: [ "This is a sentence (with blockends.)?", "This is a second sentence." ],
+			},
+			{
+				input: "This is a sentence (with blockends?). This is a second sentence.",
+				expected: [ "This is a sentence (with blockends?).", "This is a second sentence." ],
+			},
+			{
 				input: "This is a sentence (with blockends.) This is a second sentence.",
 				expected: [ "This is a sentence (with blockends.)", "This is a second sentence." ],
 			},
 			{
-				input: "This is a sentence (with blockends) This is a second sentence.",
-				expected: [ "This is a sentence (with blockends)", "This is a second sentence." ],
+				input: "This is a sentence (with blockends?) This is a second sentence.",
+				expected: [ "This is a sentence (with blockends?)", "This is a second sentence." ],
 			},
 			{
-				input: "This is a sentence (with blockends.). this is a second sentence.",
-				expected: [ "This is a sentence (with blockends.). this is a second sentence." ],
+				input: "This is a sentence (with blockends) This is a second sentence.",
+				expected: [ "This is a sentence (with blockends) This is a second sentence." ],
+			},
+			{
+				input: "This is a sentence (with blockends). This is a second sentence.",
+				expected: [ "This is a sentence (with blockends).", "This is a second sentence." ],
+			},
+			{
+				input: "This is a sentence (with blockends)? This is a second sentence.",
+				expected: [ "This is a sentence (with blockends)?", "This is a second sentence." ],
+			},
+			{
+				input: "This is a sentence (with blockends.). this is still one sentence.",
+				expected: [ "This is a sentence (with blockends.). this is still one sentence." ],
+			},
+			{
+				input: "This is a sentence (with blockends?). this is still one sentence.",
+				expected: [ "This is a sentence (with blockends?). this is still one sentence." ],
+			},
+			// Second sentence starts with lower-case letter, but unlike a full stop, a ? is an unambiguosu sentence ending
+			{
+				input: "This is a sentence (with blockends.)? this is a new sentence.",
+				expected: [ "This is a sentence (with blockends.)?", "this is a new sentence." ],
 			},
 			{
 				input: "This is a sentence (with blockends.). 1 this is a second sentence.",
@@ -376,17 +424,43 @@ describe( "Parse languages written right-to-left", function() {
 			"רקע היסטורי תאורטי",
 			"שלבי התפתחות ציורי ילדים נחקרים מאז שלהי המאה ה-19.",
 			"בעבודות המוקדמות שנערכו, תיארו החוקרים שלושה שלבים מרכזיים של התפתחות אמנותית: שלב השרבוט, שלב הסכימה והשלב הנטורליסטי.",
-			"ב-1921 יצר הפסיכולוג החינוכי סיריל ברט ((אנ')‏ Cyril Burt)", "חלוקה חדשה של התפתחות ציורי ילדים לארבעה שלבים.",
-			"אחריו, בשנת 1927, יצר ז'ורז'-אנרי לוקה ((צר') ‏Georges-Henri Luquet)",
-			"שלבים, שבבסיסם עומדת ההנחה שהילד מצייר באופן ריאליסטי זמן רב לפני שהוא מסוגל לצייר את מה שהוא רואה באמת.",
-			"על בסיס שלביו של לוקה, קבעו הפסיכולוגים ההתפתחותיים ז'אן פיאז'ה וברבל אינהלדר ((אנ')‏ Bärbel Inhelder)",
-			"כי התפתחות הציור מקבילה להתפתחותו האינטלקטואלית של הילד, המתבטאת בהתפתחות הראייה ההנדסית והמרחבית (ארגון המרחב, שליטה ובקרה בעיצוב הקו), ובהתאם להתפתחות החשיבה.",
-			"בשנת 1947 תיאר איש החינוך לאמנות ויקטור לוונפלד ((אנ')‏ Viktor Lowenfeld)", "שישה שלבים עיקריים בהתפתחות הגרפית של ילדים, וזאת על בסיס עבודתו של ברט ובדומה לתאוריית ההתפתחות הקוגניטיבית של פיאז'ה;",
+			"ב-1921 יצר הפסיכולוג החינוכי סיריל ברט ((אנ')‏ Cyril Burt) חלוקה חדשה של התפתחות ציורי ילדים לארבעה שלבים.",
+			"אחריו, בשנת 1927, יצר ז'ורז'-אנרי לוקה ((צר') ‏Georges-Henri Luquet) שלבים, שבבסיסם עומדת ההנחה שהילד מצייר באופן ריאליסטי זמן רב לפני שהוא מסוגל לצייר את מה שהוא רואה באמת.",
+			"על בסיס שלביו של לוקה, קבעו הפסיכולוגים ההתפתחותיים ז'אן פיאז'ה וברבל אינהלדר ((אנ')‏ Bärbel Inhelder) כי התפתחות הציור מקבילה להתפתחותו האינטלקטואלית של הילד, המתבטאת בהתפתחות הראייה ההנדסית והמרחבית (ארגון המרחב, שליטה ובקרה בעיצוב הקו), ובהתאם להתפתחות החשיבה.",
+			"בשנת 1947 תיאר איש החינוך לאמנות ויקטור לוונפלד ((אנ')‏ Viktor Lowenfeld) שישה שלבים עיקריים בהתפתחות הגרפית של ילדים, וזאת על בסיס עבודתו של ברט ובדומה לתאוריית ההתפתחות הקוגניטיבית של פיאז'ה;",
 			"עבודתו זו מהווה עד היום בסיס לבחינת התפתחות ציורי ילדים.",
 		];
+
 		const actual = getSentences( text );
 
 		expect( actual ).toEqual( expected );
+	} );
+
+	it( "parses an RTL language text with brackets", function() {
+		const testCases = [
+			{
+				input: "רקע (היסטורי) תאורטי.",
+				expected: [ "רקע (היסטורי) תאורטי." ],
+			},
+			{
+				input: "רקע (היסטורי.) תאורטי.",
+				expected: [ "רקע (היסטורי.)", "תאורטי." ],
+			},
+			{
+				input: "רקע (היסטורי). תאורטי.",
+				expected: [ "רקע (היסטורי).", "תאורטי." ],
+			},
+			{
+				input: "רקע (היסטורי)? תאורטי.",
+				expected: [ "רקע (היסטורי)?", "תאורטי." ],
+			},
+			{
+				input: "רקע (היסטורי?) תאורטי.",
+				expected: [ "רקע (היסטורי?)", "תאורטי." ],
+			},
+		];
+
+		testGetSentences( testCases );
 	} );
 
 	it( "parses an Arabic text", function() {
@@ -436,8 +510,7 @@ describe( "Parse languages written right-to-left", function() {
 			"أنَّ النيتروجين يشكل 78.08% من الغلاف الجوي؟",
 			"أنَّ صلاح الدين الأيوبي هو أول من لُقّب بخادم الحرمين الشريفين؟",
 			"أنَّ جامعة أنديرا غاندي الوطنية المفتوحة هي أكبر جامعة في العالم من حيث عدد الملتحقين بها؟",
-			"أنَّ رفع كساء الكعبة (في الصورة)",
-			"المبطن بالقماش الأبيض في موسم الحج يُفعل لحمايتها من قطعها بآلات حادة للحصول على قطع صغيرة طلبا للبركة أو الذكرى؟",
+			"أنَّ رفع كساء الكعبة (في الصورة) المبطن بالقماش الأبيض في موسم الحج يُفعل لحمايتها من قطعها بآلات حادة للحصول على قطع صغيرة طلبا للبركة أو الذكرى؟",
 			"أنَّ ليختنشتاين ألغت جيشها في عام 1868 لأنه كان مُكلفًا للغاية لها؟",
 		];
 
@@ -473,8 +546,7 @@ describe( "Parse languages written right-to-left", function() {
 			"بالای آرامگاه یک اتاق سنگی بود که یک سقف و یک در داشت و به قدری باریک بود که یک مرد کوتاه قد به‌سختی می‌توانست داخل اتاق شود.",
 			"در داخل اتاق یک تابوت طلایی وجود داشت که پیکر کوروش را در داخل آن قرار داده بودند.",
 			"یک نیمکت نیز با پایه‌هایی از طلا در کنار تابوت قرار داشت.",
-			"یک پردهٔ بابلی پوشش آن (احتمالاً نیمکت)",
-			"بود و کف اتاق نیز با فرش پوشانده شده بود.",
+			"یک پردهٔ بابلی پوشش آن (احتمالاً نیمکت) بود و کف اتاق نیز با فرش پوشانده شده بود.",
 			"یک شنل آستین‌دار و سایر لباس‌های بابلی روی آن قرار داشتند.",
 			"شلوارها و جامه‌های مادی در اتاق یافت می‌شد، بعضی تیره و بعضی به رنگ‌های دیگر بودند.",
 			"گردن‌بند، شمشیر، گوشواره‌های سنگی با تزیینات طلا و یک میز نیز در اتاق بودند.",
@@ -496,8 +568,7 @@ describe( "Parse languages written right-to-left", function() {
 			" کی تہذیبوں کا ہم عصر سمجھا جاتا ہے۔ 1980ء میں یونیسکو نے اسے یونیسکو عالمی ثقافتی ورثہ قرار دیا۔";
 
 		const expected =     [
-			"موئن جو دڑو (سندھی:موئن جو دڙو اور اردو میں عموماً موہنجوداڑو بھی؛ انگریزی: Mohenjo-daro)",
-			"وادی سندھ کی قدیم تہذیب کا ایک مرکز تھا۔",
+			"موئن جو دڑو (سندھی:موئن جو دڙو اور اردو میں عموماً موہنجوداڑو بھی؛ انگریزی: Mohenjo-daro) وادی سندھ کی قدیم تہذیب کا ایک مرکز تھا۔",
 			"یہ لاڑکانہ سے بیس کلومیٹر دور اور سکھر سے 80 کلومیٹر جنوب مغرب میں واقع ہے۔",
 			"یہ وادی،وادی سندھ کی تہذیب کے ایک اور اہم مرکز ہڑپہ صوبہ پنجاب سے 686 میل دور ہے۔",
 			"یہ شہر 2600 قبل مسیح موجود تھا اور 1700 قبل مسیح میں نامعلوم وجوہات کی بناء پر ختم ہو گیا۔",
@@ -685,10 +756,7 @@ describe( "Get sentences from texts that have been processed for the keyphrase d
 					"On the <strong>General</strong> tab: Make sure your store address is correct and that you’ve limited selling to your country and location Enable or disable tax calculation if needed Enable or disable the use of coupon codes if needed Pick the correct currency On the <strong>Product</strong> tab: Select the page where you want the shop to appear Want users to leave reviews on your product?",
 					"Activate that option here On Inventory: Disable stock management unless you need it On the <strong>Payments</strong> tab: Pick an easy payment option, like cash on delivery or bank transfer If needed, you can add more complex payment providers like PayPal On the <strong>Accounts</strong> tab: Allow guest checkout Allow account creation if needed Select the Privacy policy Review the other options on this page carefully, you may need them On the <strong>Emails</strong> tab: Check the different email templates and activate the ones you want to use.",
 					"For every email, change the text to match what you want to say Scroll down to check the sender options Also adapt the email template to fit your brand Skip the <strong>Integrations</strong> tab On the <strong>Advanced</strong> tab: Map the essential pages for your shop, i.e. the cart, checkout, account page and terms and conditions.",
-					"You can make these pages in WordPress: Add the `[woocommerce_cart]",
-					"` shortcode to the cart page Add the `[woocommerce_checkout]",
-					"` shortcode to the checkout page Place the `[woocommerce_my_account]",
-					"` shortcode to the account page" ],
+					"You can make these pages in WordPress: Add the `[woocommerce_cart]` shortcode to the cart page Add the `[woocommerce_checkout]` shortcode to the checkout page Place the `[woocommerce_my_account]` shortcode to the account page" ],
 			},
 		];
 

--- a/packages/yoastseo/spec/stringProcessing/getSentencesSpec.js
+++ b/packages/yoastseo/spec/stringProcessing/getSentencesSpec.js
@@ -302,8 +302,7 @@ describe( "Get sentences from text", function() {
 				input: "This is a sentence (with blockends). this is still one sentence.",
 				expected: [ "This is a sentence (with blockends). this is still one sentence." ],
 			},
-			// Second sentence starts with lower-case letter, but unlike a full stop, a ? is an unambiguosu sentence ending
-
+			// Second sentence starts with lower-case letter, but unlike a full stop, a "?" is an unambiguous sentence ending.
 			{
 				input: "This is a sentence (with blockends)? this is still one sentence.",
 				expected: [ "This is a sentence (with blockends)?", "this is still one sentence." ],
@@ -329,8 +328,8 @@ describe( "Get sentences from text", function() {
 				expected: [ "This is a sentence (with blockends?)", "This is a second sentence." ],
 			},
 			{
-				input: "This is a sentence (with blockends) This is a second sentence.",
-				expected: [ "This is a sentence (with blockends) This is a second sentence." ],
+				input: "This is a sentence (with blockends) This is still one sentence.",
+				expected: [ "This is a sentence (with blockends) This is still one sentence." ],
 			},
 			{
 				input: "This is a sentence (with blockends). This is a second sentence.",

--- a/packages/yoastseo/src/stringProcessing/SentenceTokenizer.js
+++ b/packages/yoastseo/src/stringProcessing/SentenceTokenizer.js
@@ -188,7 +188,8 @@ export default class SentenceTokenizer {
 	}
 
 	/**
-	 * Checks if the token is a valid sentence start.
+	 * Checks if the token is a valid sentence ending. A valid sentence ending is either a full stop or another
+	 * delimiter such as "?", "!", etc.
 	 *
 	 * @param {Object} token The token to validate.
 	 * @returns {boolean} Returns true if the token is valid sentence ending, false if it is not.
@@ -403,7 +404,7 @@ export default class SentenceTokenizer {
 
 					/* Don't split if:
 					 * - The next character is a number. For example: IPv4-numbers.
-					 * - If the block end is preceded by a valid sentence ending, but not followed by a valid sentence beginning.
+					 * - The block end is preceded by a valid sentence ending, but not followed by a valid sentence beginning.
 					 */
 					if (
 						hasNextSentence && this.isNumber( nextCharacters[ 0 ] ) ||
@@ -415,8 +416,7 @@ export default class SentenceTokenizer {
 
 					/*
 					 * Split if:
-					 * - The block end is preceed by a sentence ending and (1) the next character is a valid sentence beginning
-					 * or (2) the next token is a valid sentence start.
+					 * - The block end is preceded by a sentence ending and followed by a valid sentence beginning.
 					 */
 					if (
 						this.isSentenceEnding( previousToken ) &&

--- a/packages/yoastseo/src/stringProcessing/SentenceTokenizer.js
+++ b/packages/yoastseo/src/stringProcessing/SentenceTokenizer.js
@@ -174,10 +174,10 @@ export default class SentenceTokenizer {
 	}
 
 	/**
-	 * Checks if the token is a valid sentence ending.
+	 * Checks if the token is a valid sentence start.
 	 *
 	 * @param {Object} token The token to validate.
-	 * @returns {boolean} Returns true if the token is valid ending, false if it is not.
+	 * @returns {boolean} Returns true if the token is valid sentence start, false if it is not.
 	 */
 	isSentenceStart( token ) {
 		return ( ! isUndefined( token ) && (
@@ -185,6 +185,19 @@ export default class SentenceTokenizer {
 			"html-end" === token.type ||
 			"block-start" === token.type
 		) );
+	}
+
+	/**
+	 * Checks if the token is a valid sentence start.
+	 *
+	 * @param {Object} token The token to validate.
+	 * @returns {boolean} Returns true if the token is valid sentence ending, false if it is not.
+	 */
+	isSentenceEnding( token ) {
+		return (
+			! isUndefined( token ) &&
+			( token.type === "full-stop" || token.type === "sentence-delimiter" )
+		);
 	}
 
 	/**
@@ -325,6 +338,7 @@ export default class SentenceTokenizer {
 		tokenArray.forEach( ( token, i ) => {
 			let hasNextSentence, nextCharacters, tokenizeResults;
 			const nextToken = tokenArray[ i + 1 ];
+			const previousToken = tokenArray[ i - 1 ];
 			const secondToNextToken = tokenArray[ i + 2 ];
 
 			switch ( token.type ) {
@@ -386,12 +400,28 @@ export default class SentenceTokenizer {
 					// For a new sentence we need to check the next two characters.
 					hasNextSentence = nextCharacters.length >= 2;
 					nextSentenceStart = hasNextSentence ? nextCharacters[ 0 ] : "";
-					// If the next character is a number, never split. For example: IPv4-numbers.
-					if ( hasNextSentence && this.isNumber( nextCharacters[ 0 ] ) ) {
+
+					/* Don't split if:
+					 * - The next character is a number. For example: IPv4-numbers.
+					 * - If the block end is preceded by a valid sentence ending, but not followed by a valid sentence beginning.
+					 */
+					if (
+						hasNextSentence && this.isNumber( nextCharacters[ 0 ] ) ||
+						( this.isSentenceEnding( previousToken ) &&
+							( ! ( this.isValidSentenceBeginning( nextSentenceStart ) || this.isSentenceStart( nextToken ) ) ) )
+					) {
 						break;
 					}
 
-					if ( ( hasNextSentence && this.isValidSentenceBeginning( nextSentenceStart ) ) || this.isSentenceStart( nextToken ) ) {
+					/*
+					 * Split if:
+					 * - The block end is preceed by a sentence ending and (1) the next character is a valid sentence beginning
+					 * or (2) the next token is a valid sentence start.
+					 */
+					if (
+						this.isSentenceEnding( previousToken ) &&
+						( this.isValidSentenceBeginning( nextSentenceStart ) || this.isSentenceStart( nextToken ) )
+					) {
 						tokenSentences.push( currentSentence );
 						currentSentence = "";
 					}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:
* [Yoast SEO] Fixes a bug where closing parentheses would always be regarded as sentence endings in RTL languages.
* [Yoast SEO] Fixes a bug where closing parentheses would always be regarded as sentence endings when followed by an upper-case letter.
* [yoastseo] Fixes a bug where closing parentheses would always be regarded as sentence endings in RTL languages.
* [yoastseo] Fixes a bug where closing parentheses would always be regarded as sentence endings when followed by an upper-case letter.


## Relevant technical choices:

* The behavior follows the specifications from the [issue](https://yoast.atlassian.net/browse/LIN-486). In one respect, the result is different from what we had specified in the issue. That's because we had made some wrong assumptions in the issue specifications. We had made the following assumptions:
  * Hereinafter in examples . denotes all punctuation signs that we consider sentence delimiters (e.g., !, ?). Look in the code!
  * `This is a (sentence). with brackets.` for LTR languages should keep doing what it’s doing now (not splitting).
  ` This is a (sentence.) with brackets.` for LTR languages should keep doing what it’s doing now (not splitting).

In fact, for sentences such as `(sentence)? with brackets.` and `(sentence?) with brackets.` (i.e., non-full-stops delimiters) we always _did_ split. That's because delimiters such as `?` are more unambiguously sentence endings than a `.`. Therefore, I didn't make any changes to this behavior.

* The changes not only affect RTL languages but also RTL languages (as specified in the issue). In general, tokenization seems to become better. See for example the Swedish text below, where we used to split on brackets more frequently and therefore split sentences in places where they shouldn't have been split.
<details>
<summary>Old</summary>

```
<p>Ester Blenda Nordström var yngsta dottern till målarmästare <a href="/wiki/Daniel_Nordstr%C3%B6m" title="Daniel Nordström">Daniel Johan Nordström</a> och pigan Charlotta (Lotten)',
	'Wilhelmina Jansson i en syskonskara med elva år äldre systern Agda, nio år äldre brodern <a href="/wiki/Frithiof_Nordstr%C3%B6m" title="Frithiof Nordström">Fritihof</a> (sedermera tandläkare och entomolog<sup id="cite_ref-7" class="reference"><a href="#cite_note-7"><span class="cite-reference-link-bracket"> [</span>7<span class="cite-reference-link-bracket">]',
	'</span></a></sup>) och sju år äldre systern Hildur.',
	'<sup id="cite_ref-FOOTNOTEBremmer201739_8-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201739-8"><span class="cite-reference-link-bracket"> [</span>8<span class="cite-reference-link-bracket">]',
	'</span></a></sup> Ester Blenda Nordström blev faster till sångtextförfattaren <a href="/wiki/Gunilla_Sandberg" title="Gunilla Sandberg">Gunilla Sandberg</a>.',
	'</p>',
	'Ester, ofta kallad "Essan",<sup id="cite_ref-9" class="reference"><a href="#cite_note-9"><span class="cite-reference-link-bracket"> [</span>a<span class="cite-reference-link-bracket">]',
	'</span></a></sup> växte till en början upp på familjens gård Ryafors (strax utanför <a href="/wiki/Ljungby" title="Ljungby">Ljungby</a> i <a href="/wiki/Sm%C3%A5land" title="Småland">Småland</a>), som pappan hade köpt för sin första ihoptjänade förmögenhet, och i lägenheten på <a href="/wiki/Kungsholmsgatan" title="Kungsholmsgatan">Kungsholmsgatan</a> 7 i Stockholm.',
	'<sup id="cite_ref-FOOTNOTEBremmer201739_8-2" class="reference"><a href="#cite_note-FOOTNOTEBremmer201739-8"><span class="cite-reference-link-bracket"> [</span>8<span class="cite-reference-link-bracket">]',
	'</span></a>',
	'</p>',
	'Hon önskade ofta att hon var en pojke eftersom de fick leva så mycket friare.',
	'Hennes rastlöshet stillades bara av att vara utomhus och utforska naturen, leka farliga lekar, springa och cykla snabbt, och att skriva.',
	'<sup id="cite_ref-FOOTNOTEBremmer201737-39_10-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201737-39-10"><span class="cite-reference-link-bracket"> [</span>9<span class="cite-reference-link-bracket">]',
	'</span></a>',
	'</p>',
	'Esters pappa Daniel var bondson från början och träffade hennes mamma Lotten i Stockholm dit hon skickats som piga med mjölk från <a href="/wiki/Roslagen" title="Roslagen">Roslagen</a>.',
	'Pappan var precis som Ester mycket nyfiken till sin natur, skrev, tecknade och målade.',
	'Men istället för att satsa på sina konstnärsdrömmar tog han över den målerifirma där han börjat som gesäll och arbetat sig upp i.',
	'Affärerna gick bra och han introducerade <a href="/wiki/Elektricitet" title="Elektricitet">elektriciteten</a> i de mörka <a href="/wiki/Sm%C3%A5land" title="Småland">Smålandsskogarna</a> redan på 1890-talet.',
	'<sup id="cite_ref-FOOTNOTEBremmer201740-41_11-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201740-41-11"><span class="cite-reference-link-bracket"> [</span>10<span class="cite-reference-link-bracket">]',
	'</span></a>',
	'</p>',
	'Småland var den plats Ester Blenda Nordström alltid kallade sitt barndomshem.',
	'När pappa Daniel tröttnat på att pendla mellan Stockholm och Ryafors sålde han gården då Ester var 6 år och flyttade familjen på heltid till Stockholm under två år.',
	'När utbyggnaden av järnvägsnätet möjliggjorde snabbare transporter köpte han en tomt utanför <a href="/wiki/Ljungby" title="Ljungby">Ljungby</a> där han lät bygga Villa Åbyfors och en kraftstation samt drog fram el till huset.',
	'Ester Blenda Nordström älskade livet på Åbyfors.',
	'Hon trampade runt till granngårdarna på sin <a href="/wiki/Velociped" class="mw-redirect" title="Velociped">velociped</a> för att leka med bondbarnen och lärde sig snart alla på landet förekommande sysslor, som att mjölka och köra häst och vagn.',
	'<sup id="cite_ref-FOOTNOTEBremmer201743-45_12-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201743-45-12"><span class="cite-reference-link-bracket"> [</span>11<span class="cite-reference-link-bracket">]',
	'</span></a>',
	'</p>',
	'Av sina äldre syskon lärde hon sig spela på alla de instrument som fanns i hemmet: <a href="/wiki/Piano" title="Piano">piano</a>, <a href="/wiki/Dragspel" title="Dragspel">dragspel</a>, <a href="/wiki/Luta" title="Luta">luta</a>, <a href="/wiki/Fiol" class="mw-redirect" title="Fiol">fiol</a>, <a href="/wiki/Banjo" title="Banjo">banjo</a>, <a href="/wiki/Gitarr" title="Gitarr">gitarr</a> och <a href="/wiki/Munspel" title="Munspel">munspel</a>.',
	'Hennes favoritinstrument blev fiol och dragspel.',
	'De hade också många husdjur som hon lekte med på ett naturligt och varsamt sätt, som om de förstod varandra.',
	'<sup id="cite_ref-FOOTNOTEBremmer201746_13-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201746-13"><span class="cite-reference-link-bracket"> [</span>12<span class="cite-reference-link-bracket">]',
	'</span></a>',
	'</p>',
	'Hon gick inte i skolan utan undervisades i hemmet av <a href="/wiki/Privatl%C3%A4rare" title="Privatlärare">privatlärare</a>, men ansågs som "arbetsovillig".',
	'Hennes upptåg blev fler, farligare och resulterade i <a href="/wiki/Aga" title="Aga">stryk</a>, <a href="/wiki/Husarrest" title="Husarrest">husarrest</a> och <a href="/wiki/F%C3%B6rbud" title="Förbud">förbud</a>.',
	'När hon var 13 år tog tålamodet därhemma slut, och efter familjeöverläggningar skickades hon till farbror Håkan, <a href="/wiki/Kyrkoherde" title="Kyrkoherde">kyrkoherde</a> i <a href="/wiki/V%C3%A4stbo_kontrakt" title="Västbo kontrakt">Västbo kontrakt</a>, där han bodde och tjänstgjorde i <a href="/wiki/Villstad" title="Villstad">Villstad</a>, en liten by utanför <a href="/wiki/Gislaved" title="Gislaved">Gislaved</a>.',
	'Förhoppningen var att ett år i en <a href="/wiki/H%C3%B6gkyrklighet" title="Högkyrklighet">högkyrklig</a> miljö skulle kurera tonåringens olämpliga sinnelag samt åtgärda hennes dåliga betyg.',
	'Men farbrodern som ansågs vara intelligent, kunnig, god talare och en synnerligen älskvärd sällskapsmänniska visade fram helt andra sidor som <a href="/wiki/Uppfostran" title="Uppfostran">uppfostrare</a>.',
	'Ester Blenda Nordström beskriver i sitt självbiografiska manuskript till Märta Lindqvist<sup id="cite_ref-14" class="reference"><a href="#cite_note-14"><span class="cite-reference-link-bracket"> [</span>13<span class="cite-reference-link-bracket">]',
	'</span></a></sup> hur hon bestraffades med risbastu på bara stjärten av kyrkoherden, och hur hon tog sin gruvliga hämnd.',
	'<sup id="cite_ref-FOOTNOTEBremmer201746-49_15-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201746-49-15"><span class="cite-reference-link-bracket"> [</span>14<span class="cite-reference-link-bracket">]',
	'</span></a>',
	'</p>',
	'Hemma i Stockholm igen fick hon en ny lärare, men betygen fortsatte att dala.',
	'Vid 16 års ålder flyttade hon med familjen till en stor och flott våning på Kungsholmsgatan 29.',
	'Då hade brodern Frithiof redan flyttat hemifrån, tagit <a href="/wiki/Tandl%C3%A4kare" title="Tandläkare">tandläkarexamen</a>, startat egen praktik och stod i begrepp att gifta sig med Gerda von Porat, prästdotter från <a href="/wiki/Tumba" title="Tumba">Tumba</a> och släkt med farbror Håkans fru.',
	'Ester och Gerda blev genast goda vänner och det livet ut.',
	'<sup id="cite_ref-FOOTNOTEBremmer201749-51_16-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201749-51-16"><span class="cite-reference-link-bracket"> [</span>15<span class="cite-reference-link-bracket">]',
	'</span></a>',
	'</p>',
	'Ester Blenda Nordström började först på <a href="/wiki/Wallinska_flickskolan" class="mw-redirect" title="Wallinska flickskolan">Wallinska flickskolan</a> och fick bättre betyg, och när hon sedan bytte till <a href="/wiki/Palmgrenska_samskolan" title="Palmgrenska samskolan">Palmgrenska samskolan</a> för både pojkar och flickor fortsatte betygen att förbättras, förutom det i uppförande.',
	'Inför hennes studentexamen anställde familjen en extralärare och Nordström fick betyget "med beröm godkänt" för sitt uppsatsskrivande i svenska.',
	'<sup id="cite_ref-FOOTNOTEBremmer201752-53_17-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201752-53-17"><span class="cite-reference-link-bracket"> [</span>16<span class="cite-reference-link-bracket">]',
	'</span></a>',
	'</p>',
	'Familjens förmögenhet ökade och tillät pappa Daniel att köpa flera tomter vid <a href="/wiki/Skurusundet" title="Skurusundet">Skurusundet</a> på <a href="/wiki/V%C3%A4rmd%C3%B6" title="Värmdö">Värmdö</a> utanför Stockholm.',
	'Där, i nära anslutning till <a href="/wiki/Eken%C3%A4s" title="Ekenäs">Ekenäs</a> brygga och <a href="/wiki/Waxholm" class="mw-redirect" title="Waxholm">Waxholmsbåtarna</a>, uppfördes familjens <i>Ekefors</i> med tolvrumsvilla och rymlig målarateljé.',
	'Daniel Nordström hade fått det hedrande uppdraget att måla 21 landskapsbilder i taket på nyrestaurerade salongen Grand Restaurang National, nuvarande <a href="/wiki/Nalen" title="Nalen">Nalen</a>, på Regeringsgatan 74.',
	'<sup id="cite_ref-FOOTNOTEBremmer201752-53_17-1" class="reference"><a href="#cite_note-FOOTNOTEBremmer201752-53-17"><span class="cite-reference-link-bracket"> [</span>16<span class="cite-reference-link-bracket">]',
	'</span></a>',
	'</p>'
```
</details>

<details>
<summary>New</summary>

```
'<p>Ester Blenda Nordström var yngsta dottern till målarmästare <a href="/wiki/Daniel_Nordstr%C3%B6m" title="Daniel Nordström">Daniel Johan Nordström</a> och pigan Charlotta (Lotten) Wilhelmina Jansson i en syskonskara med elva år äldre systern Agda, nio år äldre brodern <a href="/wiki/Frithiof_Nordstr%C3%B6m" title="Frithiof Nordström">Fritihof</a> (sedermera tandläkare och entomolog<sup id="cite_ref-7" class="reference"><a href="#cite_note-7"><span class="cite-reference-link-bracket"> [</span>7<span class="cite-reference-link-bracket">]</span></a></sup>) och sju år äldre systern Hildur.',
	'<sup id="cite_ref-FOOTNOTEBremmer201739_8-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201739-8"><span class="cite-reference-link-bracket"> [</span>8<span class="cite-reference-link-bracket">]</span></a></sup> Ester Blenda Nordström blev faster till sångtextförfattaren <a href="/wiki/Gunilla_Sandberg" title="Gunilla Sandberg">Gunilla Sandberg</a>.',
	'</p>',
	'Ester, ofta kallad "Essan",<sup id="cite_ref-9" class="reference"><a href="#cite_note-9"><span class="cite-reference-link-bracket"> [</span>a<span class="cite-reference-link-bracket">]</span></a></sup> växte till en början upp på familjens gård Ryafors (strax utanför <a href="/wiki/Ljungby" title="Ljungby">Ljungby</a> i <a href="/wiki/Sm%C3%A5land" title="Småland">Småland</a>), som pappan hade köpt för sin första ihoptjänade förmögenhet, och i lägenheten på <a href="/wiki/Kungsholmsgatan" title="Kungsholmsgatan">Kungsholmsgatan</a> 7 i Stockholm.',
	'<sup id="cite_ref-FOOTNOTEBremmer201739_8-2" class="reference"><a href="#cite_note-FOOTNOTEBremmer201739-8"><span class="cite-reference-link-bracket"> [</span>8<span class="cite-reference-link-bracket">]</span></a>',
	'</p>',
	'Hon önskade ofta att hon var en pojke eftersom de fick leva så mycket friare.',
	'Hennes rastlöshet stillades bara av att vara utomhus och utforska naturen, leka farliga lekar, springa och cykla snabbt, och att skriva.',
	'<sup id="cite_ref-FOOTNOTEBremmer201737-39_10-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201737-39-10"><span class="cite-reference-link-bracket"> [</span>9<span class="cite-reference-link-bracket">]</span></a>',
	'</p>',
	'Esters pappa Daniel var bondson från början och träffade hennes mamma Lotten i Stockholm dit hon skickats som piga med mjölk från <a href="/wiki/Roslagen" title="Roslagen">Roslagen</a>.',
	'Pappan var precis som Ester mycket nyfiken till sin natur, skrev, tecknade och målade.',
	'Men istället för att satsa på sina konstnärsdrömmar tog han över den målerifirma där han börjat som gesäll och arbetat sig upp i.',
	'Affärerna gick bra och han introducerade <a href="/wiki/Elektricitet" title="Elektricitet">elektriciteten</a> i de mörka <a href="/wiki/Sm%C3%A5land" title="Småland">Smålandsskogarna</a> redan på 1890-talet.',
	'<sup id="cite_ref-FOOTNOTEBremmer201740-41_11-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201740-41-11"><span class="cite-reference-link-bracket"> [</span>10<span class="cite-reference-link-bracket">]</span></a>',
	'</p>',
	'Småland var den plats Ester Blenda Nordström alltid kallade sitt barndomshem.',
	'När pappa Daniel tröttnat på att pendla mellan Stockholm och Ryafors sålde han gården då Ester var 6 år och flyttade familjen på heltid till Stockholm under två år.',
	'När utbyggnaden av järnvägsnätet möjliggjorde snabbare transporter köpte han en tomt utanför <a href="/wiki/Ljungby" title="Ljungby">Ljungby</a> där han lät bygga Villa Åbyfors och en kraftstation samt drog fram el till huset.',
	'Ester Blenda Nordström älskade livet på Åbyfors.',
	'Hon trampade runt till granngårdarna på sin <a href="/wiki/Velociped" class="mw-redirect" title="Velociped">velociped</a> för att leka med bondbarnen och lärde sig snart alla på landet förekommande sysslor, som att mjölka och köra häst och vagn.',
	'<sup id="cite_ref-FOOTNOTEBremmer201743-45_12-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201743-45-12"><span class="cite-reference-link-bracket"> [</span>11<span class="cite-reference-link-bracket">]</span></a>',
	'</p>',
	'Av sina äldre syskon lärde hon sig spela på alla de instrument som fanns i hemmet: <a href="/wiki/Piano" title="Piano">piano</a>, <a href="/wiki/Dragspel" title="Dragspel">dragspel</a>, <a href="/wiki/Luta" title="Luta">luta</a>, <a href="/wiki/Fiol" class="mw-redirect" title="Fiol">fiol</a>, <a href="/wiki/Banjo" title="Banjo">banjo</a>, <a href="/wiki/Gitarr" title="Gitarr">gitarr</a> och <a href="/wiki/Munspel" title="Munspel">munspel</a>.',
	'Hennes favoritinstrument blev fiol och dragspel.',
	'De hade också många husdjur som hon lekte med på ett naturligt och varsamt sätt, som om de förstod varandra.',
	'<sup id="cite_ref-FOOTNOTEBremmer201746_13-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201746-13"><span class="cite-reference-link-bracket"> [</span>12<span class="cite-reference-link-bracket">]</span></a>',
	'</p>',
	'Hon gick inte i skolan utan undervisades i hemmet av <a href="/wiki/Privatl%C3%A4rare" title="Privatlärare">privatlärare</a>, men ansågs som "arbetsovillig".',
	'Hennes upptåg blev fler, farligare och resulterade i <a href="/wiki/Aga" title="Aga">stryk</a>, <a href="/wiki/Husarrest" title="Husarrest">husarrest</a> och <a href="/wiki/F%C3%B6rbud" title="Förbud">förbud</a>.',
	'När hon var 13 år tog tålamodet därhemma slut, och efter familjeöverläggningar skickades hon till farbror Håkan, <a href="/wiki/Kyrkoherde" title="Kyrkoherde">kyrkoherde</a> i <a href="/wiki/V%C3%A4stbo_kontrakt" title="Västbo kontrakt">Västbo kontrakt</a>, där han bodde och tjänstgjorde i <a href="/wiki/Villstad" title="Villstad">Villstad</a>, en liten by utanför <a href="/wiki/Gislaved" title="Gislaved">Gislaved</a>.',
	'Förhoppningen var att ett år i en <a href="/wiki/H%C3%B6gkyrklighet" title="Högkyrklighet">högkyrklig</a> miljö skulle kurera tonåringens olämpliga sinnelag samt åtgärda hennes dåliga betyg.',
	'Men farbrodern som ansågs vara intelligent, kunnig, god talare och en synnerligen älskvärd sällskapsmänniska visade fram helt andra sidor som <a href="/wiki/Uppfostran" title="Uppfostran">uppfostrare</a>.',
	'Ester Blenda Nordström beskriver i sitt självbiografiska manuskript till Märta Lindqvist<sup id="cite_ref-14" class="reference"><a href="#cite_note-14"><span class="cite-reference-link-bracket"> [</span>13<span class="cite-reference-link-bracket">]</span></a></sup> hur hon bestraffades med risbastu på bara stjärten av kyrkoherden, och hur hon tog sin gruvliga hämnd.',
	'<sup id="cite_ref-FOOTNOTEBremmer201746-49_15-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201746-49-15"><span class="cite-reference-link-bracket"> [</span>14<span class="cite-reference-link-bracket">]</span></a>',
	'</p>',
	'Hemma i Stockholm igen fick hon en ny lärare, men betygen fortsatte att dala.',
	'Vid 16 års ålder flyttade hon med familjen till en stor och flott våning på Kungsholmsgatan 29.',
	'Då hade brodern Frithiof redan flyttat hemifrån, tagit <a href="/wiki/Tandl%C3%A4kare" title="Tandläkare">tandläkarexamen</a>, startat egen praktik och stod i begrepp att gifta sig med Gerda von Porat, prästdotter från <a href="/wiki/Tumba" title="Tumba">Tumba</a> och släkt med farbror Håkans fru.',
	'Ester och Gerda blev genast goda vänner och det livet ut.',
	'<sup id="cite_ref-FOOTNOTEBremmer201749-51_16-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201749-51-16"><span class="cite-reference-link-bracket"> [</span>15<span class="cite-reference-link-bracket">]</span></a>',
	'</p>',
	'Ester Blenda Nordström började först på <a href="/wiki/Wallinska_flickskolan" class="mw-redirect" title="Wallinska flickskolan">Wallinska flickskolan</a> och fick bättre betyg, och när hon sedan bytte till <a href="/wiki/Palmgrenska_samskolan" title="Palmgrenska samskolan">Palmgrenska samskolan</a> för både pojkar och flickor fortsatte betygen att förbättras, förutom det i uppförande.',
	'Inför hennes studentexamen anställde familjen en extralärare och Nordström fick betyget "med beröm godkänt" för sitt uppsatsskrivande i svenska.',
	'<sup id="cite_ref-FOOTNOTEBremmer201752-53_17-0" class="reference"><a href="#cite_note-FOOTNOTEBremmer201752-53-17"><span class="cite-reference-link-bracket"> [</span>16<span class="cite-reference-link-bracket">]</span></a>',
	'</p>',
	'Familjens förmögenhet ökade och tillät pappa Daniel att köpa flera tomter vid <a href="/wiki/Skurusundet" title="Skurusundet">Skurusundet</a> på <a href="/wiki/V%C3%A4rmd%C3%B6" title="Värmdö">Värmdö</a> utanför Stockholm.',
	'Där, i nära anslutning till <a href="/wiki/Eken%C3%A4s" title="Ekenäs">Ekenäs</a> brygga och <a href="/wiki/Waxholm" class="mw-redirect" title="Waxholm">Waxholmsbåtarna</a>, uppfördes familjens <i>Ekefors</i> med tolvrumsvilla och rymlig målarateljé.',
	'Daniel Nordström hade fått det hedrande uppdraget att måla 21 landskapsbilder i taket på nyrestaurerade salongen Grand Restaurang National, nuvarande <a href="/wiki/Nalen" title="Nalen">Nalen</a>, på Regeringsgatan 74.',
	'<sup id="cite_ref-FOOTNOTEBremmer201752-53_17-1" class="reference"><a href="#cite_note-FOOTNOTEBremmer201752-53-17"><span class="cite-reference-link-bracket"> [</span>16<span class="cite-reference-link-bracket">]</span></a>',
	'</p>'
```

</details>

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Test case 1

* Set your website language to Hebrew.
* Paste the following text: 
```
שון בחירות שתי את, שמו גם אקראי פילוסופיה (למאמרים שימושיים על שמו) על אתה רשימות לערכים, עסקים מרצועת אם אחד היום אירועים אקטואליה כלל של.
```

Expected behavior after this PR was implemented:
* The sentence length assessment should show a red bullet (because the text is correctly interpreted as one long sentence).

Expected behavior before this PR was implemented:
* The sentence length assessment would show a green bullet (because the text is was incorrectly split at the closing parenthesis).

### Test case 2
* Set your website language to English.
* Paste the following text:"
```
Est erant ridens id, mutat partem id eum ex integre propriae (dissentias) Nec per cu nulla mundi labore, dico vide in sed eu has erroribus gloriatur adolescens, ea vitae alterum.
```

Expected behavior after this PR was implemented:
* The sentence length assessment should show a red bullet (because the text is correctly interpreted as one long sentence).

Expected behavior before this PR was implemented:
* The sentence length assessment would show a green bullet (because the text is was incorrectly split at the closing parenthesis).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

https://yoast.atlassian.net/browse/LIN-486