### PR TITLE
Removes the configuration wizard imports- and exports from the yoast-components package and deprecates the exports.

### DIFF
--- a/packages/yoast-components/index.js
+++ b/packages/yoast-components/index.js
@@ -32,7 +32,8 @@ const OnboardingWizard = () => {
  * @returns {null} returns nothing.
  */
 const MessageBox = () => {
-	console.warn( "Deprecation Warning: Deprecated since 15.2.1. Use the `MessageBox` from the `@yoast/configuration-wizard` package instead." );
+	console.warn( "Deprecation Warning: Deprecated since 15.2.1. " +
+		"Use the `MessageBox` from the `@yoast/configuration-wizard` package instead." );
 	return null;
 };
 

--- a/packages/yoast-components/index.js
+++ b/packages/yoast-components/index.js
@@ -2,7 +2,6 @@
  * Composites imports.
  */
 // Composites/ConfigurationWizard imports.
-import { default as OnboardingWizard, LoadingIndicator, MessageBox } from "@yoast/configuration-wizard";
 import { decodeHTML, getDirectionalStyle, sendRequest } from "@yoast/helpers";
 // Import colors from the style guide.
 import { colors } from "@yoast/style-guide";
@@ -16,6 +15,37 @@ import { default as LinkSuggestions } from "./composites/LinkSuggestions/LinkSug
 
 const getRtlStyle = getDirectionalStyle;
 
+/**
+ * @deprecated since 15.2.1. Use the `OnboardingWizard` from the `@yoast/configuration-wizard` package instead.
+ *
+ * @returns {null} returns nothing.
+ */
+const OnboardingWizard = () => {
+	console.warn( "Deprecation Warning: Deprecated since 15.2.1. " +
+		"Use the `OnboardingWizard` from the `@yoast/configuration-wizard` package instead." );
+	return null;
+};
+
+/**
+ * @deprecated since 15.2.1. Use the `MessageBox` from the `@yoast/configuration-wizard` package instead.
+ *
+ * @returns {null} returns nothing.
+ */
+const MessageBox = () => {
+	console.warn( "Deprecation Warning: Deprecated since 15.2.1. Use the `MessageBox` from the `@yoast/configuration-wizard` package instead." );
+	return null;
+};
+
+/**
+ * @deprecated since 15.2.1. Use the `LoadingIndicator` from the `@yoast/configuration-wizard` package instead.
+ *
+ * @returns {null} returns nothing.
+ */
+const LoadingIndicator = () => {
+	console.warn( "Deprecation Warning: Deprecated since 15.2.1. " +
+		"Use the `LoadingIndicator` from the `@yoast/configuration-wizard` package instead." );
+	return null;
+};
 
 export {
 	OnboardingWizard,

--- a/packages/yoast-components/index.js
+++ b/packages/yoast-components/index.js
@@ -16,34 +16,34 @@ import { default as LinkSuggestions } from "./composites/LinkSuggestions/LinkSug
 const getRtlStyle = getDirectionalStyle;
 
 /**
- * @deprecated since 15.2.1. Use the `OnboardingWizard` from the `@yoast/configuration-wizard` package instead.
+ * @deprecated since 5.13.1. Use the `OnboardingWizard` from the `@yoast/configuration-wizard` package instead.
  *
  * @returns {null} returns nothing.
  */
 const OnboardingWizard = () => {
-	console.warn( "Deprecation Warning: Deprecated since 15.2.1. " +
+	console.warn( "Deprecation Warning: Deprecated since 5.13.1. " +
 		"Use the `OnboardingWizard` from the `@yoast/configuration-wizard` package instead." );
 	return null;
 };
 
 /**
- * @deprecated since 15.2.1. Use the `MessageBox` from the `@yoast/configuration-wizard` package instead.
+ * @deprecated since 5.13.1. Use the `MessageBox` from the `@yoast/configuration-wizard` package instead.
  *
  * @returns {null} returns nothing.
  */
 const MessageBox = () => {
-	console.warn( "Deprecation Warning: Deprecated since 15.2.1. " +
+	console.warn( "Deprecation Warning: Deprecated since 5.13.1. " +
 		"Use the `MessageBox` from the `@yoast/configuration-wizard` package instead." );
 	return null;
 };
 
 /**
- * @deprecated since 15.2.1. Use the `LoadingIndicator` from the `@yoast/configuration-wizard` package instead.
+ * @deprecated since 5.13.1. Use the `LoadingIndicator` from the `@yoast/configuration-wizard` package instead.
  *
  * @returns {null} returns nothing.
  */
 const LoadingIndicator = () => {
-	console.warn( "Deprecation Warning: Deprecated since 15.2.1. " +
+	console.warn( "Deprecation Warning: Deprecated since 5.13.1. " +
 		"Use the `LoadingIndicator` from the `@yoast/configuration-wizard` package instead." );
 	return null;
 };


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the Yoast metabox could not be loaded in the post editor when the `configuration-wizard-1520.js` JavaScript file is blocked from loading.

## Relevant technical choices:

* The OnboardingWizard, LoadingIndicator and MessageBox are not imported in the plugin from the `yoast-components` package, but directly from the `@yoast/configuration` package instead.
  * So they can be removed from the exports from `yoast-components`.
  * However, since they may be used by others, we deprecated them (just to be sure). 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### For developers:
* Import and use the `OnboardingWizard`, `LoadingIndicator` and `MessageBox` from the `yoast-components` package somewhere in the plugin.
* See that a deprecation warning is shown in the console.

### For QA:
* See the test instruction for https://github.com/Yoast/wordpress-seo/pull/16285. If that PR has been tested, this PR has been tested as well.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
