### PR TITLE
Add sentence length assessment for Turkish

### DIFF
--- a/packages/yoastseo/spec/assessments/sentenceLengthInTextSpec.js
+++ b/packages/yoastseo/spec/assessments/sentenceLengthInTextSpec.js
@@ -516,6 +516,56 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
+	it( "returns the score for 100% long sentences in Turkish", function() {
+		const mockPaper = new Paper( "text", { locale: "tr_TR" } );
+		const sentenceLengthInTextAssessmentHebrew = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
+
+		const assessment = sentenceLengthInTextAssessmentHebrew.getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 12 },
+		] ), i18n );
+
+		expect( assessment.hasScore() ).toBe( true );
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"100% of the sentences contain more than 10 words, which is more than the recommended maximum of 25%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
+		expect( assessment.hasMarks() ).toBe( true );
+	} );
+
+	it( "returns the score for 50% long sentences in Turkish", function() {
+		const mockPaper = new Paper( "text", { locale: "tr_TR" } );
+		const sentenceLengthInTextAssessmentHungarian = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
+
+		const assessment = sentenceLengthInTextAssessmentHungarian.getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 12 },
+			{ sentence: "", sentenceLength: 7 },
+		] ), i18n );
+
+		expect( assessment.hasScore() ).toBe( true );
+		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
+			"50% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%." +
+			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
+		expect( assessment.hasMarks() ).toBe( true );
+	} );
+
+	it( "returns the score for 25% long sentences in Turkish", function() {
+		const mockPaper = new Paper( "text", { locale: "tr_TR" } );
+		const sentenceLengthInTextAssessmentHebrew = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
+
+		const assessment = sentenceLengthInTextAssessmentHebrew.getResult( mockPaper, Factory.buildMockResearcher( [
+			{ sentence: "", sentenceLength: 12 },
+			{ sentence: "", sentenceLength: 11 },
+			{ sentence: "", sentenceLength: 11 },
+			{ sentence: "", sentenceLength: 11 },
+		] ), i18n );
+
+		expect( assessment.hasScore() ).toBe( true );
+		expect( assessment.getScore() ).toEqual( 9 );
+		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
+		expect( assessment.hasMarks() ).toBe( true );
+	} );
+
 	it( "is not applicable for empty papers", function() {
 		const mockPaper = new Paper();
 		const assessment = sentenceLengthInTextAssessment.isApplicable( mockPaper );

--- a/packages/yoastseo/spec/assessments/sentenceLengthInTextSpec.js
+++ b/packages/yoastseo/spec/assessments/sentenceLengthInTextSpec.js
@@ -187,7 +187,6 @@ describe( "An assessment for sentence length", function() {
 	it( "returns the score for all short sentences in Catalan", function() {
 		const mockPaper = new Paper( "text", { locale: "ca_ES" } );
 		const sentenceLengthInTextAssessmentCatalan = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
-
 		const assessment = sentenceLengthInTextAssessmentCatalan.getResult( mockPaper, Factory.buildMockResearcher( [
 			{ sentence: "", sentenceLength: 24 },
 
@@ -527,7 +526,7 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
-			"100% of the sentences contain more than 10 words, which is more than the recommended maximum of 25%." +
+			"100% of the sentences contain more than 11 words, which is more than the recommended maximum of 25%." +
 			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
@@ -544,7 +543,7 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
-			"50% of the sentences contain more than 20 words, which is more than the recommended maximum of 25%." +
+			"50% of the sentences contain more than 11 words, which is more than the recommended maximum of 25%." +
 			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );

--- a/packages/yoastseo/src/config/content/combinedConfig.js
+++ b/packages/yoastseo/src/config/content/combinedConfig.js
@@ -8,6 +8,7 @@ import es from "./es";
 import ca from "./ca";
 import pt from "./pt";
 import he from "./he";
+import tr from "./tr";
 
 const configurations = {
 	it: it,
@@ -17,6 +18,7 @@ const configurations = {
 	ca: ca,
 	pt: pt,
 	he: he,
+	tr: tr,
 };
 
 /**

--- a/packages/yoastseo/src/config/content/tr.js
+++ b/packages/yoastseo/src/config/content/tr.js
@@ -1,0 +1,10 @@
+/**
+ * Turkish sentences tend to be shorter because it is a synthetic language. According to our research, sentences that consist of 10 words or above
+ * diffciult to read because each word contains suffixes.
+ */
+
+export default {
+	sentenceLength: {
+		recommendedWordCount: 11,
+	},
+};


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds the sentence length assessment for Turkish.
* [Yoast SEO Free] Adds Sentence length assessment for Turkish.

## Relevant technical choices:

* Research has confirmed that the default value of 11 words is a suitable value for Turkish.


## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:



* Set your website to Turkish.  
* Create a new post 
* Add a text with Turkish sentences with less than or 11 words, e.g.:
     `Bir varmış bir yokmuş. Evvel zamanda bir padişah ve üç de oğlu varmış. Bunlar ülkelerinde mutlu bir hayat sürerlermiş. Küçük oğlan bir gün köşkünde otururken, sokaktaki çeşmeden su almak için bir kocakarının geldiğini görmüş. Oğlan kocakarının testisine küçük bir taş atmış ve testiyi kırmış. Kocakarı bir şey söylemeden evine dönmüş.`
* Make sure that your sentence length assessment score reads: `Sentence length: Great!`
* Make the first sentences longer than 11 words by removing the period between the first two pairs of sentences. e.g.: 
`Bir varmış bir yokmuş Evvel zamanda bir padişah ve üç de oğlu varmış. Bunlar ülkelerinde mutlu bir hayat sürerlermiş Küçük oğlan bir gün köşkünde otururken, sokaktaki çeşmeden su almak için bir kocakarının geldiğini görmüş. Oğlan kocakarının testisine küçük bir taş atmış ve testiyi kırmış. Kocakarı bir şey söylemeden evine dönmüş.`
* Check that the Sentence length assessment score becomes worse, e.g.: `Sentence length: 50% of the sentences contain more than 11 words, which is more than the recommended maximum of 25%. Try to shorten the sentences.`
* Make all sentences longer than 11 words by removing the period between each pair of sentences, e.g.:
`Bir varmış bir yokmuş Evvel zamanda bir padişah ve üç de oğlu varmış. Bunlar ülkelerinde mutlu bir hayat sürerlermiş Küçük oğlan bir gün köşkünde otururken, sokaktaki çeşmeden su almak için bir kocakarının geldiğini görmüş. Oğlan kocakarının testisine küçük bir taş atmış ve testiyi kırmış Kocakarı bir şey söylemeden evine dönmüş.`
* Check that the Sentence length assessment score becomes worse, e.g.: `Sentence length: 100% of the sentences contain more than 11 words, which is more than the recommended maximum of 25%. Try to shorten the sentences.`

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-536