### PR TITLE
Add onInputHandler to Select so that we can access input events

### DIFF
--- a/packages/components/src/select/Select.js
+++ b/packages/components/src/select/Select.js
@@ -159,6 +159,7 @@ export class Select extends React.Component {
 	constructor( props ) {
 		super( props );
 		this.onBlurHandler = this.onBlurHandler.bind( this );
+		this.onInputHandler = this.onInputHandler.bind( this );
 	}
 
 	/**
@@ -175,6 +176,19 @@ export class Select extends React.Component {
 		this.props.onChange( event.target.value );
 	}
 
+	/**
+	 * Passes the target's name and input value to the onOptionFocus function.
+	 *
+	 * NOTE: Please do not pass functions to props.onOptionFocus that would induce a context change in the DOM (navigation, focus changes).
+	 *       This is an a11y concern, because it disorients keyboard and screenreader users.
+	 *
+	 * @param {Event} event The event triggered by an Input.
+	 *
+	 * @returns {void}
+	 */
+	onInputHandler( event ) {
+		this.props.onOptionFocus( event.target.name, event.target.value );
+	}
 	/**
 	 * Render function for component.
 	 *
@@ -202,6 +216,7 @@ export class Select extends React.Component {
 					name={ name }
 					defaultValue={ selection }
 					onBlur={ this.onBlurHandler }
+					onInput={ this.onInputHandler }
 				>
 					{ options.map( Option ) }
 				</select>
@@ -210,5 +225,11 @@ export class Select extends React.Component {
 	}
 }
 
-Select.propTypes = selectProps;
-Select.defaultProps = selectDefaultProps;
+Select.propTypes = {
+	...selectProps,
+	onOptionFocus: PropTypes.func,
+};
+Select.defaultProps = {
+	...selectDefaultProps,
+	onOptionFocus: () => {},
+};

--- a/packages/components/src/select/Select.js
+++ b/packages/components/src/select/Select.js
@@ -177,7 +177,7 @@ export class Select extends React.Component {
 	}
 
 	/**
-	 * Passes the target's name and input value to the onOptionFocus function.
+	 * Passes the target's name and input value to the onOptionFocus function if it exists.
 	 *
 	 * NOTE: Please do not pass functions to props.onOptionFocus that would induce a context change in the DOM (navigation, focus changes).
 	 *       This is an a11y concern, because it disorients keyboard and screenreader users.
@@ -200,6 +200,7 @@ export class Select extends React.Component {
 			selected,
 			options,
 			name,
+			onOptionFocus,
 			...fieldGroupProps
 		} = this.props;
 
@@ -216,7 +217,7 @@ export class Select extends React.Component {
 					name={ name }
 					defaultValue={ selection }
 					onBlur={ this.onBlurHandler }
-					onInput={ this.onInputHandler }
+					onInput={ onOptionFocus ? this.onInputHandler : null }
 				>
 					{ options.map( Option ) }
 				</select>
@@ -231,5 +232,5 @@ Select.propTypes = {
 };
 Select.defaultProps = {
 	...selectDefaultProps,
-	onOptionFocus: () => {},
+	onOptionFocus: null,
 };

--- a/packages/components/tests/__snapshots__/SelectTest.js.snap
+++ b/packages/components/tests/__snapshots__/SelectTest.js.snap
@@ -51,6 +51,7 @@ exports[`Select should render a select 1`] = `
     id="my-awesome-multiselect"
     name="my-selection"
     onBlur={[Function]}
+    onInput={null}
   >
     <option
       value="hi"


### PR DESCRIPTION
## Summary

Needed for https://github.com/Yoast/wordpress-seo/pull/15844 due to https://yoast.atlassian.net/browse/P1-120

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Allows passing an optional onOptionFocus prop to the Select component, which should be a function. When an input event is fired, the Select calls onOptionFocus with the select's name, and the current input value.


See https://github.com/Yoast/wordpress-seo/pull/15844

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-120
