### PR TITLE
Change boundaries for Turkish sentence length assessment

### DIFF
--- a/packages/yoastseo/spec/assessments/sentenceLengthInTextSpec.js
+++ b/packages/yoastseo/spec/assessments/sentenceLengthInTextSpec.js
@@ -515,54 +515,54 @@ describe( "An assessment for sentence length", function() {
 		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
-	it( "returns the score for 100% long sentences in Turkish", function() {
+	it( "returns a bad score for 100% long sentences in Turkish", function() {
 		const mockPaper = new Paper( "text", { locale: "tr_TR" } );
 		const sentenceLengthInTextAssessmentHebrew = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
 
 		const assessment = sentenceLengthInTextAssessmentHebrew.getResult( mockPaper, Factory.buildMockResearcher( [
-			{ sentence: "", sentenceLength: 12 },
+			{ sentence: "", sentenceLength: 16 },
 		] ), i18n );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 3 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
-			"100% of the sentences contain more than 11 words, which is more than the recommended maximum of 25%." +
+			"100% of the sentences contain more than 15 words, which is more than the recommended maximum of 20%." +
 			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 50% long sentences in Turkish", function() {
+	it( "returns an okay score for for 25% long sentences in Turkish", function() {
 		const mockPaper = new Paper( "text", { locale: "tr_TR" } );
 		const sentenceLengthInTextAssessmentHungarian = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
-
 		const assessment = sentenceLengthInTextAssessmentHungarian.getResult( mockPaper, Factory.buildMockResearcher( [
-			{ sentence: "", sentenceLength: 12 },
-			{ sentence: "", sentenceLength: 7 },
+			{ sentence: "", sentenceLength: 16 },
+			{ sentence: "", sentenceLength: 10 },
+			{ sentence: "", sentenceLength: 10 },
+			{ sentence: "", sentenceLength: 10 },
 		] ), i18n );
 
 		expect( assessment.hasScore() ).toBe( true );
-		expect( assessment.getScore() ).toEqual( 3 );
+		expect( assessment.getScore() ).toEqual( 6 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: " +
-			"50% of the sentences contain more than 11 words, which is more than the recommended maximum of 25%." +
+			"25% of the sentences contain more than 15 words, which is more than the recommended maximum of 20%." +
 			" <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>." );
 		expect( assessment.hasMarks() ).toBe( true );
 	} );
 
-	it( "returns the score for 25% long sentences in Turkish", function() {
+	it( "returns a good score for 100% short sentences in Turkish", function() {
 		const mockPaper = new Paper( "text", { locale: "tr_TR" } );
 		const sentenceLengthInTextAssessmentHebrew = new SentenceLengthInTextAssessment( contentConfiguration( mockPaper.getLocale() ).sentenceLength );
 
 		const assessment = sentenceLengthInTextAssessmentHebrew.getResult( mockPaper, Factory.buildMockResearcher( [
-			{ sentence: "", sentenceLength: 12 },
-			{ sentence: "", sentenceLength: 11 },
-			{ sentence: "", sentenceLength: 11 },
-			{ sentence: "", sentenceLength: 11 },
+			{ sentence: "", sentenceLength: 10 },
+			{ sentence: "", sentenceLength: 10 },
+			{ sentence: "", sentenceLength: 10 },
 		] ), i18n );
 
 		expect( assessment.hasScore() ).toBe( true );
 		expect( assessment.getScore() ).toEqual( 9 );
 		expect( assessment.getText() ).toEqual( "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!" );
-		expect( assessment.hasMarks() ).toBe( true );
+		expect( assessment.hasMarks() ).toBe( false );
 	} );
 
 	it( "is not applicable for empty papers", function() {

--- a/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper1.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper1.js
@@ -115,8 +115,8 @@ const expectedResults = {
 	},
 	textSentenceLength: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 28.6% of the sentences contain more than 11 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!",
 	},
 	textTransitionWords: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper2.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper2.js
@@ -115,8 +115,8 @@ const expectedResults = {
 	},
 	textSentenceLength: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 28.6% of the sentences contain more than 11 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!",
 	},
 	textTransitionWords: {
 		isApplicable: true,

--- a/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper3.js
+++ b/packages/yoastseo/spec/fullTextTests/testTexts/tr/turkishPaper3.js
@@ -115,8 +115,8 @@ const expectedResults = {
 	},
 	textSentenceLength: {
 		isApplicable: true,
-		score: 6,
-		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: 25.7% of the sentences contain more than 11 words, which is more than the recommended maximum of 25%. <a href='https://yoa.st/34w' target='_blank'>Try to shorten the sentences</a>.",
+		score: 9,
+		resultText: "<a href='https://yoa.st/34v' target='_blank'>Sentence length</a>: Great!",
 	},
 	textTransitionWords: {
 		isApplicable: true,

--- a/packages/yoastseo/src/config/content/tr.js
+++ b/packages/yoastseo/src/config/content/tr.js
@@ -5,6 +5,8 @@
 
 export default {
 	sentenceLength: {
-		recommendedWordCount: 11,
+		recommendedWordCount: 15,
+		slightlyTooMany: 20,
+		farTooMany: 25,
 	},
 };


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Changes boundaries of the Turkish sentence length assessment.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*  Set your site to Turkish.
* In a new post, add a single sentence that's shorter than 15 words, e.g. `Bu masa, çocuklarınızın topladığı herşeyi tepsiyle beraber üzerine koyabileceği sonbahar masası olacak.` You should get a green bullet for sentence length.
* Replace the sentence with a sentence longer than 15 words, e.g. `Onlara sırasıyla topladıklarını yerleştirmek için izin vererek, bu el işinin sonunda gurur duyacakları bir aktiviteye dönüşeceğini göreceksiniz.` You should get a red bullet and the feedback for the sentence length assessment should read: `Sentence length: 100% of the sentences contain more than 15 words, which is more than the recommended maximum of 20%. Try to shorten the sentences.`
* Replace the text with 3 short sentences and 1 long sentence, e.g. `Onlara sırasıyla topladıklarını yerleştirmek için izin vererek, bu el işinin sonunda gurur duyacakları bir aktiviteye dönüşeceğini göreceksiniz. Bu masa, çocuklarınızın topladığı herşeyi tepsiyle beraber üzerine koyabileceği sonbahar masası olacak. Bu masa, çocuklarınızın topladığı herşeyi tepsiyle beraber üzerine koyabileceği sonbahar masası olacak. Bu masa, çocuklarınızın topladığı herşeyi tepsiyle beraber üzerine koyabileceği sonbahar masası olacak.`  You should get an orange bullet and the feedback for the sentence length assessment should read: `Sentence length: 25% of the sentences contain more than 15 words, which is more than the recommended maximum of 20%. Try to shorten the sentences.` 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
