### PR TITLE
P1-261 Capture anchor tags with whitespace inside

### DIFF
--- a/packages/yoastseo/spec/stringProcessing/getAnchorsFromTextSpec.js
+++ b/packages/yoastseo/spec/stringProcessing/getAnchorsFromTextSpec.js
@@ -5,4 +5,21 @@ describe( "matches links in URL", function() {
 		expect( linkMatches( "a text without links" ) ).toEqual( [] );
 		expect( linkMatches( "a <a href='test.com'>text</a> with a link" )[ 0 ] ).toBe( "<a href='test.com'>text</a>" );
 	} );
+
+	it( "does not match an anchor tag without attributes", () => {
+		expect( linkMatches( "an <a>anchor without a link</a> is ignored" ) ).toEqual( [] );
+		expect( linkMatches( "an <a >anchor without a link</a> is ignored" ) ).toEqual( [] );
+	} );
+
+	it( "can handle whitespace and HTML inside the anchor tag", () => {
+		expect( linkMatches(
+			"a <a href='test.com'>text\n" +
+			"with <strong>HTML</strong>, whitespace\n" +
+			"and</a> with a link" )[ 0 ]
+		).toBe(
+			"<a href='test.com'>text\n" +
+			"with <strong>HTML</strong>, whitespace\n" +
+			"and</a>"
+		);
+	} );
 } );

--- a/packages/yoastseo/src/stringProcessing/getAnchorsFromText.js
+++ b/packages/yoastseo/src/stringProcessing/getAnchorsFromText.js
@@ -9,8 +9,19 @@
 export default function( text ) {
 	var matches;
 
-	// Regex matches everything between <a> and </a>
-	matches = text.match( /<a(?:[^>]+)?>(.*?)<\/a>/ig );
+	/*
+	  * Regex matches everything between <a> and </a>.
+	  *
+	  * There must be:
+	  * - at least one whitespace after the starting `<a`, otherwise it matches `<abbr` tags.
+	  * - followed by at least one not `>`, to match any attributes that are given.
+	  *   This could be one or zero (`*`), but an anchor tag without an `href` attribute does not make sense.
+	  *   The regex could be more precise here, by checking for the `href`, but this is less complex.
+	  * - losing tag of the opening tag `>`.
+	  * - content of the anchor tag. Any character, including line separators (`[\n\r\u2028\u2029]`).
+	  * - the closing anchor tag.
+	 */
+	matches = text.match( /<a[\s]+(?:[^>]+)>((?:.|[\n\r\u2028\u2029])*?)<\/a>/ig );
 
 	if ( matches === null ) {
 		matches = [];


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where links that contain line terminators (`\n` or `\r`) would not be detected as a link.

## Relevant technical choices:

* The `.` is any character except line terminators. `\u2028` is a line separator and `\u2029` is a paragraph separator.
* I made it so there has to be at least one non-`>`, this can be debated I suppose.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Edit a post/page without any links in the Elementor editor.
* Verify the SEO analysis has the problems with `Outbound links` and `Internal links`.
* Add an internal link.
* Verify the `Internal links` assessment is now a `Good result`.
* Add an outbound link.
* Verify the `Outbound links` assessment is now a `Good result`.
* Influences other editors too. Verify the above still works in the block editor and classic editor too.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * The keyword in first paragraph assessment, it removes anchors found. So in theory this assessment could come up more now.
  * The links research (couldn't find it being used by assessments directly).
  * The link statistics research: internal and outbound links assessments. Should be finding more now.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Partially fixes https://yoast.atlassian.net/browse/P1-261
