### PR TITLE
Implement Farsi affixes to be ignored in keyphrase recognition

### DIFF
--- a/packages/yoastseo/spec/morphology/farsi/createBasicWordFormsFarsiSpec.js
+++ b/packages/yoastseo/spec/morphology/farsi/createBasicWordFormsFarsiSpec.js
@@ -65,7 +65,7 @@ const wordsToStem = [
 	/*
 	 * Possessive pronoun suffix ‌اش
 	 * His/her house "خانه‌اش"
-	 * House "خانه‌" (word that ends in silent ه )
+	 * House "خانه" (word that ends in silent ه )
 	 */
 	{
 		original: "خانه‌اش",
@@ -118,7 +118,7 @@ const wordsToStem = [
 		],
 	},
 	/*
-	 * A plura
+	 * A word with an ending that looks like a valid ending ی (indefinite suffix)
 	 */
 	{
 		original: "باری",

--- a/packages/yoastseo/spec/morphology/farsi/createBasicWordFormsFarsiSpec.js
+++ b/packages/yoastseo/spec/morphology/farsi/createBasicWordFormsFarsiSpec.js
@@ -1,0 +1,196 @@
+import { createBasicWordForms } from "../../../src/morphology/farsi/createBasicWordForms";
+
+const wordsToStem = [
+	// Creates affixed forms based on an input word that starts with a valid prefix.
+	/*
+	 * Prefix ن "negation"
+	 * Don't love "ندارم"
+	 * love "دارم"
+	 */
+	{
+		original: "ندارم",
+		forms: [
+			// Affixed forms based on original:
+			"نندارم",
+			"ندارممان",
+			"ندارمشان",
+			"ندارمتان",
+			"ندارمش",
+			"ندارمت",
+			"ندارمم",
+			"ندارمی",
+			// De-affixed form:
+			"دارم",
+			// Other affixed forms based on de-prefixed form:
+			"ندارم",
+			"دارممان",
+			"دارمشان",
+			"دارمتان",
+			"دارمش",
+			"دارمت",
+			"دارمم",
+			"دارمی",
+		],
+	},
+	/*
+	 * Possessive pronoun suffix ش
+	 * His/her book "کتابش"
+	 * Book "کتاب"
+	 */
+	{
+		original: "کتابش",
+		forms: [
+			// Affixed forms based on original:
+			"نکتابش",
+			"کتابشمان",
+			"کتابششان",
+			"کتابشتان",
+			"کتابشش",
+			"کتابشت",
+			"کتابشم",
+			"کتابشی",
+			// De-affixed form:
+			"کتاب",
+			// Other affixed forms based on de-affixed form:
+			"نکتاب",
+			"کتابمان",
+			"کتابشان",
+			"کتابتان",
+			"کتابش",
+			"کتابت",
+			"کتابم",
+			"کتابی",
+		],
+	},
+	/*
+	 * Possessive pronoun suffix ‌اش
+	 * His/her house "خانه‌اش"
+	 * House "خانه‌" (word that ends in silent ه )
+	 */
+	{
+		original: "خانه‌اش",
+		forms: [
+			// Affixed forms based on original:
+			"نخانه‌اش",
+			"خانه‌اشمان",
+			"خانه‌اششان",
+			"خانه‌اشتان",
+			"خانه‌اشش",
+			"خانه‌اشت",
+			"خانه‌اشم",
+			"خانه‌اشی",
+			// De-affixed form:
+			"خانه",
+			// Other affixed forms based on de-affixed form:
+			"نخانه",
+			"خانه‌ای",
+			"خانه‌یی",
+			"خانه‌ام",
+			"خانه‌ات",
+			"خانه‌اش",
+		],
+	},
+	/*
+	 * Possessive pronoun suffix یش
+	 * His/her leg "پایش"
+	 * leg "پا" (word ends in ا )
+	 */
+	{
+		original: "پایش",
+		forms: [
+			// Affixed forms based on original:
+			"نپایش",
+			"پایشمان",
+			"پایششان",
+			"پایشتان",
+			"پایشش",
+			"پایشت",
+			"پایشم",
+			"پایشی",
+			// De-affixed form:
+			"پا",
+			// Other affixed forms based on de-affixed form:
+			"نپا",
+			"پایی",
+			"پایم",
+			"پایت",
+			"پایش",
+		],
+	},
+	/*
+	 * A plura
+	 */
+	{
+		original: "باری",
+		forms: [
+			// Affixed forms based on original:
+			"نباری",
+			"باری‌ای",
+			"باریمان",
+			"باریشان",
+			"باریتان",
+			"باریش",
+			"باریت",
+			"باریم",
+			"باریی",
+			// De-affixed form:
+			"بار",
+			// Other affixed forms based on de-affixed form:
+			"نبار",
+			"بارمان",
+			"بارشان",
+			"بارتان",
+			"بارش",
+			"بارت",
+			"بارم",
+			"باری",
+		],
+	},
+	// A word with an ending that looks like a valid suffix ش, e.g "ارزش" (value)
+	{
+		original: "ارزش",
+		forms: [
+			// Affixed forms based on original:
+			"نارزش",
+			"ارزشمان",
+			"ارزششان",
+			"ارزشتان",
+			"ارزشش",
+			"ارزشت",
+			"ارزشم",
+			"ارزشی",
+			// De-affixed form:
+			"ارز",
+			// Other affixed forms based on de-affixed form:
+			"نارز",
+			"ارزمان",
+			"ارزشان",
+			"ارزتان",
+			"ارزش",
+			"ارزت",
+			"ارزم",
+			"ارزی",
+		],
+	},
+	// When a word doesn't start with one of the prefixes, the stemmer only creates affixed words based on the original:
+	{
+		original: "ماهر",
+		forms: [
+			// Affixed forms based on original:
+			"نماهر",
+			"ماهرمان",
+			"ماهرشان",
+			"ماهرتان",
+			"ماهرش",
+			"ماهرت",
+			"ماهرم",
+			"ماهری",
+		],
+	},
+];
+
+describe( "Test for creating basic word forms for Farsi words", () => {
+	it( "creates basic word forms for an Farsi word", () => {
+		wordsToStem.forEach( wordToStem => expect( createBasicWordForms( wordToStem.original ) ).toEqual( wordToStem.forms ) );
+	} );
+} );

--- a/packages/yoastseo/spec/researches/getWordFormsSpec.js
+++ b/packages/yoastseo/spec/researches/getWordFormsSpec.js
@@ -413,3 +413,56 @@ describe( "A test for creating basic morphology forms in supported languages", (
 		);
 	} );
 } );
