### PR TITLE
P3-115 Better accessibility for the keyphrase input errors list.

### DIFF
--- a/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
+++ b/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
@@ -2,7 +2,7 @@
 import React from "react";
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import noop from "lodash/noop";
+import { noop, isEmpty } from "lodash-es";
 
 /* Yoast dependencies */
 import { addFocusStyle, SvgIcon, InputField } from "@yoast/components";
@@ -51,16 +51,16 @@ const KeywordField = styled( InputField )`
 `;
 
 const ErrorList = styled.ul`
-    color: ${ inputErrorColor };
-    list-style-type: disc;
-    list-style-position: outside;
-    margin: 0;
-    margin-left: 1.2em;
+	color: ${ inputErrorColor };
+	list-style-type: disc;
+	list-style-position: outside;
+	margin: 0;
+	margin-left: 1.2em;
 `;
 
-const ErrorText = styled.li`
-    color: ${ inputErrorColor };
-    margin: 0 0 0.5em 0;
+const ErrorListItem = styled.li`
+	color: ${ inputErrorColor };
+	margin: 0 0 0.5em 0;
 `;
 
 const BorderlessButton = addFocusStyle(
@@ -172,16 +172,16 @@ class KeywordInput extends React.Component {
 	renderErrorMessages() {
 		const errorMessages = [ ...this.props.errorMessages ];
 		return (
-			<ErrorList>
-				{ errorMessages.map( ( message, index ) =>
-					<ErrorText
-						key={ index }
-						role={ "alert" }
-					>
-						{ message }
-					</ErrorText>
-				) }
-			</ErrorList>
+			! isEmpty( errorMessages ) &&
+				<ErrorList>
+					{ errorMessages.map( ( message, index ) =>
+						<ErrorListItem
+							key={ index }
+						>
+							<span role="alert">{ message }</span>
+						</ErrorListItem>
+					) }
+				</ErrorList>
 		);
 	}
 

--- a/packages/yoast-components/composites/Plugin/Shared/tests/KeywordInputTest.js
+++ b/packages/yoast-components/composites/Plugin/Shared/tests/KeywordInputTest.js
@@ -40,7 +40,7 @@ describe( KeywordInput, () => {
 				value: "Keyword",
 			},
 		} );
-		expect( wrapper.find( "li[role=\"alert\"]" ).length ).toBe( 0 );
+		expect( wrapper.find( "li span[role=\"alert\"]" ).length ).toBe( 0 );
 	} );
 
 	it( "does not display the error message for two words separated by whitespace", () => {
@@ -60,7 +60,7 @@ describe( KeywordInput, () => {
 				value: "Keyword1 Keyword2",
 			},
 		} );
-		expect( wrapper.find( "li[role=\"alert\"]" ).length ).toBe( 0 );
+		expect( wrapper.find( "li span[role=\"alert\"]" ).length ).toBe( 0 );
 	} );
 
 	it( "does not displays the error message for comma-separated words", () => {
@@ -80,7 +80,7 @@ describe( KeywordInput, () => {
 				value: "Keyword1, Keyword2",
 			},
 		} );
-		expect( wrapper.find( "li[role=\"alert\"]" ).length ).toBe( 0 );
+		expect( wrapper.find( "li span[role=\"alert\"]" ).length ).toBe( 0 );
 	} );
 
 	it( "does displays the error message if submitted as prop", () => {
@@ -102,6 +102,6 @@ describe( KeywordInput, () => {
 				value: "Keyword1, Keyword2",
 			},
 		} );
-		expect( wrapper.find( "li[role=\"alert\"]" ).length ).toBe( 1 );
+		expect( wrapper.find( "li span[role=\"alert\"]" ).length ).toBe( 1 );
 	} );
 } );

--- a/packages/yoast-components/package.json
+++ b/packages/yoast-components/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "start": "echo 'The yoast-components demo app has been moved to javascript/apps/components (https://github.com/Yoast/javascript/tree/develop/apps/components). Please run yarn start there.'",
     "test": "jest",
-    "lint": "eslint . --max-warnings=34",
+    "lint": "eslint . --max-warnings=28",
     "prepublishOnly": "grunt publish"
   },
   "jest": {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Improves accessibility of the keyphrase input errors list.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- yarn link the monorepo to the plugin and build the plugin
- edit a post and enter a keyphrase that triggers an error e.g. a keyphrase with a comma: `one, two`
- inspect the error list HTML in your browser's dev tools
- observe the `role="alert"` attribute is now on a `<span>` element within the list item: this preserves the unordered list native semantics and allows screen readers to announce the position and number of the list items
- when there are no errors, observe no empty `<ul>` element is rendered
- this PR also lowers the `packages/yoast-components` ESLint max-warnings to 28: run `yarn lint` and see the checks pass

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-115]
