### PR TITLE
Remove locale from Sentence and SentencePart objects

### DIFF
--- a/packages/yoastseo/src/languageProcessing/helpers/passiveVoice/periphrastic/getSentencePartsSplitOnStopwords.js
+++ b/packages/yoastseo/src/languageProcessing/helpers/passiveVoice/periphrastic/getSentencePartsSplitOnStopwords.js
@@ -54,7 +54,7 @@ function createSentenceParts( sentences, options ) {
 	const sentenceParts = [];
 	forEach( sentences, function( part ) {
 		const foundAuxiliaries = sanitizeMatches( part.match( options.regexes.auxiliaryRegex || [] ) );
-		sentenceParts.push( new options.SentencePart( part, foundAuxiliaries, options.locale ) );
+		sentenceParts.push( new options.SentencePart( part, foundAuxiliaries ) );
 	} );
 	return sentenceParts;
 }

--- a/packages/yoastseo/src/languageProcessing/languages/de/values/SentencePart.js
+++ b/packages/yoastseo/src/languageProcessing/languages/de/values/SentencePart.js
@@ -9,7 +9,7 @@ import getParticiples from "../helpers/internal/getParticiples.js";
  * @constructor
  */
 const GermanSentencePart = function( sentencePartText, auxiliaries ) {
-	SentencePart.call( this, sentencePartText, auxiliaries, "de_DE" );
+	SentencePart.call( this, sentencePartText, auxiliaries );
 };
 
 require( "util" ).inherits( GermanSentencePart, SentencePart );

--- a/packages/yoastseo/src/languageProcessing/languages/en/values/SentencePart.js
+++ b/packages/yoastseo/src/languageProcessing/languages/en/values/SentencePart.js
@@ -9,7 +9,7 @@ import getParticiples from "../helpers/internal/getParticiples.js";
  * @constructor
  */
 var EnglishSentencePart = function( sentencePartText, auxiliaries ) {
-	SentencePart.call( this, sentencePartText, auxiliaries, "en_EN" );
+	SentencePart.call( this, sentencePartText, auxiliaries );
 };
 
 require( "util" ).inherits( EnglishSentencePart, SentencePart );

--- a/packages/yoastseo/src/languageProcessing/languages/es/values/SentencePart.js
+++ b/packages/yoastseo/src/languageProcessing/languages/es/values/SentencePart.js
@@ -10,7 +10,7 @@ import getParticiples from "../helpers/internal/getParticiples.js";
  * @constructor
  */
 const SpanishSentencePart = function( sentencePartText, auxiliaries ) {
-	SentencePart.call( this, sentencePartText, auxiliaries, "es_ES" );
+	SentencePart.call( this, sentencePartText, auxiliaries );
 };
 
 require( "util" ).inherits( SpanishSentencePart, SentencePart );

--- a/packages/yoastseo/src/languageProcessing/languages/fr/values/SentencePart.js
+++ b/packages/yoastseo/src/languageProcessing/languages/fr/values/SentencePart.js
@@ -10,7 +10,7 @@ import getParticiples from "../helpers/internal/getParticiples.js";
  * @constructor
  */
 const FrenchSentencePart = function( sentencePartText, auxiliaries ) {
-	SentencePart.call( this, sentencePartText, auxiliaries, "fr_FR" );
+	SentencePart.call( this, sentencePartText, auxiliaries );
 };
 
 require( "util" ).inherits( FrenchSentencePart, SentencePart );

--- a/packages/yoastseo/src/languageProcessing/languages/it/values/SentencePart.js
+++ b/packages/yoastseo/src/languageProcessing/languages/it/values/SentencePart.js
@@ -9,7 +9,7 @@ import getParticiples from "../helpers/internal/getParticiples.js";
  * @constructor
  */
 const ItalianSentencePart = function( sentencePartText, auxiliaries ) {
-	SentencePart.call( this, sentencePartText, auxiliaries, "it_IT" );
+	SentencePart.call( this, sentencePartText, auxiliaries );
 };
 
 require( "util" ).inherits( ItalianSentencePart, SentencePart );