+
+describe( "A test for creating basic morphology forms in supported languages", () => {
+	it( "returns all possible prefixed forms for Farsi keyphrases", () => {
+		const attributes = {
+			keyword: "دانشجوی زرنگی",
+			locale: "fa",
+		};
+		const testPaper = new Paper( "", attributes );
+		const researcher = new Researcher( testPaper );
+
+		expect( getWordForms( testPaper, researcher ) ).toEqual(
+			{
+				keyphraseForms: [
+					[
+						"دانشجوی",
+						"ندانشجوی",
+						"دانشجوی‌ای",
+						"دانشجویمان",
+						"دانشجویشان",
+						"دانشجویتان",
+						"دانشجویش",
+						"دانشجویت",
+						"دانشجویم",
+						"دانشجویی",
+						"دانشجو",
+						"ندانشجو",
+					],
+					[
+						"زرنگی",
+						"نزرنگی",
+						"زرنگی‌ای",
+						"زرنگیمان",
+						"زرنگیشان",
+						"زرنگیتان",
+						"زرنگیش",
+						"زرنگیت",
+						"زرنگیم",
+						"زرنگیی",
+						"زرنگ",
+						"نزرنگ",
+						"زرنگمان",
+						"زرنگشان",
+						"زرنگتان",
+						"زرنگش",
+						"زرنگت",
+						"زرنگم",
+					],
+				],
+				synonymsForms: [],
+			}
+		);
+	} );
+} );

--- a/packages/yoastseo/src/helpers/getBasicWordForms.js
+++ b/packages/yoastseo/src/helpers/getBasicWordForms.js
@@ -1,5 +1,6 @@
 import { createBasicWordForms as createBasicWordFormsHebrew } from "../morphology/hebrew/createBasicWordForms";
 import { createBasicWordForms as createBasicWordFormsArabic } from "../morphology/arabic/createBasicWordForms";
