### PR TITLE
P2-576 - Moved schema-blocks CSS to the monorepo.

### DIFF
--- a/packages/schema-blocks/css/schema-blocks.css
+++ b/packages/schema-blocks/css/schema-blocks.css
@@ -1,0 +1,14 @@
+.yoast-labeled-inserter {
+	position: relative;
+	width: 100%;
+}
+.yoast-labeled-inserter::before {
+	content: attr(data-label);
+	position: absolute;
+	left: 0;
+	height: 100%;
+	color: black;
+}
+.yoast-labeled-inserter > .block-editor-inserter {
+	width: 100%;
+}

--- a/packages/schema-blocks/src/index.ts
+++ b/packages/schema-blocks/src/index.ts
@@ -4,12 +4,14 @@ import watch from "./functions/gutenberg/watch";
 import filter from "./functions/gutenberg/filter";
 
 /**
- * Removes all line breaks from a string.
+ * Removes all whitespace including line breaks from a string.
+ *
+ * @param text The text to remove the whitespace from.
  *
  * @returns {string} The converted string.
  */
-function getTemplate(): string {
-	return this.innerHTML.split( "\n" ).map( s => s.trim() ).join( "" );
+function removeWhitespace( text: string ): string {
+	return text.split( "\n" ).map( ( s: string ) => s.trim() ).join( "" );
 }
 
 /**
@@ -18,7 +20,7 @@ function getTemplate(): string {
 export default function initialize() {
 	jQuery( 'script[type="text/schema-template"]' ).each( function() {
 		try {
-			const template = getTemplate();
+			const template = removeWhitespace( this.innerHTML );
 			const definition = processSchema( template );
 			definition.register();
 		} catch ( e ) {
@@ -31,7 +33,7 @@ export default function initialize() {
 
 	jQuery( 'script[type="text/block-template"]' ).each( function() {
 		try {
-			const template = getTemplate();
+			const template = removeWhitespace( this.innerHTML );
 			const definition = processBlock( template );
 			definition.register();
 		} catch ( e ) {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Moves the CSS for the schema-blocks from the plugin to the schema-blocks package.
* Fixes a bug in the schema-blocks where schema templates could not be registered.

## Relevant technical choices:

* Decided to fix a bug that was on `develop` with this PR as well.
  * `this` was undefined within the scope of the `getTemplate()` function, leading to the schema templates not being able to be parsed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test this PR in tandem with https://github.com/Yoast/wordpress-seo/pull/16476.
* Change the schema-blocks CSS, to be able to check whether any changes in the styling propagate to the styling of the schema blocks in the Gutenberg editor.
  * E.g. change the color of the `yoast-labeled-inserter::before` to `darkpink`.
* Build the CSS of the WordPress SEO plugin.
  * E.g. `grunt build:css`
* Open a post in the post editor.
* Add a recipe block.
* See that it contains the styling as defined in `packages/schema-blocks/css/schema-blocks.css`. 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
