### PR TITLE
P3-202 Fix SEMrush labels stylings using Yoast CSS vars

### DIFF
--- a/packages/components/src/field-group/field-group.css
+++ b/packages/components/src/field-group/field-group.css
@@ -13,7 +13,7 @@
     color: var(--yoast-color-label);
     line-height: 1.5;
     padding: 0;
-	font-size: var(--yoast-font-size-default);
+    font-size: var(--yoast-font-size-default);
 }
 
 .yoast-field-group .field-group-description {

--- a/packages/components/src/field-group/field-group.css
+++ b/packages/components/src/field-group/field-group.css
@@ -13,6 +13,7 @@
     color: var(--yoast-color-label);
     line-height: 1.5;
     padding: 0;
+	font-size: var(--yoast-font-size-default);
 }
 
 .yoast-field-group .field-group-description {

--- a/packages/components/src/tables/table.css
+++ b/packages/components/src/tables/table.css
@@ -18,6 +18,7 @@
 	padding: 18px 12px;
 	border-bottom: var(--yoast-border-default);
 	white-space: nowrap;
+	font-weight: var(--yoast-font-weight-bold);
 }
 
 .yoast-table td {

--- a/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
+++ b/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
@@ -21,7 +21,7 @@ const KeywordInputContainer = styled.div`
 
 const KeywordFieldLabel = styled.label`
 	font-size: var(--yoast-font-size-default);
-    font-weight: var(--yoast-font-weight-bold);
+	font-weight: var(--yoast-font-weight-bold);
 	${ getDirectionalStyle( "margin-right: 4px", "margin-left: 4px" ) };
 `;
 

--- a/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
+++ b/packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js
@@ -20,8 +20,8 @@ const KeywordInputContainer = styled.div`
 `;
 
 const KeywordFieldLabel = styled.label`
-	font-size: 1em;
-	font-weight: bold;
+	font-size: var(--yoast-font-size-default);
+    font-weight: var(--yoast-font-weight-bold);
 	${ getDirectionalStyle( "margin-right: 4px", "margin-left: 4px" ) };
 `;
 

--- a/packages/yoast-components/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
+++ b/packages/yoast-components/composites/Plugin/Shared/tests/__snapshots__/KeywordInputTest.js.snap
@@ -37,8 +37,8 @@ exports[`KeywordInput matches the snapshot by default 1`] = `
 }
 
 .c2 {
-  font-size: 1em;
-  font-weight: bold;
+  font-size: var(--yoast-font-size-default);
+  font-weight: var(--yoast-font-weight-bold);
   margin-right: 4px;
 }
 


### PR DESCRIPTION
## Summary

Some labels used in the SEMrush integration have incorrect values for `font-size` and `font-weight` that need to be fixed.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/components] Fix font size and weight for table header, field group label and KeywordInput label.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* use this branch to build `release/15.1` of the Free plugin.
* edit a post and check that all these labels have the same styling, namely `font-size` should have a value of 14px and `font-weight` should have a value of 600. Notice that we are using variables so you should check the "Calculated" values in the inspector instead of just checking the CSS rules.
![style1](https://user-images.githubusercontent.com/15989132/95088891-cbd64880-0723-11eb-8959-f141688d0cd1.png)
![style2](https://user-images.githubusercontent.com/15989132/95088898-ce38a280-0723-11eb-97f9-b0c06df52096.png)


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
