### PR TITLE
Socials: change width to max-width

### DIFF
--- a/packages/social-metadata-previews/src/facebook/FacebookDescription.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookDescription.js
@@ -44,6 +44,10 @@ const FacebookDescription = styled.p`
 	-webkit-line-clamp: ${ props => determineClamp( props.mode ) };
 	-webkit-box-orient: vertical;
 	overflow: hidden;
+
+	@media all and ( max-width: ${ props => props.maxWidth } ) {
+		display: none;
+	}
 `;
 
 export default FacebookDescription;

--- a/packages/social-metadata-previews/src/facebook/FacebookImage.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookImage.js
@@ -16,7 +16,7 @@ import {
 const FacebookImageContainer = styled.div`
 	position: relative;
 	height: ${ props => props.dimensions.height };
-	width: ${ props => props.dimensions.width };
+	max-width: ${ props => props.dimensions.width };
 	overflow: hidden;
 	background-color: ${ colors.$color_white };
 `;
@@ -24,7 +24,7 @@ const FacebookImageContainer = styled.div`
 // Adding && for specificity, competing styles coming from blockeditor
 const StyledImage = styled.img`
 	&& {
-		width: ${ props => props.imageProperties.width }px;
+		max-width: ${ props => props.imageProperties.width }px;
 		height: ${ props => props.imageProperties.height }px;
 		position: absolute;
 		top: 50%;
@@ -36,7 +36,7 @@ const StyledImage = styled.img`
 
 const PlaceholderImage = styled.div`
 	box-sizing: border-box;
-	width: ${ FACEBOOK_IMAGE_SIZES.landscapeWidth }px;
+	max-width: ${ FACEBOOK_IMAGE_SIZES.landscapeWidth }px;
 	height: ${ FACEBOOK_IMAGE_SIZES.landscapeHeight }px;
 	background-color: ${ colors.$color_grey };
 	border-style: dashed;

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -61,7 +61,6 @@ const FacebookPreviewWrapper = styled.div`
 	flex-direction: ${ props => props.mode === "landscape" ? "column" : "row" };
 	background-color: #f2f3f5;
 	max-width: 527px;
-	height: ${ props => determineWrapperHeight( props.mode ) };
 `;
 
 const FacebookTextWrapper = styled.div`
@@ -78,7 +77,6 @@ const FacebookTextWrapper = styled.div`
 	flex-direction: column;
 	justify-content: ${ props => props.mode === "landscape" ? "flex-start" : "center" };
 	max-width: ${ props => determineTextContainerWidth( props.mode ) };
-	${ props => props.mode === "landscape"  ? "height: 78px;" : "" }
 	font-size: 12px;
 	overflow: hidden;
 `;

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -42,7 +42,7 @@ const determineWrapperHeight = ( mode ) => {
 const determineTextContainerWidth = ( mode ) => {
 	switch ( mode ) {
 		case "landscape":
-			return "527x";
+			return "527px";
 
 		case "square":
 			return "369px";
@@ -60,7 +60,7 @@ const FacebookPreviewWrapper = styled.div`
 	display: flex;
 	flex-direction: ${ props => props.mode === "landscape" ? "column" : "row" };
 	background-color: #f2f3f5;
-	width: 527px;
+	max-width: 527px;
 	height: ${ props => determineWrapperHeight( props.mode ) };
 `;
 
@@ -77,7 +77,7 @@ const FacebookTextWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
 	justify-content: ${ props => props.mode === "landscape" ? "flex-start" : "center" };
-	width: ${ props => determineTextContainerWidth( props.mode ) };
+	max-width: ${ props => determineTextContainerWidth( props.mode ) };
 	${ props => props.mode === "landscape"  ? "height: 78px;" : "" }
 	font-size: 12px;
 	overflow: hidden;
@@ -160,6 +160,7 @@ class FacebookPreview extends Component {
 						{ this.props.title }
 					</FacebookTitle>
 					<FacebookDescription
+						maxWidth={ determineTextContainerWidth( imageMode ) }
 						onMouseEnter={ this.onDescriptionEnter }
 						onMouseLeave={ this.onLeave }
 						onClick={ this.onSelectDescription }

--- a/packages/social-metadata-previews/src/facebook/FacebookPreview.js
+++ b/packages/social-metadata-previews/src/facebook/FacebookPreview.js
@@ -10,29 +10,6 @@ import FacebookTitle from "./FacebookTitle";
 import FacebookDescription from "./FacebookDescription";
 
 /**
- * Determines the height depending on the mode.
- *
- * @param {string} mode The mode. landscape, square, portrait.
- *
- * @returns {string} The height pixels.
- */
-const determineWrapperHeight = ( mode ) => {
-	switch ( mode ) {
-		case "landscape":
-			return "352px";
-
-		case "square":
-			return "158px";
-
-		case "portrait":
-			return "237px";
-
-		default:
-			return "57px";
-	}
-};
-
-/**
  * Determines the width depending on the mode.
  *
  * @param {string} mode The mode. landscape, square, portrait.

--- a/packages/social-metadata-previews/src/twitter/TwitterDescription.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterDescription.js
@@ -1,5 +1,6 @@
 /* External dependencies */
 import styled from "styled-components";
+import { TWITTER_IMAGE_SIZES } from "../helpers/determineImageProperties";
 
 /**
  * Renders a TwitterDescription component.
@@ -22,6 +23,10 @@ const TwitterDescription = styled.p`
 	cursor: pointer;
 	-webkit-line-clamp: 2;
 	-webkit-box-orient: vertical;
+
+	@media all and ( max-width: ${ TWITTER_IMAGE_SIZES.landscapeWidth }px ) {
+		display: none;
+	}
 `;
 
 export default TwitterDescription;

--- a/packages/social-metadata-previews/src/twitter/TwitterImage.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterImage.js
@@ -31,7 +31,7 @@ const injectCardDependentStyles = ( isLarge, border = true ) => {
 	}
 	return (
 		`
-		max-width: ${ TWITTER_IMAGE_SIZES.squareWidth }px;
+		width: ${ TWITTER_IMAGE_SIZES.squareWidth }px;
 		${ border ? "border-right: 1px solid #E1E8ED;" : "" }
 		border-radius: 14px 0 0 14px;
 		`

--- a/packages/social-metadata-previews/src/twitter/TwitterImage.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterImage.js
@@ -23,7 +23,7 @@ const injectCardDependentStyles = ( isLarge, border = true ) => {
 		return (
 			`
 			height: ${ TWITTER_IMAGE_SIZES.landscapeHeight }px;
-			width: ${ TWITTER_IMAGE_SIZES.landscapeWidth }px;
+			max-width: ${ TWITTER_IMAGE_SIZES.landscapeWidth }px;
 			${ border ? "border-bottom: 1px solid #E1E8ED;" : "" }
 			border-radius: 14px 14px 0 0;
 			`
@@ -31,7 +31,7 @@ const injectCardDependentStyles = ( isLarge, border = true ) => {
 	}
 	return (
 		`
-		width: ${ TWITTER_IMAGE_SIZES.squareWidth }px;
+		max-width: ${ TWITTER_IMAGE_SIZES.squareWidth }px;
 		${ border ? "border-right: 1px solid #E1E8ED;" : "" }
 		border-radius: 14px 0 0 14px;
 		`
@@ -49,9 +49,8 @@ const TwitterImageContainer = styled.div`
 
 const StyledImage = styled.img`
 	&& {
-		width: ${ props => props.imageProperties.width }px;
+		max-width: ${ props => props.imageProperties.width }px;
 		height: ${ props => props.imageProperties.height }px;
-		max-width: none;
 		position: absolute;
 		top: 50%;
 		left: 50%;

--- a/packages/social-metadata-previews/src/twitter/TwitterPreview.js
+++ b/packages/social-metadata-previews/src/twitter/TwitterPreview.js
@@ -15,7 +15,7 @@ const TwitterPreviewWrapper = styled.div`
 	font-size: 15px;
 	font-weight: 400;
 	line-height: 20px;
-	width: 507px;
+	max-width: 507px;
 	border: 1px solid #E1E8ED;
 	box-sizing: border-box;
 	border-radius: 14px;
@@ -23,7 +23,7 @@ const TwitterPreviewWrapper = styled.div`
 	background: #FFFFFF;
 	text-overflow: ellipsis;
 	display: flex;
-	
+
 	&:hover {
 		background: #f5f8fa;
 		border: 1px solid rgba(136,153,166,.5);

--- a/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookDescriptionTest.js.snap
+++ b/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookDescriptionTest.js.snap
@@ -16,6 +16,12 @@ exports[`FacebookDescription matches the snapshot by default 1`] = `
   overflow: hidden;
 }
 
+@media all and ( max-width:) {
+  .c0 {
+    display: none;
+  }
+}
+
 <p
   className="c0"
 />

--- a/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookImageTest.js.snap
+++ b/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookImageTest.js.snap
@@ -3,7 +3,7 @@
 exports[`FacebookImage Component matches the snapshot for a faulty image 1`] = `
 .c0 {
   box-sizing: border-box;
-  width: 527px;
+  max-width: 527px;
   height: 273px;
   background-color: #ddd;
   border-style: dashed;
@@ -42,13 +42,13 @@ exports[`FacebookImage Component matches the snapshot for a landscape image 1`] 
 .c0 {
   position: relative;
   height: 273px;
-  width: 527px;
+  max-width: 527px;
   overflow: hidden;
   background-color: #fff;
 }
 
 .c1.c1 {
-  width: 600px;
+  max-width: 600px;
   height: 300px;
   position: absolute;
   top: 50%;
@@ -77,13 +77,13 @@ exports[`FacebookImage Component matches the snapshot for a portrait image 1`] =
 .c0 {
   position: relative;
   height: 237px;
-  width: 158px;
+  max-width: 158px;
   overflow: hidden;
   background-color: #fff;
 }
 
 .c1.c1 {
-  width: 300px;
+  max-width: 300px;
   height: 600px;
   position: absolute;
   top: 50%;
@@ -112,13 +112,13 @@ exports[`FacebookImage Component matches the snapshot for a square image 1`] = `
 .c0 {
   position: relative;
   height: 158px;
-  width: 158px;
+  max-width: 158px;
   overflow: hidden;
   background-color: #fff;
 }
 
 .c1.c1 {
-  width: 300px;
+  max-width: 300px;
   height: 300px;
   position: absolute;
   top: 50%;
@@ -147,13 +147,13 @@ exports[`FacebookImage Component matches the snapshot for a too small image 1`] 
 .c0 {
   position: relative;
   height: 158px;
-  width: 158px;
+  max-width: 158px;
   overflow: hidden;
   background-color: #fff;
 }
 
 .c1.c1 {
-  width: 100px;
+  max-width: 100px;
   height: 100px;
   position: absolute;
   top: 50%;
@@ -181,7 +181,7 @@ exports[`FacebookImage Component matches the snapshot for a too small image 1`] 
 exports[`FacebookImage Component matches the snapshot in the loading state 1`] = `
 .c0 {
   box-sizing: border-box;
-  width: 527px;
+  max-width: 527px;
   height: 273px;
   background-color: #ddd;
   border-style: dashed;

--- a/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookPreviewTest.js.snap
+++ b/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookPreviewTest.js.snap
@@ -27,7 +27,7 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
 
 .c1 {
   box-sizing: border-box;
-  width: 527px;
+  max-width: 527px;
   height: 273px;
   background-color: #ddd;
   border-style: dashed;
@@ -100,7 +100,7 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   background-color: #f2f3f5;
-  width: 527px;
+  max-width: 527px;
   height: 57px;
 }
 
@@ -124,9 +124,15 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  width: 476px;
+  max-width: 476px;
   font-size: 12px;
   overflow: hidden;
+}
+
+@media all and ( max-width:476px ) {
+  .c6 {
+    display: none;
+  }
 }
 
 <div
@@ -209,7 +215,7 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
 
 .c1 {
   box-sizing: border-box;
-  width: 527px;
+  max-width: 527px;
   height: 273px;
   background-color: #ddd;
   border-style: dashed;
@@ -282,7 +288,7 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   background-color: #f2f3f5;
-  width: 527px;
+  max-width: 527px;
   height: 57px;
 }
 
@@ -306,9 +312,15 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  width: 476px;
+  max-width: 476px;
   font-size: 12px;
   overflow: hidden;
+}
+
+@media all and ( max-width:476px ) {
+  .c6 {
+    display: none;
+  }
 }
 
 <div
@@ -391,7 +403,7 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
 
 .c1 {
   box-sizing: border-box;
-  width: 527px;
+  max-width: 527px;
   height: 273px;
   background-color: #ddd;
   border-style: dashed;
@@ -464,7 +476,7 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   background-color: #f2f3f5;
-  width: 527px;
+  max-width: 527px;
   height: 57px;
 }
 
@@ -488,9 +500,15 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  width: 476px;
+  max-width: 476px;
   font-size: 12px;
   overflow: hidden;
+}
+
+@media all and ( max-width:476px ) {
+  .c6 {
+    display: none;
+  }
 }
 
 <div
@@ -573,7 +591,7 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
 
 .c1 {
   box-sizing: border-box;
-  width: 527px;
+  max-width: 527px;
   height: 273px;
   background-color: #ddd;
   border-style: dashed;
@@ -646,7 +664,7 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   background-color: #f2f3f5;
-  width: 527px;
+  max-width: 527px;
   height: 57px;
 }
 
@@ -670,9 +688,15 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  width: 476px;
+  max-width: 476px;
   font-size: 12px;
   overflow: hidden;
+}
+
+@media all and ( max-width:476px ) {
+  .c6 {
+    display: none;
+  }
 }
 
 <div
@@ -755,7 +779,7 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
 
 .c1 {
   box-sizing: border-box;
-  width: 527px;
+  max-width: 527px;
   height: 273px;
   background-color: #ddd;
   border-style: dashed;
@@ -828,7 +852,7 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
   -ms-flex-direction: row;
   flex-direction: row;
   background-color: #f2f3f5;
-  width: 527px;
+  max-width: 527px;
   height: 57px;
 }
 
@@ -852,9 +876,15 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
   -webkit-justify-content: center;
   -ms-flex-pack: center;
   justify-content: center;
-  width: 476px;
+  max-width: 476px;
   font-size: 12px;
   overflow: hidden;
+}
+
+@media all and ( max-width:476px ) {
+  .c6 {
+    display: none;
+  }
 }
 
 <div

--- a/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookPreviewTest.js.snap
+++ b/packages/social-metadata-previews/tests/facebook/__snapshots__/FacebookPreviewTest.js.snap
@@ -101,7 +101,6 @@ exports[`FacebookPreview matches the snapshot for a faulty image 1`] = `
   flex-direction: row;
   background-color: #f2f3f5;
   max-width: 527px;
-  height: 57px;
 }
 
 .c2 {
@@ -289,7 +288,6 @@ exports[`FacebookPreview matches the snapshot for a landscape image 1`] = `
   flex-direction: row;
   background-color: #f2f3f5;
   max-width: 527px;
-  height: 57px;
 }
 
 .c2 {
@@ -477,7 +475,6 @@ exports[`FacebookPreview matches the snapshot for a portrait image 1`] = `
   flex-direction: row;
   background-color: #f2f3f5;
   max-width: 527px;
-  height: 57px;
 }
 
 .c2 {
@@ -665,7 +662,6 @@ exports[`FacebookPreview matches the snapshot for a square image 1`] = `
   flex-direction: row;
   background-color: #f2f3f5;
   max-width: 527px;
-  height: 57px;
 }
 
 .c2 {
@@ -853,7 +849,6 @@ exports[`FacebookPreview matches the snapshot for a too small image 1`] = `
   flex-direction: row;
   background-color: #f2f3f5;
   max-width: 527px;
-  height: 57px;
 }
 
 .c2 {

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterDescriptionTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterDescriptionTest.js.snap
@@ -16,6 +16,12 @@ exports[`TwitterDescription matches the snapshot for the summary card 1`] = `
   -webkit-box-orient: vertical;
 }
 
+@media all and ( max-width:506px ) {
+  .c0 {
+    display: none;
+  }
+}
+
 <p
   className="c0"
 />
@@ -35,6 +41,12 @@ exports[`TwitterDescription matches the snapshot for the summary with large imag
   cursor: pointer;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+}
+
+@media all and ( max-width:506px ) {
+  .c0 {
+    display: none;
+  }
 }
 
 <p

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterImageTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterImageTest.js.snap
@@ -9,7 +9,7 @@ exports[`TwitterImage Component matches the snapshot for a landscape image in a 
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  max-width: 125px;
+  width: 125px;
   border-right: 1px solid #E1E8ED;
   border-radius: 14px 0 0 14px;
 }
@@ -88,7 +88,7 @@ exports[`TwitterImage Component matches the snapshot for a square image in a sum
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  max-width: 125px;
+  width: 125px;
   border-right: 1px solid #E1E8ED;
   border-radius: 14px 0 0 14px;
 }

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterImageTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterImageTest.js.snap
@@ -9,15 +9,14 @@ exports[`TwitterImage Component matches the snapshot for a landscape image in a 
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  width: 125px;
+  max-width: 125px;
   border-right: 1px solid #E1E8ED;
   border-radius: 14px 0 0 14px;
 }
 
 .c1.c1 {
-  width: 600px;
+  max-width: 600px;
   height: 300px;
-  max-width: none;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -50,15 +49,14 @@ exports[`TwitterImage Component matches the snapshot for a landscape image in a 
   -ms-flex-negative: 0;
   flex-shrink: 0;
   height: 265px;
-  width: 506px;
+  max-width: 506px;
   border-bottom: 1px solid #E1E8ED;
   border-radius: 14px 14px 0 0;
 }
 
 .c1.c1 {
-  width: 600px;
+  max-width: 600px;
   height: 300px;
-  max-width: none;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -90,15 +88,14 @@ exports[`TwitterImage Component matches the snapshot for a square image in a sum
   -webkit-flex-shrink: 0;
   -ms-flex-negative: 0;
   flex-shrink: 0;
-  width: 125px;
+  max-width: 125px;
   border-right: 1px solid #E1E8ED;
   border-radius: 14px 0 0 14px;
 }
 
 .c1.c1 {
-  width: 300px;
+  max-width: 300px;
   height: 300px;
-  max-width: none;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -131,15 +128,14 @@ exports[`TwitterImage Component matches the snapshot for a square image in a sum
   -ms-flex-negative: 0;
   flex-shrink: 0;
   height: 265px;
-  width: 506px;
+  max-width: 506px;
   border-bottom: 1px solid #E1E8ED;
   border-radius: 14px 14px 0 0;
 }
 
 .c1.c1 {
-  width: 300px;
+  max-width: 300px;
   height: 300px;
-  max-width: none;
   position: absolute;
   top: 50%;
   left: 50%;
@@ -183,7 +179,7 @@ exports[`TwitterImage Component matches the snapshot in the loading state 1`] = 
   text-align: center;
   font-size: 1rem;
   height: 265px;
-  width: 506px;
+  max-width: 506px;
   border-radius: 14px 14px 0 0;
   border-top-left-radius: 14px;
   border-top-right-radius: 14px;

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
@@ -47,7 +47,7 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   padding: 1em;
   text-align: center;
   font-size: 1rem;
-  width: 125px;
+  max-width: 125px;
   border-radius: 14px 0 0 14px;
   border-top-left-radius: 14px;
   border-bottom-left-radius: 14px;
@@ -115,7 +115,7 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   font-size: 15px;
   font-weight: 400;
   line-height: 20px;
-  width: 507px;
+  max-width: 507px;
   border: 1px solid #E1E8ED;
   box-sizing: border-box;
   border-radius: 14px;
@@ -135,6 +135,12 @@ exports[`TwitterPreview matches the snapshot 1`] = `
 .c0:hover {
   background: #f5f8fa;
   border: 1px solid rgba(136,153,166,.5);
+}
+
+@media all and ( max-width:506px ) {
+  .c4 {
+    display: none;
+  }
 }
 
 <div

--- a/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
+++ b/packages/social-metadata-previews/tests/twitter/__snapshots__/TwitterPreviewTest.js.snap
@@ -47,7 +47,7 @@ exports[`TwitterPreview matches the snapshot 1`] = `
   padding: 1em;
   text-align: center;
   font-size: 1rem;
-  max-width: 125px;
+  width: 125px;
   border-radius: 14px 0 0 14px;
   border-top-left-radius: 14px;
   border-bottom-left-radius: 14px;


### PR DESCRIPTION
This makes it so the previews fit on smaller screens.

## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the social previews would be able to break out of their container when viewed on smaller screens.

## Relevant technical choices:

* Removed some extra constrains on the height, as it was not listening to the hidden description. The height only makes sense on the image itself.
* Made the description hide when the screen width is smaller than the image width. Not perfect, but seems to work fine.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Combine with premium.
* Go to the social previews.
* Switch to a smaller screen (iPhone 5 or something?).
* Verify that the previews no longer break out.
* Verify that the descriptions for both Facebook and Twitter are hidden when the screen is smaller than the wanted image width.
* Change the `SEO -> Social -> Twitter -> The default card type to use` to `Summary` instead of `Summary with large image`.
* Verify that the image is unchanged.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-141
