### PR TITLE
Remove Hebrew functionality from 14.8

### DIFF
--- a/packages/yoastseo/spec/helpers/getFunctionWordsLanguagesSpec.js
+++ b/packages/yoastseo/spec/helpers/getFunctionWordsLanguagesSpec.js
@@ -2,6 +2,6 @@ import getFunctionWordsLanguages from "../../src/helpers/getFunctionWordsLanguag
 
 describe( "Checks which languages have function word support in YoastSEO.js", function() {
 	it( "returns an array of languages that have function word support", function() {
-		expect( getFunctionWordsLanguages() ).toEqual( [ "en", "de", "nl", "fr", "es", "it", "pt", "ru", "pl", "sv", "id", "he", "ar" ] );
+		expect( getFunctionWordsLanguages() ).toEqual( [ "en", "de", "nl", "fr", "es", "it", "pt", "ru", "pl", "sv", "id", "ar" ] );
 	} );
 } );

--- a/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
+++ b/packages/yoastseo/spec/researches/buildTopicStemsSpec.js
@@ -356,16 +356,6 @@ describe( "A test for building keyword and synonyms stems for a paper", function
 } );
 
 describe( "A test for filtering function words in supported languages", function() {
-	// Function word: שני
-	const forms = buildStems( "שני תפוחים", "he", false );
-	expect( forms ).toEqual(
-		new TopicPhrase(
-			[ new StemOriginalPair( "תפוחים", "תפוחים" ) ],
-			false )
-	);
-} );
-
-describe( "A test for filtering function words in supported languages", function() {
 	// Function word: هذه
 	const forms = buildStems( "هذه المعلومات", "ar", false );
 	expect( forms ).toEqual(

--- a/packages/yoastseo/spec/researches/getWordFormsSpec.js
+++ b/packages/yoastseo/spec/researches/getWordFormsSpec.js
@@ -305,59 +305,6 @@ describe( "A test for getting word forms from the text, based on the stems of a 
 } );
 
 describe( "A test for creating basic morphology forms in supported languages", () => {
-	it( "returns all possible prefixed forms for Hebrew keyphrases", () => {
-		const attributes = {
-			keyword: "בראשית לארץ",
-			locale: "he_IL",
-		};
-		const testPaper = new Paper( "", attributes );
-		const researcher = new Researcher( testPaper );
-
-		expect( getWordForms( testPaper, researcher ) ).toEqual(
-			{
-				keyphraseForms: [
-					[
-						"בראשית",
-						"בבראשית",
-						"הבראשית",
-						"ובראשית",
-						"כבראשית",
-						"לבראשית",
-						"מבראשית",
-						"שבראשית",
-						"ראשית",
-						"הראשית",
-						"וראשית",
-						"כראשית",
-						"לראשית",
-						"מראשית",
-						"שראשית",
-					],
-					[
-						"לארץ",
-						"בלארץ",
-						"הלארץ",
-						"ולארץ",
-						"כלארץ",
-						"ללארץ",
-						"מלארץ",
-						"שלארץ",
-						"ארץ",
-						"בארץ",
-						"הארץ",
-						"וארץ",
-						"כארץ",
-						"מארץ",
-						"שארץ",
-					],
-				],
-				synonymsForms: [],
-			}
-		);
-	} );
-} );
-
-describe( "A test for creating basic morphology forms in supported languages", () => {
 	it( "returns all possible prefixed forms for Arabic keyphrases", () => {
 		const attributes = {
 			keyword: "لتجاهل الرسالة",

--- a/packages/yoastseo/src/helpers/getBasicWordForms.js
+++ b/packages/yoastseo/src/helpers/getBasicWordForms.js
@@ -1,4 +1,3 @@
-import { createBasicWordForms as createBasicWordFormsHebrew } from "../morphology/hebrew/createBasicWordForms";
 import { createBasicWordForms as createBasicWordFormsArabic } from "../morphology/arabic/createBasicWordForms";
 
 /**
@@ -8,7 +7,6 @@ import { createBasicWordForms as createBasicWordFormsArabic } from "../morpholog
  */
 export default function() {
 	return {
-		he: createBasicWordFormsHebrew,
 		ar: createBasicWordFormsArabic,
 	};
 }

--- a/packages/yoastseo/src/helpers/getFunctionWords.js
+++ b/packages/yoastseo/src/helpers/getFunctionWords.js
@@ -26,8 +26,6 @@ import swedishFunctionWordsFactory from "../researches/swedish/functionWords.js"
 const swedishFunctionWords = swedishFunctionWordsFactory();
 import indonesianFunctionWordsFactory from "../researches/indonesian/functionWords.js";
 const indonesianFunctionWords = indonesianFunctionWordsFactory();
-import hebrewFunctionWordsFactory from "../researches/hebrew/functionWords.js";
-const hebrewFunctionWords = hebrewFunctionWordsFactory();
 import arabicFunctionWordsFactory from "../researches/arabic/functionWords.js";
 const arabicFunctionWords = arabicFunctionWordsFactory();
 
@@ -49,7 +47,6 @@ export default function() {
 		pl: polishFunctionWords,
 		sv: swedishFunctionWords,
 		id: indonesianFunctionWords,
-		he: hebrewFunctionWords,
 		ar: arabicFunctionWords,
 	};
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Removes Hebrew function words and prefix processing from 14.8.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### Testing tokenization
- Use Free plugin to execute the test
- Set the following text:
אמנותית: שלב השרבוט , שלב הסכימה והשלב הנטורליסטי. ב-1921 יצר הפסיכולוג החינוכי סיריל ברט ((אנ')‏ Cyril Burt) חלוקה חדשה של התפתחות ציורי ילדים לארבעה שלבים. אחריו, בשנת 1927, יצר ז'ורז'-אנרי לוקה ((צר') ‏Georges-Henri Luquet) שלבים, שבבסיסם עומדת ההנחה שהילד מצייר באופן ריאליסטי זמן רב לפני שהוא מסוגל לצייר את מה שהוא רואה באמת. על בסיס שלביו של לוקה, קבעו הפסיכולוגים ההתפתחותיים ז'אן פיאז'ה וברבל אינהלדר ((אנ')‏ Bärbel Inhelder) כי התפתחות הציור מקבילה להתפתחותו האינטלקטואלית של הילד, המתבטאת בהתפתחות הראייה ההנדסית והמרחבית (ארגון המרחב, שליטה ובקרה בעיצוב הקו), ובהתאם להתפתחות החשיבה. בשנת 1947 תיאר איש החינוך לאמנות ויקטור לוונפלד ((אנ')‏ Viktor Lowenfeld) שישה שלבים עיקריים בהתפתחות הגרפית של ילדים, וזאת על בסיס עבודתו של ברט ובדומה לתאוריית ההתפתחות הקוגניטיבית של פיאז'ה; עבודתו זו מהווה עד היום בסיס לבחינת התפתחות ציורי ילדים.
אמנותית: שלב השרבוט , שלב הסכימה והשלב הנטורליסטי. ב-1921 יצר הפסיכולוג החינוכי סיריל ברט ((אנ')‏ Cyril Burt) חלוקה חדשה של התפתחות ציורי ילדים לארבעה שלבים. אחריו, בשנת 1927, יצר ז'ורז'-אנרי לוקה ((צר') ‏Georges-Henri Luquet) שלבים, שבבסיסם עומדת ההנחה שהילד מצייר באופן ריאליסטי זמן רב לפני שהוא מסוגל לצייר את מה שהוא רואה באמת. על בסיס שלביו של לוקה, קבעו הפסיכולוגים ההתפתחותיים ז'אן פיאז'ה וברבל אינהלדר ((אנ')‏ Bärbel Inhelder) כי התפתחות הציור מקבילה להתפתחותו האינטלקטואלית של הילד, המתבטאת בהתפתחות הראייה ההנדסית והמרחבית (ארגון המרחב, שליטה ובקרה בעיצוב הקו), ובהתאם להתפתחות החשיבה. בשנת 1947 תיאר איש החינוך לאמנות ויקטור לוונפלד ((אנ')‏ Viktor Lowenfeld) שישה שלבים עיקריים בהתפתחות הגרפית של ילדים, וזאת על בסיס עבודתו של ברט ובדומה לתאוריית ההתפתחות הקוגניטיבית של פיאז'ה; עבודתו זו מהווה עד היום בסיס לבחינת התפתחות ציורי ילדים.
- Set the keyphrase: `חדשה באמת`
- Set the meta description: `.חדשה. באמת`
- You don't need to set WordPress to Hebrew.
- Check that the results of text analysis are correct:
  - Sentence length
Sentence length: Great!
(Reason: the text is split up correctly into short sentences now)

  - Keyphrase in introduction
`Keyphrase in introduction: Your keyphrase or its synonyms appear in the first paragraph of the copy, but not within one sentence. Fix that!`
(Reason: the keyphrase doesn't actually occur in one single sentence and therefore shouldn't be matched)

  - Keyphrase density
`Keyphrase density: The focus keyphrase was found 0 times. That's less than the recommended minimum of 2 times for a text of this length. Focus on your keyphrase!`
(Reason: the keyphrase doesn't actually occur in one single sentence and therefore shouldn't be matched)

  - Keyphrase in meta description
`Keyphrase in meta description: The meta description has been specified, but it does not contain the keyphrase. Fix that!`
(Reason: the keyphrase doesn't actually occur in one single sentence in the meta description and therefore shouldn't be matched)

### Testing improved keyphrase recognition for Arabic
* Set your site to Arabic.
* Test prefixation:
  * As your keyphrase, set the word `منزل`.
  * Paste a text of at least 150 words.
  * In the text, add the form `المنزل`.
  * Switch the morphology button to Off
  * The keyphrase density assessment should show 1 keyphrase occurrence. When clicking on the marker for the assessment, `المنزل` should be marked.
  * Switch the form in the text to a form with another prefix, e.g. `كمنزل`.
* Test function words:
  * Create a new post and add a text with at least 150 words.
  * Set your keyphrase to `هذان الزوجان`.
  * Add the word `الزوجان` to the text.
  * Make sure that the keyphrase density shows that the keyphrase is found once.

### Testing improved Internal linking suggestions and Insights for Arabic
* Set your site to Arabic
* Enter an Arabic text
* Pick any Arabic function word from [this list](https://github.com/Yoast/javascript/blob/develop/packages/yoastseo/src/researches/arabic/functionWords.js) and add it to the text some 20-30 times. 
* Check that this word does not appear in the list of Insights.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-545
