### PR TITLE
Fix Select's onOptionFocus call

### DIFF
--- a/packages/components/src/select/Select.js
+++ b/packages/components/src/select/Select.js
@@ -209,7 +209,7 @@ export class Select extends React.Component {
 	onInputHandler( event ) {
 		// Need to update the state in order to show the selected result before blurring.
 		this.setState( { selected: event.target.value } );
-		if ( this.onOptionFocus ) {
+		if ( this.props.onOptionFocus ) {
 			this.props.onOptionFocus( event.target.name, event.target.value );
 		}
 	}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/components] Fixes a bug where the Select's onOptionFocus would not be called.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Can be tested with wordpress-seo.
* Go to the site's schema settings: SEO -> Search Appearance -> Content types -> Schema settings.
* Changing a default type value should bring up an alert: `Upon saving, these settings will apply to all of your Posts. Posts that are manually configured will be left untouched.`
  * Where before this alert would not be shown anymore due to this bug.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
