### PR TITLE
Fix clientHeight of undefined error

### DIFF
--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -273,7 +273,7 @@ const Amp = styled.div`
 	margin-bottom: -1px;
 	opacity: 0.46;
 	margin-right: 6px;
-	background-image: url( ${ ampLogo } )
+	background-image: url( ${ ampLogo } );
 `;
 
 /**
@@ -658,6 +658,15 @@ export default class SnippetPreview extends PureComponent {
 		this.setState( {
 			isDescriptionPlaceholder: ( ! this.props.description ),
 		} );
+	}
+
+	/**
+	 * Unset the timeout when unmounting, because "element" will no longer be available to fit the title.
+	 *
+	 * @returns {void}
+	 */
+	componentWillUnmount() {
+		clearTimeout( this.fitTitleTimeout );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where a console error would appear when closing the Google Preview modal.

## Relevant technical choices:

* Timeout caused the function to look for an element after closing.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* On `trunk`, link monorepo `develop` to the plugin, and try to reproduce the bug:
1. Open the console
2. Edit a post/page
3. Open Google Preview, activate one of the text input fields (title, slug, or description), and close it by clicking outside the modal
4. Observe clientHeight bug.
* Now checkout this branch, and run `grunt build:dev` in the plugin.
* Try to reproduce again. Bug should be gone.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes QAK-2543