+import { createBasicWordForms as createBasicWordFormsFarsi } from "../morphology/farsi/createBasicWordForms";
 
 /**
  * Collects functions for creating basic word forms for different languages.
@@ -10,5 +11,6 @@ export default function() {
 	return {
 		he: createBasicWordFormsHebrew,
 		ar: createBasicWordFormsArabic,
+		fa: createBasicWordFormsFarsi,
 	};
 }

--- a/packages/yoastseo/src/morphology/farsi/createBasicWordForms.js
+++ b/packages/yoastseo/src/morphology/farsi/createBasicWordForms.js
@@ -16,13 +16,18 @@ const createForms = function( word ) {
 	const suffixes3 = [ "‌ای", "‌یی", "‌ام", "‌ات", "‌اش" ];
 	// Suffixes for words that end in ها
 	const suffixes4 = [ "یی", "ی" ];
+
 	const createdForms = [];
+
+	// Create prefixed form.
 	createdForms.push( prefix + word );
+
+	// Create suffixed forms using suffixes from one of the four groups, depending on the word's ending.
 	if ( word.endsWith( "ها" ) ) {
 		createdForms.push( ...suffixes4.map( suffix => word + suffix ) );
 	} else if ( /([^وای]ه)$/i.test( word ) ) {
 		createdForms.push( ...suffixes3.map( suffix => word + suffix ) );
-	} else if ( /(ا|و)$/i.test( word ) ) {
+	} else if ( /([وا])$/i.test( word ) ) {
 		createdForms.push( ...suffixes2.map( suffix => word + suffix ) );
 	} else {
 		if ( word.endsWith( "ی" )  ) {
@@ -49,18 +54,14 @@ const stemWord = function( word ) {
 		[ "(ها)یی$", "$1" ],
 		[ "(مان|شان|تان|ش|ت|م|ی)$", "" ],
 	];
-	let stemmedWord = "";
+	// Remove prefix.
 	if ( word.startsWith( prefix ) ) {
-		stemmedWord = word.slice( 1, word.length );
+		return word.slice( 1, word.length );
 	}
-	if ( stemmedWord.length === 0 ) {
-		const wordWithoutSuffix = searchAndReplaceWithRegex( word, suffixesAndReplacements );
-		if ( wordWithoutSuffix ) {
-			stemmedWord = wordWithoutSuffix;
-		}
-	}
-	return stemmedWord;
+	// Search for and remove suffixes.
+	return searchAndReplaceWithRegex( word, suffixesAndReplacements );
 };
+
 /**
  * Creates basic word forms for a given Farsi word.
  *

--- a/packages/yoastseo/src/morphology/farsi/createBasicWordForms.js
+++ b/packages/yoastseo/src/morphology/farsi/createBasicWordForms.js
@@ -1,0 +1,92 @@
+import { searchAndReplaceWithRegex } from "../morphoHelpers/regexHelpers";
+/**
+ * Creates the basic affixed-forms of a given Farsi word
+ *
+ * @param {string} word      The word to check
+ *
+ * @returns {Array} The created forms
+ */
+const createForms = function( word ) {
+	const prefix = "ن";
+	// Regular suffixes
+	const suffixes1 = [ "مان", "شان", "تان", "ش", "ت", "م", "ی" ];
+	// Suffixes for words that end in ا or و
+	const suffixes2 = [ "یی", "یم", "یت", "یش" ];
+	// Suffixes for words that end in silent ه
+	const suffixes3 = [ "‌ای", "‌یی", "‌ام", "‌ات", "‌اش" ];
+	// Suffixes for words that end in ها
+	const suffixes4 = [ "یی", "ی" ];
+	const createdForms = [];
+	createdForms.push( prefix + word );
+	if ( word.endsWith( "ها" ) ) {
+		createdForms.push( ...suffixes4.map( suffix => word + suffix ) );
+	} else if ( /([^وای]ه)$/i.test( word ) ) {
+		createdForms.push( ...suffixes3.map( suffix => word + suffix ) );
+	} else if ( /(ا|و)$/i.test( word ) ) {
+		createdForms.push( ...suffixes2.map( suffix => word + suffix ) );
+	} else {
+		if ( word.endsWith( "ی" )  ) {
+			createdForms.push( word + "‌ای" );
+		}
+		createdForms.push( ...suffixes1.map( suffix => word + suffix ) );
+	}
+	return createdForms;
+};
+
+/**
+ * Stem the basic affixes of a given Farsi word
+ *
+ * @param {string} word  The word to check
+ *
+ * @returns {string}    The stemmed word
+ */
+const stemWord = function( word ) {
+	const prefix = "ن";
+	const suffixesAndReplacements = [
+		[ "(و|ا)(یش|یت|یم|یی)$", "$1" ],
+		[ "([^وای]ه)(‌یی|‌ای|‌اش|‌ات|‌ام)$", "$1" ],
+		[ "(ی)‌ای$", "$1" ],
+		[ "(ها)یی$", "$1" ],
+		[ "(مان|شان|تان|ش|ت|م|ی)$", "" ],
+	];
+	let stemmedWord = "";
+	if ( word.startsWith( prefix ) ) {
+		stemmedWord = word.slice( 1, word.length );
+	}
+	if ( stemmedWord.length === 0 ) {
+		const wordWithoutSuffix = searchAndReplaceWithRegex( word, suffixesAndReplacements );
+		if ( wordWithoutSuffix ) {
+			stemmedWord = wordWithoutSuffix;
+		}
+	}
+	return stemmedWord;
+};
+/**
+ * Creates basic word forms for a given Farsi word.
+ *
+ * @param {string} word     The word for which to create basic word forms.
+ *
+ * @returns {Array}        Prefixed and de-prefixed variations of a word.
+ */
+export function createBasicWordForms( word ) {
+	const forms = [];
+
+	/*
+	 * Add prefixes and suffixes to the input word. We always do this, since some words
+	 * beginning with an affix-like letter might be exceptions where this is the
+	 * actual first letter or last letter of the word.
+	 */
+
+	forms.push( ...createForms( word ) );
+
+	/*
+	 * If a word starts with a prefix or is it ends with one of the suffixes, we strip it and create all possible
+	 * affixed forms based on this stem.
+	 */
+	const stemmedWord = stemWord( word );
+	if ( stemmedWord ) {
+		forms.push( stemmedWord );
+		forms.push( ...createForms( stemmedWord ) );
+	}
+	return forms;
+}

