### PR TITLE
Add specs for directPrecedenceException and precedenceException files

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/helpers/passiveVoice/directPrecedenceExceptionSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/passiveVoice/directPrecedenceExceptionSpec.js
@@ -1,0 +1,28 @@
+import directPrecedenceException from "../../../../src/languageProcessing/helpers/passiveVoice/directPrecedenceException";
+
+describe( "Test to check whether the participle is directly preceded by a word from the direct precedence exception list.", () => {
+	it( "Returns true if the participle is directly preceded by a word from the direct precedence exception list.", () => {
+		expect( directPrecedenceException( "I am wiser for having read that book",
+			"read", [ "having", "the", "for", "a" ] ) ).toEqual( true );
+	} );
+
+	it( "Returns false if there is no precedence exception list available and the sentence contains a participle", () => {
+		expect( directPrecedenceException( "I am wiser for having read that book",
+			"read" ) ).toEqual( false );
+	} );
+
+	it( "Returns false if a word from the precedence exception list doesn't occur directly before the participle", () => {
+		expect( directPrecedenceException( "Have I read the book?",
+			"read", [ "have", "the", "for", "a" ] ) ).toEqual( false );
+	} );
+
+	it( "Returns false if there is no participle in the sentence", () => {
+		expect( directPrecedenceException( "I have a book",
+			"read", [ "having", "the", "for", "a" ] ) ).toEqual( false );
+	} );
+
+	it( "Returns false if there is no word before the participle in the sentence", () => {
+		expect( directPrecedenceException( "Read the book!",
+			"read", [ "having", "the", "for", "a" ] ) ).toEqual( false );
+	} );
+} );

--- a/packages/yoastseo/spec/languageProcessing/helpers/passiveVoice/precedenceExceptionSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/helpers/passiveVoice/precedenceExceptionSpec.js
@@ -1,0 +1,28 @@
+import precedenceException from "../../../../src/languageProcessing/helpers/passiveVoice/precedenceException";
+
+describe( "Test to check whether a word from the precedence exception list occurs anywhere in the sentence part before the participle.", () => {
+	it( "Returns true if a word from the precedence exception list occurs anywhere in the sentence part before the participle", () => {
+		expect( precedenceException( "It's something I've always enjoyed doing",
+			"enjoyed", [ "i've", "have", "you'll" ] ) ).toEqual( true );
+	} );
+
+	it( "Returns false if a word from the precedence exception list doesn't occur anywhere in the sentence part before the participle", () => {
+		expect( precedenceException( "The money was stolen, but nobody has been able to prove it",
+			"stolen", [ "i've", "have", "has" ] ) ).toEqual( false );
+	} );
+
+	it( "Returns false if there is no precedence exception list available and the sentence contains a participle", () => {
+		expect( precedenceException( "It's something I've always enjoyed doing",
+			"read" ) ).toEqual( false );
+	} );
+
+	it( "Returns false if there is no participle in the sentence", () => {
+		expect( precedenceException( "I have a book",
+			"read", [ "i've", "have", "you'll" ] ) ).toEqual( false );
+	} );
+
+	it( "Returns false if there is no word before the participle in the sentence", () => {
+		expect( precedenceException( "Read the book!",
+			"read", [ "i've", "have", "you'll" ] ) ).toEqual( false );
+	} );
+} );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Creates a new passiveVoice folder in yoastseo/spec/languageProcessing/helpers, and adds the specs for `directPrecedenceException` and `precedenceException` there.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-565
