### PR TITLE
P3-184 changes for zapier ui

### DIFF
--- a/packages/components/src/base/colors.css
+++ b/packages/components/src/base/colors.css
@@ -13,7 +13,7 @@
 	--yoast-color-dark: #303030;
 	--yoast-color-sale: #fec228;
 	--yoast-color-sale-darker: #feb601;
-	--yoast-color-border: rgba(0,0,0, 0.2);
+	--yoast-color-border: rgba(0, 0, 0, 0.2);
 	--yoast-color-label: #303030;
 	--yoast-color-label-help: #707070;
 	--yoast-color-active: #6EA029;

--- a/packages/components/src/button/buttons.css
+++ b/packages/components/src/button/buttons.css
@@ -7,7 +7,7 @@
 	text-decoration: none;
 	border-radius: 4px;
 	border: 1px solid rgba(0, 0, 0, 0.2);
-	box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.3);
+	box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.1);
 	transition: background-color 150ms ease-out 0s;
 	line-height: 1.2;
 	font-size: 14px;

--- a/packages/components/src/button/buttons.css
+++ b/packages/components/src/button/buttons.css
@@ -7,7 +7,7 @@
 	text-decoration: none;
 	border-radius: 4px;
 	border: 1px solid rgba(0, 0, 0, 0.2);
-	box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.1);
+	box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.3);
 	transition: background-color 150ms ease-out 0s;
 	line-height: 1.2;
 	font-size: 14px;
@@ -65,6 +65,7 @@
 .yoast .yoast-button--secondary {
 	color: var(--yoast-color-dark);
 	background-color: var(--yoast-color-secondary);
+	box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.1);
 }
 
 .yoast .yoast-button--secondary:visited {

--- a/packages/components/src/field-group/field-group.css
+++ b/packages/components/src/field-group/field-group.css
@@ -22,3 +22,27 @@
 .yoast-field-group .field-group-description {
     margin: 0;
 }
+
+.yoast-field-group__inline {
+	display: flex;
+	align-items: center;
+}
+
+.yoast-field-group__inline .yoast-field-group__inputfield {
+	margin-right: 8px;
+}
+
+.yoast-field-group__inline .yoast-button {
+	flex-shrink: 0;
+}
+
+@media screen and (max-width: 782px) {
+	.yoast-field-group__inline {
+		display: block;
+	}
+
+	.yoast-field-group__inline .yoast-field-group__inputfield {
+		margin-right: 0;
+		margin-bottom: 8px;
+	}
+}

--- a/packages/components/src/field-group/field-group.css
+++ b/packages/components/src/field-group/field-group.css
@@ -15,6 +15,10 @@
     padding: 0;
 }
 
+.yoast-field-group__title.yoast-field-group__title--light {
+	font-weight: var(--yoast-font-weight-default);
+}
+
 .yoast-field-group .field-group-description {
     margin: 0;
 }

--- a/packages/components/src/inputs/input.css
+++ b/packages/components/src/inputs/input.css
@@ -7,7 +7,7 @@
 	width: 100%;
 	font-size: var(--yoast-font-size-default);
 	padding: 8px;
-	background: white;
+	background: var(--yoast-color-white);
 	border: var(--yoast-border-default);
 	box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
 	box-sizing: border-box;
@@ -38,6 +38,12 @@
 .yoast-field-group .description + .yoast-field-group__inputfield {
 	margin-top: 8px;
 	margin-bottom: 24px;
+}
+
+.yoast .yoast-field-group__inputfield:read-only,
+.yoast .yoast-field-group__inputfield:disabled,
+.yoast .yoast-field-group__inputfield[aria-disabled="true"] {
+	background: var(--yoast-color-inactive-grey-light);
 }
 
 /* Edge. */

--- a/packages/components/src/inputs/input.html
+++ b/packages/components/src/inputs/input.html
@@ -76,6 +76,15 @@
 		<input readonly class="yoast-field-group__inputfield" type="text" value="some value" name="foobar" id="example-input-03">
 	</div>
 
+	<p>Input field with normal font-weight label</p>
+
+	<div class="yoast-field-group">
+		<div class="yoast-field-group__title yoast-field-group__title--light">
+			<label for="example-input-05">Do you have a passport?</label>
+		</div>
+		<input class="yoast-field-group__inputfield" type="text" value="" name="foobar" id="example-input-05">
+	</div>
+
 	<p>Textarea with a label and help icon</p>
 
 	<div class="yoast-field-group">

--- a/packages/components/src/inputs/input.html
+++ b/packages/components/src/inputs/input.html
@@ -24,6 +24,7 @@
 	<link rel='stylesheet' href='../help-icon/help-icon.css' type='text/css' media='all'/>
 	<link rel='stylesheet' href='input.css' type='text/css' media='all'/>
 	<link rel='stylesheet' href='../checkbox/checkbox.css' type='text/css' media='all'/>
