### PR TITLE
P3 172 p3 175 fix semrush country selector styling

### DIFF
--- a/packages/components/src/select/select.css
+++ b/packages/components/src/select/select.css
@@ -108,7 +108,7 @@
 }
 
 .yoast-select-container input[type="text"]:focus {
-	box-shadow: none !important;
+	box-shadow: none;
 }
 
 /**

--- a/packages/components/src/select/select.css
+++ b/packages/components/src/select/select.css
@@ -83,6 +83,8 @@
 
 .yoast-select-container .yoast-select__control {
 	border-radius: 0;
+	border: none;
+	background-color: transparent;
 }
 
 .yoast-select-container .yoast-select__option {

--- a/packages/components/src/select/select.css
+++ b/packages/components/src/select/select.css
@@ -105,6 +105,10 @@
 	color: var(--yoast-color-white);
 }
 
+.yoast-select-container input[type="text"]:focus {
+	box-shadow: none !important;
+}
+
 /**
  * Styling for the HTML select.
  */


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoast-components] Fixes some styling issues in the `YoastReactSelect` component

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* build Free plugin `trunk` against the `develop` branch of the monorepo
* edit a post, insert a focus keyphrase, click on "Get related keyphrases" to open the SEMrush modal
* look at the country selector and see that it has this styling:
![wrong](https://user-images.githubusercontent.com/15989132/94009179-676ecd00-fda4-11ea-8fcd-45cf172718c7.png)
* try to search in the list by styping some letters and see that the inner input field is surrounded by a visible blueish border:
![wrong2](https://user-images.githubusercontent.com/15989132/94009292-8c634000-fda4-11ea-9d56-1f192829fc14.png)
* checkout the PR branch on the monorepo and build again the free plugin
* refresh the edit screen, insert a focus keyphrase, click on "Get related keyphrases" to open the SEMrush modal
* look at the country selector and check that the styling is now right (border is narrower, inner shadow is visible):
![right](https://user-images.githubusercontent.com/15989132/94009542-e7953280-fda4-11ea-9e04-c4662e90b957.png)
* start typing some letters in the select and see that the blue border is gone.


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-172][P3-175]