--- a/packages/yoastseo/src/languageProcessing/languages/nl/values/SentencePart.js
+++ b/packages/yoastseo/src/languageProcessing/languages/nl/values/SentencePart.js
@@ -9,7 +9,7 @@ import getParticiples from "../helpers/internal/getParticiples.js";
  * @constructor
  */
 const DutchSentencePart = function( sentencePartText, auxiliaries ) {
-	SentencePart.call( this, sentencePartText, auxiliaries, "nl_NL" );
+	SentencePart.call( this, sentencePartText, auxiliaries );
 };
 
 require( "util" ).inherits( DutchSentencePart, SentencePart );

--- a/packages/yoastseo/src/languageProcessing/languages/pl/helpers/getSentenceParts.js
+++ b/packages/yoastseo/src/languageProcessing/languages/pl/helpers/getSentenceParts.js
@@ -6,7 +6,6 @@ import stopwordsFactory from "../config/stopwords.js";
 
 const options = {
 	SentencePart: SentencePart,
-	locale: "pl_PL",
 	regexes: {
 		auxiliaryRegex: arrayToRegex( auxiliariesFactory().all ),
 		stopwordRegex: arrayToRegex( stopwordsFactory() ),

--- a/packages/yoastseo/src/languageProcessing/languages/pl/values/SentencePart.js
+++ b/packages/yoastseo/src/languageProcessing/languages/pl/values/SentencePart.js
@@ -9,7 +9,7 @@ import getParticiples from "../helpers/internal/getParticiples.js";
  * @constructor
  */
 const PolishSentencePart = function( sentencePartText, auxiliaries ) {
-	SentencePart.call( this, sentencePartText, auxiliaries, "pl_PL" );
+	SentencePart.call( this, sentencePartText, auxiliaries );
 };
 
 require( "util" ).inherits( PolishSentencePart, SentencePart );

--- a/packages/yoastseo/src/languageProcessing/languages/pt/values/SentencePart.js
+++ b/packages/yoastseo/src/languageProcessing/languages/pt/values/SentencePart.js
@@ -9,7 +9,7 @@ import getParticiples from "../helpers/internal/getParticiples.js";
  * @constructor
  */
 const PortugueseSentencePart = function( sentencePartText, auxiliaries ) {
-	SentencePart.call( this, sentencePartText, auxiliaries, "pt_PT" );
+	SentencePart.call( this, sentencePartText, auxiliaries );
 };
 
 require( "util" ).inherits( PortugueseSentencePart, SentencePart );

--- a/packages/yoastseo/src/values/Sentence.js
+++ b/packages/yoastseo/src/values/Sentence.js
@@ -2,7 +2,6 @@
  * Construct the Sentence object and set the sentence text and locale.
  *
  * @param {string} sentence The text of the sentence.
- * @param {string} locale The locale.
  * @constructor
  */
 var Sentence = function( sentence ) {
@@ -58,7 +57,7 @@ Sentence.prototype.serialize = function() {
  * @returns {Sentence} The parsed Sentence.
  */
 Sentence.parse = function( serialized ) {
-	const sentence = new Sentence( serialized.sentenceText, serialized.locale );
+	const sentence = new Sentence( serialized.sentenceText );
 	sentence.setPassive( serialized.isPassive );
 
 	return sentence;

--- a/packages/yoastseo/src/values/Sentence.js
+++ b/packages/yoastseo/src/values/Sentence.js
@@ -1,21 +1,12 @@
 /**
- * Default attributes to be used by the Sentence if they are left undefined.
- * @type {{locale: string}}
- */
-var defaultAttributes = {
-	locale: "en_US",
-};
-
-/**
  * Construct the Sentence object and set the sentence text and locale.
  *
  * @param {string} sentence The text of the sentence.
  * @param {string} locale The locale.
  * @constructor
  */
-var Sentence = function( sentence, locale ) {
+var Sentence = function( sentence ) {
 	this._sentenceText = sentence || "";
-	this._locale = locale || defaultAttributes.locale;
 	this._isPassive = false;
 };
 
@@ -25,14 +16,6 @@ var Sentence = function( sentence, locale ) {
  */
 Sentence.prototype.getSentenceText = function() {
 	return this._sentenceText;
-};
-
-/**
- * Returns the locale.
- * @returns {String} The locale.
- */
-Sentence.prototype.getLocale = function() {
-	return this._locale;
 };
 
 /**
@@ -63,7 +46,6 @@ Sentence.prototype.serialize = function() {
 	return {
 		_parseClass: "Sentence",
 		sentenceText: this._sentenceText,
-		locale: this._locale,
 		isPassive: this._isPassive,
 	};
 };

--- a/packages/yoastseo/src/values/SentencePart.js
+++ b/packages/yoastseo/src/values/SentencePart.js
@@ -3,11 +3,10 @@
  *
  * @param {string} sentencePartText The text in the sentence part.
  * @param {Array} auxiliaries The list of auxiliaries from the sentence part.
- * @param {string} locale The locale used for this sentence part.
  *
  * @constructor
  */
-var SentencePart = function( sentencePartText, auxiliaries ) {
+const SentencePart = function( sentencePartText, auxiliaries ) {
 	this._sentencePartText = sentencePartText;
 	this._auxiliaries = auxiliaries;
 	this._isPassive = false;

--- a/packages/yoastseo/src/values/SentencePart.js
+++ b/packages/yoastseo/src/values/SentencePart.js
@@ -7,10 +7,9 @@
  *
  * @constructor
  */
-var SentencePart = function( sentencePartText, auxiliaries, locale ) {
+var SentencePart = function( sentencePartText, auxiliaries ) {
 	this._sentencePartText = sentencePartText;
 	this._auxiliaries = auxiliaries;
-	this._locale = locale;
 	this._isPassive = false;
 };
 
@@ -42,15 +41,6 @@ SentencePart.prototype.getAuxiliaries = function() {
 };
 
 /**
- * Returns the locale of the sentence part.
- *
- * @returns {string} The locale of the sentence part.
- */
-SentencePart.prototype.getLocale = function() {
-	return this._locale;
-};
-
-/**
  * Sets the passiveness of the sentence part.
  *
  * @param {boolean} passive Whether the sentence part is passive or not.
@@ -70,7 +60,6 @@ SentencePart.prototype.serialize = function() {
 		_parseClass: "SentencePart",
 		sentencePartText: this._sentencePartText,
 		auxiliaries: this._auxiliaries,
-		locale: this._locale,
 		isPassive: this._isPassive,
 	};
 };
@@ -83,7 +72,7 @@ SentencePart.prototype.serialize = function() {
  * @returns {SentencePart} The parsed SentencePart.
  */
 SentencePart.parse = function( serialized ) {
-	const sentencePart = new SentencePart( serialized.sentencePartText, serialized.auxiliaries, serialized.locale );
+	const sentencePart = new SentencePart( serialized.sentencePartText, serialized.auxiliaries );
 	sentencePart.setPassive( serialized.isPassive );
 
 	return sentencePart;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Removes `locale` property from the `Sentence` and `SentencePart` objects used for the passive voice assessment.

## Relevant technical choices:

### Sentence
As far as I can see, we only create `Sentence` objects in `getPassiveVoice`. However, locale isn't set there. From this I conclude that we can remove the locale from the `Sentence` object.

### SentencePart
- We create sentence parts in the language-specific sentence part constructors, where we set the locale.
- These are called in `getSentencePartsSplitOnStopwords`, where the sentence parts are exported as `splitSentence`. This in term is used in `getSentenceParts`, which is saved as a helper on the researcher. This data is used in `isPassiveSentencePart`. This function is called in `getPassiveVoice`, where it's called with the `sentencePart.getSentencePartText()` and `sentencePart.getAuxiliaries()` as parameters. `sentencePart.getlocale()` never seems to be called anywhere. From this I conclude that we can remove the locale from the `SentencePart` object.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-535
