### PR TITLE
Make feedback strings in the keyphrase in subheadings assessment more explicit

### DIFF
--- a/packages/yoastseo/spec/assessments/SubHeadingsKeywordAssessmentSpec.js
+++ b/packages/yoastseo/spec/assessments/SubHeadingsKeywordAssessmentSpec.js
@@ -16,7 +16,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!"
 		);
 	} );
 
@@ -30,7 +30,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!"
 		);
 	} );
 
@@ -44,7 +44,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: Your higher-level subheading reflects the topic of your copy. Good job!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: Your H2 or H3 subheading reflects the topic of your copy. Good job!"
 		);
 	} );
 
@@ -58,7 +58,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 1 of your higher-level subheadings reflects the topic of your copy. Good job!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 1 of your H2 and H3 subheadings reflects the topic of your copy. Good job!"
 		);
 	} );
 
@@ -72,7 +72,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 2 of your higher-level subheadings reflect the topic of your copy. Good job!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: 2 of your H2 and H3 subheadings reflect the topic of your copy. Good job!"
 		);
 	} );
 
@@ -86,7 +86,7 @@ describe( "An assessment for matching keywords in subheadings", () => {
 
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual(
-			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: More than 75% of your higher-level subheadings reflect the topic of your copy. That's too much. <a href='https://yoa.st/33n' target='_blank'>Don't over-optimize</a>!"
+			"<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: More than 75% of your H2 and H3 subheadings reflect the topic of your copy. That's too much. <a href='https://yoa.st/33n' target='_blank'>Don't over-optimize</a>!"
 		);
 	} );
 

