### PR TITLE
P1-181 Add id to the multiselect input

### DIFF
--- a/packages/components/src/select/Select.js
+++ b/packages/components/src/select/Select.js
@@ -67,6 +67,7 @@ const changeOptionFormatToReactSelect = ( options ) => {
 export const MultiSelect = ( props ) => {
 	const {
 		id,
+		inputId,
 		selected,
 		options,
 		name,
@@ -98,6 +99,7 @@ export const MultiSelect = ( props ) => {
 			<ReactSelect
 				isMulti={ true }
 				id={ id }
+				inputId={ inputId }
 				name={ `${ name }[]` }
 				value={ selectedOptions }
 				options={ reactSelectOptions }
@@ -113,8 +115,14 @@ export const MultiSelect = ( props ) => {
 	);
 };
 
-MultiSelect.propTypes = selectProps;
-MultiSelect.defaultProps = selectDefaultProps;
+MultiSelect.propTypes = {
+	...selectProps,
+	inputId: PropTypes.string,
+};
+MultiSelect.defaultProps = {
+	...selectDefaultProps,
+	inputId: null,
+};
 
 /**
  * React wrapper for a basic HTML select.


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/components] Adds an id to the MultiSelect's input field.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test with https://github.com/Yoast/wordpress-seo/pull/16058

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
