### PR TITLE
Enable spellcheck on all replacevar editors.

### DIFF
--- a/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
@@ -502,7 +502,7 @@ class ReplacementVariableEditorStandalone extends React.Component {
 					stripPastedStyles={ true }
 					ariaLabelledBy={ ariaLabelledBy }
 					placeholder={ placeholder }
-					spellCheck={true}
+					spellCheck={ true }
 				/>
 				<ZIndexOverride>
 					<MentionSuggestions

--- a/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
+++ b/packages/replacement-variable-editor/src/ReplacementVariableEditorStandalone.js
@@ -502,6 +502,7 @@ class ReplacementVariableEditorStandalone extends React.Component {
 					stripPastedStyles={ true }
 					ariaLabelledBy={ ariaLabelledBy }
 					placeholder={ placeholder }
+					spellCheck={true}
 				/>
 				<ZIndexOverride>
 					<MentionSuggestions


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Enables spellcheck attribute on the standalone replacement variable editor.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Use in Yoast SEO.
* Notice the inputs for title and metadescription now have spellcheck on true.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Anywhere where there's an input field which supports replacement vars. (Post edit, term edit, search appearance settings)

## Quality assurance

* [x] I have tested this code to the best of my abilities

Fixes https://github.com/Yoast/wordpress-seo/issues/13174