### PR TITLE
Create prepublish script for schema-blocks

### DIFF
--- a/packages/schema-blocks/package.json
+++ b/packages/schema-blocks/package.json
@@ -51,7 +51,8 @@
     "watch": "tsc --watch",
     "prepare": "yarn build",
     "lint": "eslint 'src/**'",
-    "test": "jest"
+    "test": "jest",
+    "prepublishOnly": "rm -rf dist && tsc && cp package.json dist/package.json && json -I -f dist/package.json -e \"this.main='index.js'\""
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Adds the required prepublish script to the schema-blocks package.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `yarn run prepublishOnly`
* You should have a dist directory.
* This dist directory should have a package.json and index.js

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * The published package for schema-blocks.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes missing prepublishOnly script for schema-blocks.
