### PR TITLE
Update readme.md with new assessments for Hungarian and Hebrew

### DIFF
--- a/packages/yoastseo/README.md
+++ b/packages/yoastseo/README.md
@@ -36,7 +36,7 @@ import { AnalysisWebWorker } from "yoastseo";
 
 const worker = new AnalysisWebWorker( self );
 worker.register();
-``` 
+```
 
 Then in a different script you have the following code:
 
@@ -59,7 +59,7 @@ worker.initialize( {
     const paper = new Paper( "Text to analyze", {
         keyword: "analyze",
     } );
-    
+
     return worker.analyze( paper );
 } ).then( ( results ) => {
     console.log( 'Analysis results:' );
@@ -101,10 +101,10 @@ console.log( researcher.getResearch( "wordCountInText" ) );
 | Catalan    	| ✅                	|                     	|               	|                     	|                             	|                            	|
 | Polish     	| ✅                	| ❌<sup>3</sup>       	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
 | Swedish    	| ✅                	| ❌<sup>3</sup>       	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
-| Hungarian  	| ✅                	|                     	|               	|                     	|                             	|                            	|
+| Hungarian  	| ✅                	| ❌<sup>3</sup>        |  ✅          	|     ✅           	|         ✅             	|             ✅                 	|                            	|
 | Indonesian 	| ✅                	| ❌<sup>3</sup>       	| ✅             	| ✅                   	| ✅                           	| ✅                          	|
-| Arabic    	| ✅                	| ❌<sup>3</sup>         | ✅             	| ✅                   	| ✅                           	| ✅                          	|
-| Hebrew      |                   |                         |                 |                        |                                | ✅                         |    
+| Arabic    	| ✅                	| ❌<sup>3</sup>        | ✅             	| ✅                   	| ✅                           	| ✅                          	|
+| Hebrew      |   ✅                | ❌<sup>3</sup>             | ✅             |    ✅               |      ✅                   |           ✅                     | ✅                         |
 | Farsi    	  |                  	|                         |               	|                       |                             	| ✅                          	|
 
 <sup>1</sup> This means the default upper limit of 20 words has been verified for this language, or the upper limit has been changed.
@@ -114,7 +114,7 @@ console.log( researcher.getResearch( "wordCountInText" ) );
 <sup>3</sup> There is no existing Flesch reading ease formula for these languages.
 
 
-The following readability assessments are available for all languages: 
+The following readability assessments are available for all languages:
 - sentence length (with a default upper limit of 20 words, see<sup>1</sup> above )
 - paragraph length
 - subheading distribution


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds checkmark for the assessments that are now available in Hungarian and Hebrew.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-568
