### PR TITLE
Added default option to VariableRichText and made sure required- and recommmendedBlocks in the InnerBlocks block instruction are always an array.

### DIFF
--- a/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
@@ -54,6 +54,9 @@ export default class InnerBlocks extends BlockInstruction {
 			key: i,
 		};
 
+		this.options.requiredBlocks = this.options.requiredBlocks || [];
+		this.options.recommendedBlocks = this.options.recommendedBlocks || [];
+
 		this.renderAppender( properties );
 
 		this.arrangeAllowedBlocks( properties );

--- a/packages/schema-blocks/src/instructions/blocks/VariableTagRichText.ts
+++ b/packages/schema-blocks/src/instructions/blocks/VariableTagRichText.ts
@@ -31,6 +31,7 @@ class VariableTagRichText extends RichTextBase {
 				[ this.options.name ]: {
 					type: "string",
 					source: "html",
+					"default": this.options.default,
 					selector: `[data-id=${this.options.name}]`,
 				},
 				[ this.options.name + "_tag" ]: {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [schema-blocks] Fixes a bug where no default value could be given to a `VariableRichText` block instruction.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* This PR should be tested in tandem with https://github.com/Yoast/wordpress-seo-premium/pull/3163.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * N/A: This code only affects the Schema blocks functionality, which is still behind a feature flag.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
