### PR TITLE
Rebase Estimated Reading Time changes from develop

### DIFF
--- a/packages/components/src/InsightsCard.js
+++ b/packages/components/src/InsightsCard.js
@@ -1,11 +1,25 @@
 import React, { Fragment } from "react";
 import PropTypes from "prop-types";
+import HelpIcon from "./help-icon/HelpIcon";
 
 class InsightsCard extends React.Component {
 
 	getDescription() {
 		if ( this.props.description ) {
-			return <p className="yoast-insights-card__description">{ this.props.description }</p>;
+			return this.props.description;
+		}
+
+		return;
+	}
+
+	getHelpIcon() {
+		if ( this.props.linkTo ) {
+			return (
+				<HelpIcon
+					linkTo={ this.props.linkTo }
+					linkText={ this.props.linkText }
+				/>
+			);
 		}
 
 		return;
@@ -14,26 +28,26 @@ class InsightsCard extends React.Component {
 	render() {
 		return (
 			<div className="yoast-insights-card">
-				<p className="yoast-field-group__title">{ this.props.title }</p>
+				<div className="yoast-field-group__title">
+					<b>{ this.props.title }</b>
+					{ this.getHelpIcon() }
+				</div>
 				<div className="yoast-insights-card__content">
-					<p><span className="yoast-insights-card__amount">{ this.props.amount }</span> minutes</p>
-					{ this.getDescription() }
+					<p className="yoast-insights-card__score"><span className="yoast-insights-card__amount">{ this.props.amount }</span> { this.props.measurement }</p>
+					<div className="yoast-insights-card__description">{ this.getDescription() }</div>
 				</div>
 			</div>
 		);
 	}
 }
 
-export default InsightsCard;
-
 InsightsCard.propTypes = {
-	title: PropTypes.String,
-	amount: PropTypes.String.isRequired,
-	description: PropTypes.String,
+	title: PropTypes.string,
+	amount: PropTypes.number,
+	description: PropTypes.element,
+	measurement: PropTypes.string,
+	linkTo: PropTypes.string,
+	linkText: PropTypes.string,
 }
 
-InsightsCard.defaultProps = {
-	title: "",
-	amount: "",
-	description: "",
-}
+export default InsightsCard;

--- a/packages/components/src/InsightsCard.js
+++ b/packages/components/src/InsightsCard.js
@@ -33,7 +33,7 @@ class InsightsCard extends React.Component {
 					{ this.getHelpIcon() }
 				</div>
 				<div className="yoast-insights-card__content">
-					<p className="yoast-insights-card__score"><span className="yoast-insights-card__amount">{ this.props.amount }</span> { this.props.measurement }</p>
+					<p className="yoast-insights-card__score"><span className="yoast-insights-card__amount">{ this.props.amount }</span> { this.props.unit }</p>
 					<div className="yoast-insights-card__description">{ this.getDescription() }</div>
 				</div>
 			</div>
@@ -45,7 +45,7 @@ InsightsCard.propTypes = {
 	title: PropTypes.string,
 	amount: PropTypes.number,
 	description: PropTypes.element,
-	measurement: PropTypes.string,
+	unit: PropTypes.string,
 	linkTo: PropTypes.string,
 	linkText: PropTypes.string,
 }

--- a/packages/components/src/InsightsCard.js
+++ b/packages/components/src/InsightsCard.js
@@ -1,9 +1,16 @@
-import React, { Fragment } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import HelpIcon from "./help-icon/HelpIcon";
 
+/**
+ * A card component that can be used in the Insights Modal.
+ */
 class InsightsCard extends React.Component {
-
+	/**
+	 * Function to return the description if a description is provided.
+	 *
+	 * @returns {React.Component} The description.
+	 */
 	getDescription() {
 		if ( this.props.description ) {
 			return this.props.description;
@@ -12,6 +19,11 @@ class InsightsCard extends React.Component {
 		return;
 	}
 
+	/**
+	 * Function to return the help icon if a linkTo is provided.
+	 *
+	 * @returns {React.component} The HelpIcon.
+	 */
 	getHelpIcon() {
 		if ( this.props.linkTo ) {
 			return (
@@ -25,6 +37,11 @@ class InsightsCard extends React.Component {
 		return;
 	}
 
+	/**
+	 * Returns the rendered HTML.
+	 *
+	 * @returns {React.Component} The InsightsCard.
+	 */
 	render() {
 		return (
 			<div className="yoast-insights-card">
@@ -33,7 +50,10 @@ class InsightsCard extends React.Component {
 					{ this.getHelpIcon() }
 				</div>
 				<div className="yoast-insights-card__content">
-					<p className="yoast-insights-card__score"><span className="yoast-insights-card__amount">{ this.props.amount }</span> { this.props.unit }</p>
+					<p className="yoast-insights-card__score">
+						<span className="yoast-insights-card__amount">{ this.props.amount }</span>
+						{ this.props.unit }
+					</p>
 					<div className="yoast-insights-card__description">{ this.getDescription() }</div>
 				</div>
 			</div>
@@ -41,13 +61,21 @@ class InsightsCard extends React.Component {
 	}
 }
 
+export default InsightsCard;
+
 InsightsCard.propTypes = {
 	title: PropTypes.string,
-	amount: PropTypes.number,
+	amount: PropTypes.number.isRequired,
 	description: PropTypes.element,
 	unit: PropTypes.string,
 	linkTo: PropTypes.string,
 	linkText: PropTypes.string,
-}
+};
 
-export default InsightsCard;
+InsightsCard.defaultProps = {
+	title: "",
+	description: null,
+	unit: "",
+	linkTo: "",
+	linkText: "",
+};

--- a/packages/components/src/InsightsCard.js
+++ b/packages/components/src/InsightsCard.js
@@ -1,0 +1,39 @@
+import React, { Fragment } from "react";
+import PropTypes from "prop-types";
+
+class InsightsCard extends React.Component {
+
+	getDescription() {
+		if ( this.props.description ) {
+			return <p className="yoast-insights-card__description">{ this.props.description }</p>;
+		}
+
+		return;
+	}
+
+	render() {
+		return (
+			<div className="yoast-insights-card">
+				<p className="yoast-field-group__title">{ this.props.title }</p>
+				<div className="yoast-insights-card__content">
+					<p><span className="yoast-insights-card__amount">{ this.props.amount }</span> minutes</p>
+					{ this.getDescription() }
+				</div>
+			</div>
+		);
+	}
+}
+
+export default InsightsCard;
+
+InsightsCard.propTypes = {
+	title: PropTypes.String,
+	amount: PropTypes.String.isRequired,
+	description: PropTypes.String,
+}
+
+InsightsCard.defaultProps = {
+	title: "",
+	amount: "",
+	description: "",
+}

--- a/packages/components/src/WordOccurrenceInsights.js
+++ b/packages/components/src/WordOccurrenceInsights.js
@@ -60,9 +60,15 @@ const getExplanation = keywords => {
 	);
 };
 
+/**
+ * Returns the title for the header.
+ *
+ *
+ * @returns {string} The title.
+ */
 const getHeader = () => {
-	return __("Prominent words", "yoast-components");
-}
+	return __( "Prominent words", "yoast-components" );
+};
 
 /**
  * @summary WordList component.

--- a/packages/components/src/WordOccurrenceInsights.js
+++ b/packages/components/src/WordOccurrenceInsights.js
@@ -60,7 +60,6 @@ const getExplanation = keywords => {
 	);
 };
 
-
 /**
  * @summary WordList component.
  *

--- a/packages/components/src/WordOccurrenceInsights.js
+++ b/packages/components/src/WordOccurrenceInsights.js
@@ -60,6 +60,10 @@ const getExplanation = keywords => {
 	);
 };
 
+const getHeader = () => {
+	return __("Prominent words", "yoast-components");
+}
+
 /**
  * @summary WordList component.
  *
@@ -69,12 +73,14 @@ const getExplanation = keywords => {
  * @returns {JSX.Element} Rendered WordList component.
  */
 const WordOccurrenceInsights = ( { words } ) => {
-	const header = <p>{ getExplanation( words ) }</p>;
+	const header = <h2>{ getHeader() }</h2>;
+	const introduction = <p>{ getExplanation( words ) }</p>;
 	const footer = <p>{ getKeywordResearchArticleLink() }</p>;
 	return (
 		<WordOccurrences
 			words={ words }
 			header={ header }
+			introduction={ introduction }
 			footer={ footer }
 		/>
 	);

--- a/packages/components/src/WordOccurrenceInsights.js
+++ b/packages/components/src/WordOccurrenceInsights.js
@@ -73,7 +73,7 @@ const getHeader = () => {
  * @returns {JSX.Element} Rendered WordList component.
  */
 const WordOccurrenceInsights = ( { words } ) => {
-	const header = <h2>{ getHeader() }</h2>;
+	const header = <p className="yoast-field-group__title">{ getHeader() }</p>;
 	const introduction = <p>{ getExplanation( words ) }</p>;
 	const footer = <p>{ getKeywordResearchArticleLink() }</p>;
 	return (

--- a/packages/components/src/WordOccurrenceInsights.js
+++ b/packages/components/src/WordOccurrenceInsights.js
@@ -70,7 +70,7 @@ const getExplanation = keywords => {
  * @returns {JSX.Element} Rendered WordList component.
  */
 const WordOccurrenceInsights = ( { words } ) => {
-	const header = <p className="yoast-field-group__title">__( "Prominent words", "yoast-components" )</p>;
+	const header = <p className="yoast-field-group__title">{ __( "Prominent words", "yoast-components" ) }</p>;
 	const introduction = <p>{ getExplanation( words ) }</p>;
 	const footer = <p>{ getKeywordResearchArticleLink() }</p>;
 	return (

--- a/packages/components/src/WordOccurrenceInsights.js
+++ b/packages/components/src/WordOccurrenceInsights.js
@@ -60,15 +60,6 @@ const getExplanation = keywords => {
 	);
 };
 
-/**
- * Returns the title for the header.
- *
- *
- * @returns {string} The title.
- */
-const getHeader = () => {
-	return __( "Prominent words", "yoast-components" );
-};
 
 /**
  * @summary WordList component.
@@ -79,7 +70,7 @@ const getHeader = () => {
  * @returns {JSX.Element} Rendered WordList component.
  */
 const WordOccurrenceInsights = ( { words } ) => {
-	const header = <p className="yoast-field-group__title">{ getHeader() }</p>;
+	const header = <p className="yoast-field-group__title">__( "Prominent words", "yoast-components" )</p>;
 	const introduction = <p>{ getExplanation( words ) }</p>;
 	const footer = <p>{ getKeywordResearchArticleLink() }</p>;
 	return (

--- a/packages/components/src/WordOccurrences.js
+++ b/packages/components/src/WordOccurrences.js
@@ -62,13 +62,13 @@ class WordOccurrences extends React.Component {
 	 */
 	render() {
 		return (
-			<React.Fragment>
+			<div>
 				{ this.props.header }
 				<DataModel
 					items={ this.state.words }
 				/>
 				{ this.props.footer }
-			</React.Fragment>
+			</div>
 		);
 	}
 }

--- a/packages/components/src/WordOccurrences.js
+++ b/packages/components/src/WordOccurrences.js
@@ -64,6 +64,7 @@ class WordOccurrences extends React.Component {
 		return (
 			<div>
 				{ this.props.header }
+				{ this.props.introduction }
 				<DataModel
 					items={ this.state.words }
 				/>
@@ -76,11 +77,13 @@ class WordOccurrences extends React.Component {
 WordOccurrences.propTypes = {
 	words: PropTypes.array.isRequired,
 	header: PropTypes.element,
+	introduction: PropTypes.element,
 	footer: PropTypes.element,
 };
 
 WordOccurrences.defaultProps = {
 	header: null,
+	introduction: null,
 	footer: null,
 };
 

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -8,6 +8,7 @@ export * from "./button";
 export * from "./data-model";
 export * from "./field-group";
 export * from "./inputs";
+export * from "./insights-card";
 export * from "./radiobutton";
 export * from "./select";
 export * from "./help-icon";
@@ -90,7 +91,7 @@ export { default as WordList } from "./WordList";
 export { default as WordOccurrences } from "./WordOccurrences";
 export { default as Checkbox } from "./Checkbox";
 export { VariableEditorInputContainer } from "./input/InputContainer";
-export { default as InsightsCard } from "./InsightsCard";
+export { default as InsightsCard } from "./insights-card/InsightsCard";
 
 export { ListTable, ZebrafiedListTable } from "./table/ListTable";
 export { Row } from "./table/Row";

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -90,6 +90,7 @@ export { default as WordList } from "./WordList";
 export { default as WordOccurrences } from "./WordOccurrences";
 export { default as Checkbox } from "./Checkbox";
 export { VariableEditorInputContainer } from "./input/InputContainer";
+export { default as InsightsCard } from "./InsightsCard";
 
 export { ListTable, ZebrafiedListTable } from "./table/ListTable";
 export { Row } from "./table/Row";

--- a/packages/components/src/insights-card/InsightsCard.js
+++ b/packages/components/src/insights-card/InsightsCard.js
@@ -37,7 +37,7 @@ class InsightsCard extends React.Component {
 				linkText={ this.props.linkText }
 				wrapperClassName={ "yoast-insights-card" }
 			>
-				this.getInsightsCardContent()
+				{ this.getInsightsCardContent() }
 			</FieldGroup>
 		);
 	}

--- a/packages/components/src/insights-card/InsightsCard.js
+++ b/packages/components/src/insights-card/InsightsCard.js
@@ -1,62 +1,44 @@
 import React from "react";
 import PropTypes from "prop-types";
 import HelpIcon from "../help-icon/HelpIcon";
+import { FieldGroup } from "../field-group";
 
 /**
  * A card component that can be used in the Insights Modal.
  */
 class InsightsCard extends React.Component {
 	/**
-	 * Function to return the description if a description is provided.
+	 * Function to return the content of the insights card.
 	 *
-	 * @returns {React.Component} The description.
+	 * @returns {React.component} The InsightsCardContent.
 	 */
-	getDescription() {
-		if ( this.props.description ) {
-			return this.props.description;
-		}
-
-		return;
-	}
-
-	/**
-	 * Function to return the help icon if a linkTo is provided.
-	 *
-	 * @returns {React.component} The HelpIcon.
-	 */
-	getHelpIcon() {
-		if ( this.props.linkTo ) {
-			return (
-				<HelpIcon
-					linkTo={ this.props.linkTo }
-					linkText={ this.props.linkText }
-				/>
-			);
-		}
-
-		return;
+	getInsightsCardContent() {
+		return (
+			<div className="yoast-insights-card__content">
+				<p className="yoast-insights-card__score">
+					<span className="yoast-insights-card__amount">{ this.props.amount }</span>
+					{ this.props.unit }
+				</p>
+				{ this.props.description
+				&& <div className="yoast-insights-card__description">{ this.props.description }</div> }
+			</div>
+		)
 	}
 
 	/**
 	 * Returns the rendered HTML.
 	 *
-	 * @returns {React.Component} The insights-card.
+	 * @returns {React.Component} The InsightsCard.
 	 */
 	render() {
 		return (
-			<div className="yoast-insights-card">
-				<div className="yoast-field-group__title">
-					<b>{ this.props.title }</b>
-					{ this.getHelpIcon() }
-				</div>
-				<div className="yoast-insights-card__content">
-					<p className="yoast-insights-card__score">
-						<span className="yoast-insights-card__amount">{ this.props.amount }</span>
-						{ this.props.unit }
-					</p>
-					<div className="yoast-insights-card__description">{ this.getDescription() }</div>
-				</div>
-			</div>
+			<FieldGroup
+				label={ this.props.title }
+				linkTo={ this.props.linkTo }
+				linkText={ this.props.linkText }
+				wrapperClassName={ "yoast-insights-card" }
+				children={ this.getInsightsCardContent() }
+			/>
 		);
 	}
 }

--- a/packages/components/src/insights-card/InsightsCard.js
+++ b/packages/components/src/insights-card/InsightsCard.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import HelpIcon from "./help-icon/HelpIcon";
+import HelpIcon from "../help-icon/HelpIcon";
 
 /**
  * A card component that can be used in the Insights Modal.
@@ -40,7 +40,7 @@ class InsightsCard extends React.Component {
 	/**
 	 * Returns the rendered HTML.
 	 *
-	 * @returns {React.Component} The InsightsCard.
+	 * @returns {React.Component} The insights-card.
 	 */
 	render() {
 		return (

--- a/packages/components/src/insights-card/InsightsCard.js
+++ b/packages/components/src/insights-card/InsightsCard.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-import HelpIcon from "../help-icon/HelpIcon";
 import { FieldGroup } from "../field-group";
 
 /**
@@ -19,10 +18,10 @@ class InsightsCard extends React.Component {
 					<span className="yoast-insights-card__amount">{ this.props.amount }</span>
 					{ this.props.unit }
 				</p>
-				{ this.props.description
-				&& <div className="yoast-insights-card__description">{ this.props.description }</div> }
+				{ this.props.description &&
+				<div className="yoast-insights-card__description">{ this.props.description }</div> }
 			</div>
-		)
+		);
 	}
 
 	/**
@@ -37,8 +36,9 @@ class InsightsCard extends React.Component {
 				linkTo={ this.props.linkTo }
 				linkText={ this.props.linkText }
 				wrapperClassName={ "yoast-insights-card" }
-				children={ this.getInsightsCardContent() }
-			/>
+			>
+				this.getInsightsCardContent()
+			</FieldGroup>
 		);
 	}
 }

--- a/packages/components/src/insights-card/index.js
+++ b/packages/components/src/insights-card/index.js
@@ -1,0 +1,3 @@
+import "./insightscard.css";
+
+export { default as InsightsCard } from "./InsightsCard.js";

--- a/packages/components/src/insights-card/insightscard.css
+++ b/packages/components/src/insights-card/insightscard.css
@@ -1,0 +1,34 @@
+/* Cards in Insights panel/modal */
+.yoast-insights-card {
+	margin-top: 24px;
+	border-top: 1px solid rgba(0, 0, 0, 0.1);
+	padding-top: 24px;
+}
+
+/* Only when Insights is opened in a modal */
+@media(min-width: 782px) {
+	.yoast-modal-content .yoast-insights-card {
+		margin-top: inherit;
+		border-top: none;
+		padding-top: inherit;
+		padding-bottom: 24px;
+		border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+		margin-bottom: 24px;
+	}
+}
+
+.yoast-insights-card__content {
+	display: flex;
+}
+
+.yoast-insights-card__score {
+	flex-shrink: 0;
+	margin-right: 2em;
+	text-align: center;
+}
+
+.yoast-insights-card__amount {
+	display: block;
+	font-size: 3.5em;
+	line-height: 1;
+}

--- a/packages/components/tests/WordOccurrencesTest.js
+++ b/packages/components/tests/WordOccurrencesTest.js
@@ -6,6 +6,7 @@ import ProminentWord from "yoastseo/src/values/ProminentWord";
 
 const showBeforeList = <p>{ "I'm a before list paragraph" }</p>;
 const showAfterList = <p>{ "I'm an after list paragraph" }</p>;
+const introductionText = <p>{ "I'm an introduction text" }</p>;
 const words = [
 	new ProminentWord( "reviewing", "review",  13 ),
 	new ProminentWord( "code", "code",  8 ),
@@ -16,7 +17,7 @@ const noWords = [];
 describe( "WordOccurrences", function() {
 	it( "renders WordOccurrences as list items", () => {
 		const wordOccurrences = renderer.create(
-			<WordOccurrences words={ words } header={ showBeforeList } footer={ showAfterList } />
+			<WordOccurrences words={ words } header={ showBeforeList } introduction={ introductionText } footer={ showAfterList } />
 		);
 
 		const tree = wordOccurrences.toJSON();
@@ -25,7 +26,7 @@ describe( "WordOccurrences", function() {
 
 	it( "renders correctly without items", () => {
 		const wordOccurrences = renderer.create(
-			<WordOccurrences words={ noWords } header={ showBeforeList } footer={ showAfterList } />
+			<WordOccurrences words={ noWords } header={ showBeforeList } introduction={ introductionText } footer={ showAfterList } />
 		);
 
 		const tree = wordOccurrences.toJSON();

--- a/packages/components/tests/__snapshots__/WordOccurrencesTest.js.snap
+++ b/packages/components/tests/__snapshots__/WordOccurrencesTest.js.snap
@@ -1,10 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`WordOccurrences renders WordOccurrences as list items 1`] = `
-Array [
+<div>
   <p>
     I'm a before list paragraph
-  </p>,
+  </p>
+  <p>
+    I'm an introduction text
+  </p>
   <ul
     aria-label="Prominent words"
     className="yoast-data-model"
@@ -60,90 +63,97 @@ Array [
         6 occurrences
       </span>
     </li>
-  </ul>,
+  </ul>
   <p>
     I'm an after list paragraph
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`WordOccurrences renders correctly without before and after elements 1`] = `
-<ul
-  aria-label="Prominent words"
-  className="yoast-data-model"
->
-  <li
-    style={
-      Object {
-        "--yoast-width": "100%",
-      }
-    }
-  >
-    reviewing
-    <span>
-      13
-    </span>
-    <span
-      className="screen-reader-text"
-    >
-      13 occurrences
-    </span>
-  </li>
-  <li
-    style={
-      Object {
-        "--yoast-width": "61.53846153846154%",
-      }
-    }
-  >
-    code
-    <span>
-      8
-    </span>
-    <span
-      className="screen-reader-text"
-    >
-      8 occurrences
-    </span>
-  </li>
-  <li
-    style={
-      Object {
-        "--yoast-width": "46.15384615384615%",
-      }
-    }
-  >
-    fun
-    <span>
-      6
-    </span>
-    <span
-      className="screen-reader-text"
-    >
-      6 occurrences
-    </span>
-  </li>
-</ul>
-`;
-
-exports[`WordOccurrences renders correctly without items 1`] = `
-Array [
-  <p>
-    I'm a before list paragraph
-  </p>,
+<div>
   <ul
     aria-label="Prominent words"
     className="yoast-data-model"
-  />,
+  >
+    <li
+      style={
+        Object {
+          "--yoast-width": "100%",
+        }
+      }
+    >
+      reviewing
+      <span>
+        13
+      </span>
+      <span
+        className="screen-reader-text"
+      >
+        13 occurrences
+      </span>
+    </li>
+    <li
+      style={
+        Object {
+          "--yoast-width": "61.53846153846154%",
+        }
+      }
+    >
+      code
+      <span>
+        8
+      </span>
+      <span
+        className="screen-reader-text"
+      >
+        8 occurrences
+      </span>
+    </li>
+    <li
+      style={
+        Object {
+          "--yoast-width": "46.15384615384615%",
+        }
+      }
+    >
+      fun
+      <span>
+        6
+      </span>
+      <span
+        className="screen-reader-text"
+      >
+        6 occurrences
+      </span>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`WordOccurrences renders correctly without items 1`] = `
+<div>
+  <p>
+    I'm a before list paragraph
+  </p>
+  <p>
+    I'm an introduction text
+  </p>
+  <ul
+    aria-label="Prominent words"
+    className="yoast-data-model"
+  />
   <p>
     I'm an after list paragraph
-  </p>,
-]
+  </p>
+</div>
 `;
 
 exports[`WordOccurrences renders correctly without words and without before and after elements 1`] = `
-<ul
-  aria-label="Prominent words"
-  className="yoast-data-model"
-/>
+<div>
+  <ul
+    aria-label="Prominent words"
+    className="yoast-data-model"
+  />
+</div>
 `;


### PR DESCRIPTION
## Summary

In https://github.com/Yoast/javascript/pull/978 we accidentally merged Estimated Reading Time changes to `develop`, but they also have to be in `release/15.6`. Thus, this is a copy of that branch, rebased to `release/15.6`. For all further information, see the original PR.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Adds InsightCard component for the Insight modal.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes N/A