--- a/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper1.js
@@ -45,7 +45,7 @@ const expectedResults = {
 	subheadingsKeyword: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper2.js
@@ -44,7 +44,7 @@ const expectedResults = {
 	subheadingsKeyword: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/de/germanPaper3.js
@@ -45,7 +45,7 @@ const expectedResults = {
 	subheadingsKeyword: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper1.js
@@ -45,7 +45,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 9,
 		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
-			"2 of your higher-level subheadings reflect the topic of your copy. Good job!",
+			"2 of your H2 and H3 subheadings reflect the topic of your copy. Good job!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper2.js
@@ -45,7 +45,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 9,
 		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
-			"1 of your higher-level subheadings reflects the topic of your copy. Good job!",
+			"1 of your H2 and H3 subheadings reflects the topic of your copy. Good job!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/en/englishPaper3.js
@@ -45,7 +45,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 3,
 		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
-			"More than 75% of your higher-level subheadings reflect the topic of your copy. That's too much. " +
+			"More than 75% of your H2 and H3 subheadings reflect the topic of your copy. That's too much. " +
 			"<a href='https://yoa.st/33n' target='_blank'>Don't over-optimize</a>!",
 	},
 	textCompetingLinks: {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper1.js
@@ -44,7 +44,7 @@ const expectedResults = {
 	subheadingsKeyword: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/es/spanishPaper2.js
@@ -44,7 +44,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 9,
 		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
-			"2 of your higher-level subheadings reflect the topic of your copy. Good job!",
+			"2 of your H2 and H3 subheadings reflect the topic of your copy. Good job!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper1.js
@@ -45,7 +45,7 @@ const expectedResults = {
 	subheadingsKeyword: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper2.js
@@ -44,7 +44,7 @@ const expectedResults = {
 	subheadingsKeyword: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/fr/frenchPaper3.js
@@ -43,7 +43,7 @@ const expectedResults = {
 	subheadingsKeyword: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/it/italianPaper1.js
@@ -44,7 +44,7 @@ const expectedResults = {
 	subheadingsKeyword: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper1.js
@@ -45,7 +45,7 @@ const expectedResults = {
 	subheadingsKeyword: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/pl/polishPaper3.js
@@ -45,7 +45,7 @@ const expectedResults = {
 	subheadingsKeyword: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper1.js
@@ -44,7 +44,7 @@ const expectedResults = {
 	subheadingsKeyword: {
 		isApplicable: true,
 		score: 3,
-		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: <a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/ru/russianPaper3.js
@@ -44,7 +44,7 @@ const expectedResults = {
 		isApplicable: true,
 		score: 3,
 		resultText: "<a href='https://yoa.st/33m' target='_blank'>Keyphrase in subheading</a>: " +
-			"<a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your higher-level subheadings</a>!",
+			"<a href='https://yoa.st/33n' target='_blank'>Use more keyphrases or synonyms in your H2 and H3 subheadings</a>!",
 	},
 	textCompetingLinks: {
 		isApplicable: true,

--- a/packages/yoastseo/src/assessments/seo/SubHeadingsKeywordAssessment.js
+++ b/packages/yoastseo/src/assessments/seo/SubHeadingsKeywordAssessment.js
@@ -152,7 +152,7 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 					/* Translators: %1$s and %2$s expand to a link on yoast.com, %3$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your higher-level subheadings%3$s!",
+						"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your H2 and H3 subheadings%3$s!",
 					),
 					this._config.urlTitle,
 					this._config.urlCallToAction,
@@ -168,7 +168,7 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 					/* Translators: %1$s and %2$s expand to a link on yoast.com, %3$s expands to the anchor end tag. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in subheading%3$s: More than 75%% of your higher-level subheadings reflect the topic of your copy. " +
+						"%1$sKeyphrase in subheading%3$s: More than 75%% of your H2 and H3 subheadings reflect the topic of your copy. " +
 						"That's too much. %2$sDon't over-optimize%3$s!",
 					),
 					this._config.urlTitle,
@@ -186,7 +186,7 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 					%3$d expands to the number of subheadings containing the keyphrase. */
 					i18n.dgettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in subheading%2$s: Your higher-level subheading reflects the topic of your copy. Good job!",
+						"%1$sKeyphrase in subheading%2$s: Your H2 or H3 subheading reflects the topic of your copy. Good job!",
 						this._subHeadings.matches,
 					),
 					this._config.urlTitle,
@@ -203,8 +203,8 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 					%3$d expands to the number of subheadings containing the keyphrase. */
 					i18n.dngettext(
 						"js-text-analysis",
-						"%1$sKeyphrase in subheading%2$s: %3$s of your higher-level subheadings reflects the topic of your copy. Good job!",
-						"%1$sKeyphrase in subheading%2$s: %3$s of your higher-level subheadings reflect the topic of your copy. Good job!",
+						"%1$sKeyphrase in subheading%2$s: %3$s of your H2 and H3 subheadings reflects the topic of your copy. Good job!",
+						"%1$sKeyphrase in subheading%2$s: %3$s of your H2 and H3 subheadings reflect the topic of your copy. Good job!",
 						this._subHeadings.matches,
 					),
 					this._config.urlTitle,
@@ -220,7 +220,7 @@ export default class SubHeadingsKeywordAssessment extends Assessment {
 				/* Translators: %1$s and %2$s expand to a link on yoast.com, %3$s expands to the anchor end tag. */
 				i18n.dgettext(
 					"js-text-analysis",
-					"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your higher-level subheadings%3$s!",
+					"%1$sKeyphrase in subheading%3$s: %2$sUse more keyphrases or synonyms in your H2 and H3 subheadings%3$s!",
 				),
 				this._config.urlTitle,
 				this._config.urlCallToAction,


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Makes feedback string in the keyphrase in subheadings assessment more explicit.
* [Yoast SEO Free] Improves feedback string in the Keyphrase in Subheadings assessment to make it more explicit.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check the behavior of the Keyphrase in subheadings assessment. In all these cases the assessment should return feedback about "H2 and H3 subheadings", not about "higher-level subheadings".
  * Add a text with H2 and H3 subheadings, but do not use the keyphrase in the subheadings.
  * Add a text with H2 and H3 subheadings, use the keyphrase in all of them.
  * Add a text with H2 and H3 subheadings, use the keyphrase in half of them.
  * Add a text with H2 and H3 subheadings, use the keyphrase in one of them.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-548
