### PR TITLE
Fix app/components

### DIFF
--- a/apps/components/AppWrapper.js
+++ b/apps/components/AppWrapper.js
@@ -1,7 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Provider } from "react-redux";
-import { AppContainer } from "react-hot-loader";
 
 import DevTools from "./utils/DevTools";
 import configureStore from "./configureStore";
@@ -16,14 +15,12 @@ const store = configureStore();
  * @returns {ReactElement} The AppContainer component.
  */
 const AppWrapper = ( { children } ) => (
-	<AppContainer>
-		<Provider store={ store }>
-			<div>
-				{ children }
-				<DevTools />
-			</div>
-		</Provider>
-	</AppContainer>
+	<Provider store={ store }>
+		<div>
+			{ children }
+			<DevTools />
+		</div>
+	</Provider>
 );
 
 AppWrapper.propTypes = {

--- a/apps/components/ReactifiedComponentsWrapper.js
+++ b/apps/components/ReactifiedComponentsWrapper.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React, { Fragment, useState } from "react";
 import TextInput from "@yoast/components/src/inputs/TextInput";
 import TextArea from "@yoast/components/src/inputs/TextArea";
 import CheckboxGroup from "@yoast/components/src/checkbox/CheckboxGroup";
@@ -21,6 +21,12 @@ function clickerDiClick() {
 	console.log( "You are an exceptional clicker!" );
 }
 
+const ButtonWrapper = ( props ) => {
+	const [ count, countUp ] = useState( 0 );
+
+	return <Button variant="primary" onClick={ () => countUp( count + 1 ) }>{ `${ props.name }: ${ count }` }</Button>
+}
+
 const buttonRef = React.createRef();
 const buttonStyledLinkRef = React.createRef();
 
@@ -34,6 +40,7 @@ const focusLinkRef = () => {
 
 const buttonGrouping = <Fragment>
 	<h3>"primary" variant (default)</h3>
+	<ButtonWrapper name="Test usestate" />
 	<Button onClick={ clickerDiClick } title="Testing whether other props are also passed, like this tooltip">Default button</Button>
 	<Button variant="primary" onClick={ clickerDiClick }>Primary button</Button>
 	<Button variant="primary" disabled={ true } onClick={ clickerDiClick }>Primary disabled button</Button>

--- a/apps/components/package.json
+++ b/apps/components/package.json
@@ -52,8 +52,8 @@
   },
   "peerDependencies": {
     "material-ui": "^0.18.6",
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
     "react-redux": "6.0.1",
     "redux": "4.0.1"
   },

--- a/apps/components/package.json
+++ b/apps/components/package.json
@@ -41,7 +41,6 @@
     "concurrently": "^3.5.0",
     "css-loader": "^2.1.1",
     "draft-js-mention-plugin": "^3.0.4",
-    "react-hot-loader": "^4.12.19",
     "redux-devtools": "3.5.0",
     "sass-loader": "7.1.0",
     "stubby": "^0.3.1",

--- a/apps/components/webpack.config.js
+++ b/apps/components/webpack.config.js
@@ -16,9 +16,6 @@ module.exports = {
 		// Compile the yoast-components standalone .scss
 		"yoast-components/css/standalone.scss",
 
-		// Activate HMR for React
-		"react-hot-loader/patch",
-
 		// Bundle the client for webpack-dev-server
 		// And connect to the provided endpoint
 		`webpack-dev-server/client?http://localhost:${PORT}`,
@@ -53,14 +50,12 @@ module.exports = {
 					options: {
 						presets: [
 							[ "es2015",
-								// https://github.com/gaearon/react-hot-loader/tree/master/docs#webpack-2
 								{ modules: false },
 							] ],
 
 						env: {
 							development: {
 								plugins: [
-									"react-hot-loader/babel",
 									"babel-plugin-styled-components",
 								],
 							},

--- a/packages/analysis-report/package.json
+++ b/packages/analysis-report/package.json
@@ -22,8 +22,6 @@
     "@yoast/style-guide": "^0.13.0",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.0",
-    "react": "16.6.3",
-    "react-dom": "16.6.3",
     "styled-components": "^4.2.0"
   },
   "devDependencies": {

--- a/packages/analysis-report/package.json
+++ b/packages/analysis-report/package.json
@@ -36,8 +36,8 @@
     "react-test-renderer": "^16.2.0"
   },
   "peerDependencies": {
-    "react": "^16.2.0",
-    "react-dom": "16.2.0"
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "jest": {
     "testURL": "http://localhost",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,8 +56,8 @@
     "react-test-renderer": "^16.8.4"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/configuration-wizard/package.json
+++ b/packages/configuration-wizard/package.json
@@ -41,14 +41,12 @@
     "jest": "^22.4.3",
     "jest-styled-components": "^5.0.1",
     "material-ui": "^0.18.6",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0",
     "react-test-renderer": "^16.8.4"
   },
   "peerDependencies": {
     "material-ui": "^0.18.6",
-    "react": "^16.2.0",
-    "react-dom": "16.2.0"
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "jest": {
     "testURL": "http://localhost",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -23,7 +23,7 @@
     "whatwg-fetch": "1.1.1"
   },
   "peerDependencies": {
-    "react": "^16.2.0"
+    "react": "^16.12.0"
   },
   "jest": {
     "testURL": "http://localhost",
@@ -37,7 +37,6 @@
     "@yoast/browserslist-config": "^1.2.2",
     "browserslist": "^4.7.3",
     "jest-styled-components": "^5.0.1",
-    "react": "^16.12.0",
     "react-test-renderer": "^16.8.6",
     "wicked-good-xpath": "^1.3.0"
   },

--- a/packages/schema-blocks/package.json
+++ b/packages/schema-blocks/package.json
@@ -42,13 +42,15 @@
     "jest": "^26.0.15",
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
-    "react": "^16.13.0",
-    "react-dom": "^16.13.0",
     "react-test-renderer": "^17.0.1",
     "react-with-direction": "^1.3.1",
     "ts-jest": "^26.0.15",
     "typescript": "^3.7.4",
     "xmldom": "^0.1.27"
+  },
+  "peerDependencies": {
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/social-metadata-forms/package.json
+++ b/packages/social-metadata-forms/package.json
@@ -51,6 +51,6 @@
 		"jest-styled-components": "^6.3.1"
 	},
 	"peerDependencies": {
-		"react": "^16.2.0"
+		"react": "^16.12.0"
 	}
 }

--- a/packages/social-metadata-previews/package.json
+++ b/packages/social-metadata-previews/package.json
@@ -52,6 +52,6 @@
     "jest-styled-components": "^6.3.1"
   },
   "peerDependencies": {
-    "react": "^16.2.0"
+    "react": "^16.12.0"
   }
 }

--- a/packages/yoast-components/package.json
+++ b/packages/yoast-components/package.json
@@ -115,9 +115,6 @@
     "load-grunt-config": "^0.19.2",
     "material-ui": "^0.18.6",
     "raf": "^3.4.0",
-    "react": "16.6.3",
-    "react-dom": "16.6.3",
-    "react-hot-loader": "^4.0.0-beta.17",
     "react-test-renderer": "^16.2.0",
     "redux-devtools": "^3.4.1",
     "redux-devtools-dock-monitor": "^1.1.3",
@@ -131,8 +128,8 @@
   },
   "peerDependencies": {
     "material-ui": "^0.18.6",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   },
   "browserify": {
     "transform": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -19322,16 +19322,6 @@ react-dock@^0.2.4:
     lodash.debounce "^3.1.1"
     prop-types "^15.5.8"
 
-react-dom@16.6.3:
-  version "16.6.3"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.6.3.tgz#8fa7ba6883c85211b8da2d0efeffc9d3825cccc0"
-  integrity sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.11.2"
-
 "react-dom@^0.14.3 || ^15.1.0 || ^16.0.0":
   version "16.8.4"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.4.tgz#1061a8e01a2b3b0c8160037441c3bf00a0e3bc48"
@@ -19687,16 +19677,6 @@ react-with-styles@^3.2.0:
     object.assign "^4.1.0"
     prop-types "^15.6.2"
     react-with-direction "^1.3.0"
-
-react@16.6.3:
-  version "16.6.3"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.6.3.tgz#25d77c91911d6bbdd23db41e70fb094cc1e0871c"
-  integrity sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.11.2"
 
 "react@^0.14.3 || ^15.1.0 || ^16.0.0":
   version "16.8.4"
@@ -20850,14 +20830,6 @@ saxes@^5.0.0:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
-
-scheduler@^0.11.2:
-  version "0.11.3"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.11.3.tgz#b5769b90cf8b1464f3f3cfcafe8e3cd7555a2d6b"
-  integrity sha512-i9X9VRRVZDd3xZw10NY5Z2cVMbdYg6gqFecfj79USv1CFN+YrJ3gIPRKf1qlY+Sxly4djoKdfx1T+m9dnRB8kQ==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 scheduler@^0.13.4:
   version "0.13.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19352,16 +19352,6 @@ react-dom@^16.12.0:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react-dom@^16.13.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
-  integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
-
 react-dom@^16.9.0:
   version "16.13.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.0.tgz#cdde54b48eb9e8a0ca1b3dc9943d9bb409b81866"
@@ -19722,15 +19712,6 @@ react@^16.12.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.12.0.tgz#0c0a9c6a142429e3614834d5a778e18aa78a0b83"
   integrity sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-
-react@^16.13.0:
-  version "16.14.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
-  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -20898,14 +20879,6 @@ scheduler@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.0.tgz#a715d56302de403df742f4a9be11975b32f5698d"
   integrity sha512-xowbVaTPe9r7y7RUejcK73/j8tt2jfiyTednOvHbA8JoClvMYCp+r8QegLwK/n8zWQAtZb1fFnER4XLBZXrCxA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9359,11 +9359,6 @@ dom-serializer@0, dom-serializer@~0.1.0:
     domelementtype "^1.3.0"
     entities "^1.1.1"
 
-dom-walk@^0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
-  integrity sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=
-
 domain-browser@^1.1.1, domain-browser@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.2.0.tgz#3d31f50191a6749dd1375a7f522e823d42e54eda"
@@ -10663,7 +10658,7 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
 
-fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.4, fast-levenshtein@~2.0.6:
+fast-levenshtein@~2.0.4, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -11539,14 +11534,6 @@ global-prefix@^3.0.0:
     ini "^1.3.5"
     kind-of "^6.0.2"
     which "^1.3.1"
-
-global@^4.3.0:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
-  integrity sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=
-  dependencies:
-    min-document "^2.19.0"
-    process "~0.5.1"
 
 globals@^11.1.0, globals@^11.7.0:
   version "11.11.0"
@@ -16327,13 +16314,6 @@ mimic-response@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-min-document@^2.19.0:
-  version "2.19.0"
-  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
-  integrity sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=
-  dependencies:
-    dom-walk "^0.1.0"
-
 mini-css-extract-plugin@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/mini-css-extract-plugin/-/mini-css-extract-plugin-0.8.0.tgz#81d41ec4fe58c713a96ad7c723cdb2d0bd4d70e1"
@@ -18874,11 +18854,6 @@ process@^0.11.10, process@~0.11.0:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
-process@~0.5.1:
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
-  integrity sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=
-
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -19420,35 +19395,6 @@ react-event-listener@^0.6.2:
     "@babel/runtime" "^7.2.0"
     prop-types "^15.6.0"
     warning "^4.0.1"
-
-react-hot-loader@^4.0.0-beta.17:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.8.0.tgz#0b7c7dd9407415e23eb8246fdd28b0b839f54cb6"
-  integrity sha512-HY9F0vITYSVmXhAR6tPkMk240nxmoH8+0rca9iO2B82KVguiCiBJkieS0Wb4CeSIzLWecYx3iOcq8dcbnp0bxA==
-  dependencies:
-    fast-levenshtein "^2.0.6"
-    global "^4.3.0"
-    hoist-non-react-statics "^3.3.0"
-    loader-utils "^1.1.0"
-    lodash "^4.17.11"
-    prop-types "^15.6.1"
-    react-lifecycles-compat "^3.0.4"
-    shallowequal "^1.0.2"
-    source-map "^0.7.3"
-
-react-hot-loader@^4.12.19:
-  version "4.12.19"
-  resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.12.19.tgz#99a1c763352828f404fa51cd887c5e16bb5b74d1"
-  integrity sha512-p8AnA4QE2GtrvkdmqnKrEiijtVlqdTIDCHZOwItkI9kW51bt5XnQ/4Anz8giiWf9kqBpEQwsmnChDCAFBRyR/Q==
-  dependencies:
-    fast-levenshtein "^2.0.6"
-    global "^4.3.0"
-    hoist-non-react-statics "^3.3.0"
-    loader-utils "^1.1.0"
-    prop-types "^15.6.1"
-    react-lifecycles-compat "^3.0.4"
-    shallowequal "^1.1.0"
-    source-map "^0.7.3"
 
 react-input-autosize@^2.2.2:
   version "2.2.2"
@@ -21222,11 +21168,6 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
-
-shallowequal@^1.0.2, shallowequal@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
-  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shasum@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
## Summary

The components app was broken by `react-hot-loader`. Removing the `AppContainer` fixed that.

Also React Hooks were broken in the components app. They are especially useful there, because they allow the creation of very shallow wrapper components for our "stateless" components.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Removes the react-hot-loader dependency from the components app.
* Sets react and react-dom as a peer dependency in yoast-components, configuration-wizard, and schema-block packages.

## Relevant technical choices:

* I have removed `react-hot-loader` because it could not deal with `react hooks`. I have found a solution here https://github.com/gaearon/react-hot-loader/issues/1227 which requires another `react-dom` package and some code refactoring. Instead, I quickly removed the hot-loader to see whether that worked, and it seems to me that we then still have a hot-loading functionality via webpack. So I deemed react-hot-loader unnecessary. But there might be something I have missed, so this needs some extra eyes.
* React Hooks were still not available in the components app, and set `react` as a peer-dependency (almost) everywhere. We had multiple `react` versions which seemed to violate the criteria set out here: https://reactjs.org/warnings/invalid-hook-call-warning.html#duplicate-react

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* `yarn install` in the monorepo root, and `yarn start` in `apps/components`. Go to `localhost:3333`
* Test `useState`: I have added a buttonwrapper in the components `app`: there is a button called "test usestate" in the `Reactified Components` section, and it uses `useState`. Clicking it should update the count. ⚠️ You could undo the changes I made to the ReactifiedComponentsWrapper before merging, if you'd like.
* Test "hot reloading": Change some things in the components app (like, add a simple `button`, change some button "variants". Verify that the components app reloads to reflect your changes.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended
