### PR TITLE
Configured JSX for the schema-blocks package.

### DIFF
--- a/packages/schema-blocks/.eslintrc
+++ b/packages/schema-blocks/.eslintrc
@@ -77,6 +77,8 @@
                 "requireReturnType": false,
                 "requireParamType": false
             }
-        ]
+        ],
+        // We use `wp.element.createElement` instead of the `react` package directly.
+        "react/react-in-jsx-scope": 0
     }
 }

--- a/packages/schema-blocks/tsconfig.json
+++ b/packages/schema-blocks/tsconfig.json
@@ -4,6 +4,7 @@
         "noImplicitAny": true,
         "target": "es5",
         "jsx": "react",
+        "jsxFactory": "createElement",
         "allowJs": true,
         "lib": [
             "DOM",


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Adds support for JSX to the schema-blocks package.

## Relevant technical choices:

* I disabled the ESLint rule that checks whether `React` is imported, since we use `wp.element.createElement` instead (see also the ESLint configuration in the plugin).

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Replace a `createElement` function within a file in the schema-block package with the appropriate JSX syntax.
  * For example https://github.com/Yoast/javascript/blob/develop/packages/schema-blocks/src/instructions/blocks/abstract/RichTextBase.ts#L57
    with:
    ```js
    return <WordPressRichText { ...attributes } />;
    ```
* Give the file a `.tsx` filetype.
  * The `.tsx` ending makes sure that TypeScript correctly identifies the React elements in the file.
* Build the schema-blocks package and the JS files in the plugin.
* Test out the recipe block, it should still work as expected.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * N/A

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
