### PR TITLE
Use value rather than default value so the component can be controlled

### DIFF
--- a/packages/components/src/inputs/TextArea.js
+++ b/packages/components/src/inputs/TextArea.js
@@ -24,7 +24,7 @@ const TextArea = ( props ) => {
 			<textarea
 				id={ id }
 				name={ props.name }
-				defaultValue={ props.value }
+				value={ props.value }
 				className="yoast-field-group__textarea"
 				aria-describedby={ props.ariaDescribedBy }
 				onChange={ props.onChange }

--- a/packages/components/src/inputs/TextInput.js
+++ b/packages/components/src/inputs/TextInput.js
@@ -56,7 +56,7 @@ const TextInput = ( props ) => {
 			<input
 				id={ id }
 				name={ props.name }
-				defaultValue={ props.value }
+				value={ props.value }
 				type={ props.type }
 				className="yoast-field-group__inputfield"
 				aria-describedby={ props.ariaDescribedBy }

--- a/packages/components/tests/inputs/TextAreaTest.js
+++ b/packages/components/tests/inputs/TextAreaTest.js
@@ -27,7 +27,7 @@ describe( "TextArea", () => {
 		expect( result ).toBeDefined();
 		expect( result.props.linkTo ).toBe( "google" );
 		expect( result.props.htmlFor ).toBe( "very-nice-id" );
-		expect( result.props.children.props.defaultValue ).toBe( "Nice value you got here!" );
+		expect( result.props.children.props.value ).toBe( "Nice value you got here!" );
 		expect( result.props.children.props.id ).toBe( "very-nice-id" );
 	} );
 

--- a/packages/components/tests/inputs/TextInputTest.js
+++ b/packages/components/tests/inputs/TextInputTest.js
@@ -20,7 +20,7 @@ describe( "TextInput", () => {
 		expect( result.props.label ).toBe( "Heya" );
 		expect( result.props.linkTo ).toBe( "linkTo" );
 		expect( result.props.children.props.name ).toBe( "textInput" );
-		expect( result.props.children.props.defaultValue ).toBe( "" );
+		expect( result.props.children.props.value ).toBe( "" );
 	} );
 
 	it( "generates an input based on the defaults if required props are missing", () => {
@@ -34,7 +34,7 @@ describe( "TextInput", () => {
 
 		expect( result.props.children.props.name ).toBe( "" );
 		expect( result.props.children.props.type ).toBe( "text" );
-		expect( result.props.children.props.defaultValue ).toBe( "" );
+		expect( result.props.children.props.value ).toBe( "" );
 	} );
 
 	it( "generates an input based on the defaults if required props are partially missing", () => {
@@ -49,7 +49,7 @@ describe( "TextInput", () => {
 
 		expect( result.props.children.props.name ).toBe( "textInput" );
 		expect( result.props.children.props.type ).toBe( "text" );
-		expect( result.props.children.props.defaultValue ).toBe( "" );
+		expect( result.props.children.props.value ).toBe( "" );
 	} );
 
 	it( "generates a warning when a faulty input type is passed", () => {


### PR DESCRIPTION
## Summary

Because the AdvancedSettings Tab is now in two places, their values can go out of sync. We need a way to update the TextInput and TextArea components with external props from e.g. a redux store.

Therefore they need to be switched to be controlled components.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* TextInput and TextArea have been changed to controlled components, their value should be passed from a higher order component.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout `feature/metabox-modal` on free or premium, and `yarn link-monorepo` to this branch.
* Scroll down to the metabox, and open the advanced settings tab. Make sure you see the CanonicalURL input.
* Now open the modal, open its AdvancedSettings, and change the CanonicalURL input. Note that in the background, the advancedsettings in the Metabox are updated accordingly.
* Also test the components on their own, in the monorepo. Check the components app.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-66