+	<link rel='stylesheet' href='../button/buttons.css' type='text/css' media='all'/>
 
 </head>
 <body class="yoast">
@@ -83,6 +84,18 @@
 			<label for="example-input-05">Do you have a passport?</label>
 		</div>
 		<input class="yoast-field-group__inputfield" type="text" value="" name="foobar" id="example-input-05">
+	</div>
+
+	<p>Input field with horizontally aligned button</p>
+
+	<div class="yoast-field-group">
+		<div class="yoast-field-group__title">
+			<label for="example-input-06">Do you have a passport?</label>
+		</div>
+		<div class="yoast-field-group__inline">
+			<input class="yoast-field-group__inputfield" type="text" value="" name="foobar" id="example-input-06">
+			<button class="yoast-button yoast-button--secondary" type="button">Yoast button</button>
+		</div>
 	</div>
 
 	<p>Textarea with a label and help icon</p>

--- a/packages/components/src/inputs/input.html
+++ b/packages/components/src/inputs/input.html
@@ -33,7 +33,7 @@
 
 	<div class="yoast-field-group">
 		<div class="yoast-field-group__title">
-			<label for="example-input">Do you have a passport?</label>
+			<label for="example-input-01">Do you have a passport?</label>
 			<a class="yoast-help" target="_blank" href="https://yoast.com">
 				<span class="yoast-help__icon">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" role="img" aria-hidden="true"
@@ -45,7 +45,7 @@
 			</a>
 		</div>
 		<p class="description" id="yoast_unique_description_id">This is a description</p>
-		<input class="yoast-field-group__inputfield" value="" name="foobar" id="example-input"
+		<input class="yoast-field-group__inputfield" type="text" value="" name="foobar" id="example-input-01"
 			   placeholder="This is a fake placeholder" aria-describedby="yoast_unique_description_id">
 	</div>
 
@@ -53,7 +53,7 @@
 
 	<div class="yoast-field-group">
 		<div class="yoast-field-group__title">
-			<label for="example-input">Do you have a passport?</label>
+			<label for="example-input-02">Do you have a passport?</label>
 			<a class="yoast-help" target="_blank" href="https://yoast.com">
 				<span class="yoast-help__icon">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" role="img" aria-hidden="true"
@@ -64,15 +64,23 @@
 				<span class="screen-reader-text">(Opens in a new browser tab)</span>
 			</a>
 		</div>
-		<input class="yoast-field-group__inputfield" type="password" value="" name="foobar" id="example-input"
-			   aria-describedby="yoast_unique_description_id">
+		<input class="yoast-field-group__inputfield" type="password" value="" name="foobar" id="example-input-02">
+	</div>
+
+	<p>Input field, readonly (or disabled, or aria-disabled)</p>
+
+	<div class="yoast-field-group">
+		<div class="yoast-field-group__title">
+			<label for="example-input-03">Do you have a passport?</label>
+		</div>
+		<input readonly class="yoast-field-group__inputfield" type="text" value="some value" name="foobar" id="example-input-03">
 	</div>
 
 	<p>Textarea with a label and help icon</p>
 
 	<div class="yoast-field-group">
 		<div class="yoast-field-group__title">
-			<label for="example-input">Do you have a passport?</label>
+			<label for="example-input-04">Do you have a passport?</label>
 			<a class="yoast-help" target="_blank" href="https://yoast.com">
 				<span class="yoast-help__icon">
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" role="img" aria-hidden="true"
@@ -83,8 +91,7 @@
 				<span class="screen-reader-text">(Opens in a new browser tab)</span>
 			</a>
 		</div>
-		<textarea value="" name="foobar" id="example-input" class="yoast-field-group__textarea"
-				  aria-describedby="yoast_unique_description_id"></textarea>
+		<textarea value="" name="foobar" id="example-input-04" class="yoast-field-group__textarea"></textarea>
 	</div>
 
 </form>


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

[components] Add styles for the input field and button for the Zapier integration.

## Relevant technical choices:

To match the design for the Zapier integration the following adjustments and new styles are needed:
- The box-shadow of the button should be `box-shadow: inset 0 -2px 0 rgba(0, 0, 0, 0.1);`
- A grey background for the input field when it's readonly or disabled.
- A style variant to make the input label element not bold.
- Horizontal alignment of input field + button: the current CSS makes the input field full width so the button goes in a new line; we need styling to make the input + button horizontally aligned

Design to match:

<img width="652" alt="Screenshot 2020-10-06 at 11 41 30" src="https://user-images.githubusercontent.com/1682452/95201421-38af1880-07e0-11eb-8056-437d0f0c3ec2.png">

See https://yoast.atlassian.net/browse/P3-184

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

- open the `packages/components/src/inputs/input.html` file in your browser and see the new examples

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Zapier integration tab

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

See https://yoast.atlassian.net/browse/P3-184