### PR TITLE
Let prominent words threshold be dependent on the availability of morphology data

### DIFF
--- a/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
+++ b/packages/yoastseo/spec/researches/getProminentWordsForInternalLinkingSpec.js
@@ -25,7 +25,7 @@ describe( "relevantWords research", function() {
 		expect( words ).toEqual( expected );
 	} );
 
-	it( "does return prominent words for texts with more than 300 words", function() {
+	it( "returns prominent words for texts with more than 300 words", function() {
 		const paper = new Paper( "texte" + " et texte".repeat( 180 ), { title: "Title" } );
 
 		const researcher = new Researcher( paper );
@@ -147,6 +147,67 @@ describe( "relevantWords research", function() {
 			],
 			hasMetaDescription: true,
 			hasTitle: true,
+		};
+
+		const words = prominentWordsResearch( paper, researcher );
+
+		expect( words ).toEqual( expected );
+	} );
+
+	it( "lowers the prominent words occurrence threshold if a language does not have morphology support ", function() {
+		const paper = new Paper( ( "Romeo and Juliet borrows from a tradition of tragic love stories dating back to antiquity. " +
+								   "One of these is Pyramus and Thisbe, from Ovid's Metamorphoses, which contains parallels " +
+								   "to Shakespeare's story: the lovers' parents despise each other, " +
+								   "and Pyramus falsely believes his lover Thisbe is dead. " +
+								   "The Ephesiaca of Xenophon of Ephesus, written in the 3rd century, also contains several similarities " +
+								   "to the play, including the separation of the lovers, and a potion that induces a deathlike sleep." +
+								   "One of the earliest references to the names Montague and Capulet is from Dante's Divine Comedy, " +
+								   "who mentions the Montecchi (Montagues) and Capulets." +
+								   "Romeo and Juliet. " +
+								   "Romeo and Juliet. " +
+								   "Romeo and Juliet. " ) );
+
+		const researcher = new Researcher( paper );
+
+		const expected = {
+			prominentWords: [
+				new ProminentWord( "juliet", "juliet", 4 ),
+				new ProminentWord( "romeo", "romeo", 3 ),
+				new ProminentWord( "lovers", "lovers", 2 ),
+				new ProminentWord( "pyramus", "pyramus", 2 ),
+				new ProminentWord( "thisbe", "thisbe", 2 ),
+			],
+			hasMetaDescription: false,
+			hasTitle: false,
+		};
+
+		const words = prominentWordsResearch( paper, researcher );
+
+		expect( words ).toEqual( expected );
+	} );
+
+	it( "sets the prominent words occurrence threshold to 4 if a language does have morphology support ", function() {
+		const paper = new Paper( ( "Romeo and Juliet borrows from a tradition of tragic love stories dating back to antiquity. " +
+								   "One of these is Pyramus and Thisbe, from Ovid's Metamorphoses, which contains parallels " +
+								   "to Shakespeare's story: the lovers' parents despise each other, " +
+								   "and Pyramus falsely believes his lover Thisbe is dead. " +
+								   "The Ephesiaca of Xenophon of Ephesus, written in the 3rd century, also contains several similarities " +
+								   "to the play, including the separation of the lovers, and a potion that induces a deathlike sleep." +
+								   "One of the earliest references to the names Montague and Capulet is from Dante's Divine Comedy, " +
+								   "who mentions the Montecchi (Montagues) and Capulets." +
+								   "Romeo and Juliet. " +
+								   "Romeo and Juliet. " +
+								   "Romeo and Juliet. " ) );
+
+		const researcher = new Researcher( paper );
+		researcher.addResearchData( "morphology", morphologyData );
+
+		const expected = {
+			prominentWords: [
+				new ProminentWord( "juliet", "juliet", 4 ),
+			],
+			hasMetaDescription: false,
+			hasTitle: false,
 		};
 
 		const words = prominentWordsResearch( paper, researcher );

--- a/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
+++ b/packages/yoastseo/src/researches/getProminentWordsForInternalLinking.js
@@ -68,13 +68,23 @@ function getProminentWordsForInternalLinking( paper, researcher ) {
 	sortProminentWords( collapsedWords );
 
 	/*
+	 * If morphology data are available for a language, the minimum number of occurrences to consider a word to be prominent is 4.
+	 * This minimum number was chosen in order to avoid premature suggestions of words from the paper attributes.
+	 * These get a times-3 boost and would therefore be prominent with just 1 occurrence.
+	 *
+	 * If morphology data are not available, and therefore word forms are not recognized, the minimum threshold is lowered to 2.
+	 */
+	let minimumNumberOfOccurrences = 4;
+
+	if ( ! morphologyData ) {
+		minimumNumberOfOccurrences = 2;
+	}
+
+	/*
 	 * Return the 100 top items from the collapsed and sorted list. The number is picked deliberately to prevent larger
 	 * articles from getting too long of lists.
-	 *
-	 * Minimum required occurrences set to 4 in order to avoid premature suggestions of words from the paper attributes.
-	 * These get a times-3 boost and would therefore be prominent with just 1 occurrence.
 	 */
-	result.prominentWords = take( filterProminentWords( collapsedWords, 4 ), 100 );
+	result.prominentWords = take( filterProminentWords( collapsedWords, minimumNumberOfOccurrences ), 100 );
 
 	return result;
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Sets the threshold for words to be recognized as prominent words from 4 to 2, in case a language has no morphology support. This increases the chance that different word forms are saved, leading to better internal linking suggestions for these languages.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

**Test in a language with morphology support**
* In `Settings`, set your site language to one that has morphology support, for example English.
* Open a post (either new or existing).
* Open the `Network` tab in the inspector.
* Add (English) content to the post. 
* In the `Network` tab, see a request starting with `link_suggestions?prominent_words`.
* Click on the request, then `Headers`. Scroll down and see the prominent words. 
* See that the lowest value a prominent word can have, is 4. 
* This may require some fiddling with your content. 
    * Make sure that you have some words/word forms that occur exactly 4 times, and some words/word forms that occur 3 times (the latter ones, you shouldn't see in the request).
    * Make sure that your text isn't too long. Only the 20 prominent words are shown that occur most frequently, so you don't want to have 20 or more words/word forms with 5 or more occurrences.
    * Make sure that your text is at least 100 words, otherwise no prominent words will be generated.

**Test in a language without morphology support**
* In `Settings`, set your site language to one that has morphology support, for example Danish.
* Open a post (either new or existing).
* Open the `Network` tab in the inspector.
* Add (Danish) content to the post. 
* In the `Network` tab, see a request starting with `link_suggestions?prominent_words`.
* Click on the request, then `Headers`. Scroll down and see the prominent words. 
* See that the lowest value a prominent word can have, is 2. 
* This may require some fiddling with your content. 
    * Make sure that you have some words/word forms that occur exactly 2 times, and some words/word forms that occur 1 time (the latter ones, you shouldn't see in the request).
    * Make sure that your text isn't too long. Only the 20 prominent words are shown that occur most frequently, so you don't want to have 20 or more words/word forms with 5 or more occurrences.
    * Make sure that your text is at least 100 words, otherwise no prominent words will be generated.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * The calculation of prominent words.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-138