--- a/packages/yoastseo/src/morphology/morphoHelpers/regexHelpers.js
+++ b/packages/yoastseo/src/morphology/morphoHelpers/regexHelpers.js
@@ -14,7 +14,7 @@ export function doesWordMatchRegex( word, regex ) {
  * Loops through a nested array with pairs of regexes and replacements, and performs the needed replacement if a match is found.
  *
  * @param {string} word 							The word that may need to be modified.
- * @param {string[]} groupOfRegexAndReplacements 	The array with the regexes and the required replacements.
+ * @param {[][]} groupOfRegexAndReplacements 	The array with the regexes and the required replacements.
  * @returns {?string} The modified stem or null if no match was found.
  */
 export function searchAndReplaceWithRegex( word, groupOfRegexAndReplacements ) {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry: 

* [yoastseo] Creates basic keyphrase forms for Farsi when they have the following affixes: prefix ن, and suffixes `مان, شان, تان, ش, ت, م, ی` and their variations such as ` ‌اش, ‌ات, یی, یم, یت, یش, ‌ای, ‌ام`
* [Yoast SEO Free] Makes it possible to recognize keyphrases in Farsi when they have a negation prefix or an indefinite article (for example: ماشین ("car") in ماشینی ("a car")).

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

This PR can be tested by following these steps:
* Run `yarn test` and make sure all tests pass.

* Test in the content-analysis app:
        * Paste a text of at least 150 words
        * Set the locale to `fa` 
        * Switch the morphology button to Off
        * Set the keyphrase as `ماشین` and paste `ماشینی` in the text 
        * Check in the assessment that the keyword is found in the text
        * Check that the functionality still works when the keyphrase and form in the text are switched around
        * Check that the keyphrase `ماشین` matches also a form with a different affix (e.g., `ماشینت`)

## QA Test instructions 
This PR can be tested by following these steps:
Test the following functionality in Free:

* Set your site to Farsi 
* As your keyphrase, set the word `ماشین` ("car").
* Add a text with at least 150 words.
* In the text, add the form `ماشینی` ("a car").
* The keyphrase density assessment should show 1 keyphrase occurrence. When clicking on the marker for the assessment, `ماشینی` should be marked.
* Switch around the keyphrase and the word form.
* The keyphrase density assessment should still show 1 keyphrase occurrence.
* Switch the form in the text to a form with another affix, e.g. `ماشینت` ("your car").
* The keyphrase density assessment should still show 1 keyphrase occurrence.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LIN-500
