### PR TITLE
QAK-2652 Add missing focus style to checkbox and radio button.

### DIFF
--- a/apps/components/InputsWrapper.js
+++ b/apps/components/InputsWrapper.js
@@ -129,7 +129,7 @@ const InputsWrapper = () => {
 				] }
 				label="Horizontal radiobutton group"
 				groupName="group1"
-				selected="hi"
+				selected="hey-value"
 			/>
 			<RadioButtonGroup
 				options={ [

--- a/packages/components/src/checkbox/checkbox.css
+++ b/packages/components/src/checkbox/checkbox.css
@@ -1,36 +1,46 @@
 .yoast-field-group__checkbox {
-    display: flex;
-    cursor: pointer;
-    align-items: center;
+	display: flex;
+	align-items: center;
 }
 
 .yoast-field-group__checkbox:not(.yoast-field-group__checkbox--horizontal) + .yoast-field-group__checkbox {
-    margin-top: 4px;
+	margin-top: 4px;
+}
+
+.yoast-field-group__checkbox label {
+	cursor: pointer;
 }
 
 .yoast-field-group__checkbox input[type='checkbox'] {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    width: 18px;
-    height: 18px;
-    padding: 2px;
-    margin: 2px 8px 0 0;
-    border-radius: 2px;
-    transition: background-color 150ms ease-out 0s;
-    border: var(--yoast-border-default);
-    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
-    position: relative;
-    overflow: hidden;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	width: 18px;
+	height: 18px;
+	padding: 2px;
+	margin: 2px 8px 0 0;
+	border-radius: 2px;
+	transition: background-color 150ms ease-out 0s;
+	border: var(--yoast-border-default);
+	box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+	position: relative;
+	overflow: hidden;
+	cursor: pointer;
+}
+
+.yoast-field-group__checkbox input[type='checkbox']:focus,
+.yoast-field-group__checkbox input[type='checkbox']:checked:focus {
+	box-shadow: var(--yoast-color-focus);
+	outline: none;
 }
 
 .yoast label + input[type='checkbox'] {
-    margin-left: 16px;
+	margin-left: 16px;
 }
 
 .yoast-field-group__checkbox input[type='checkbox']:checked {
-    background: var(--yoast-checkmark--white) var(--yoast-color-primary) no-repeat center / 13px;
-    border: 1px solid var(--yoast-color-primary);
-    box-shadow: none;
+	background: var(--yoast-checkmark--white) var(--yoast-color-primary) no-repeat center / 13px;
+	border: 1px solid var(--yoast-color-primary);
+	box-shadow: none;
 }
 
 .yoast-field-group__checkbox input[type='checkbox']:checked::before {

--- a/packages/components/src/radiobutton/radiobutton.css
+++ b/packages/components/src/radiobutton/radiobutton.css
@@ -1,31 +1,37 @@
 .yoast-field-group__radiobutton {
-    display: flex;
-    align-items: center;
+	display: flex;
+	align-items: center;
 }
 
 .yoast-field-group__radiobutton--vertical:not(:last-of-type) {
-    margin-bottom: 8px;
+	margin-bottom: 8px;
 }
 
 .yoast-field-group__radiobutton label {
-    cursor: pointer;
-    margin-right: 16px;
+	cursor: pointer;
+	margin-right: 16px;
 }
 
 .yoast-field-group__radiobutton input[type='radio'] {
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    width: 18px;
-    height: 18px;
-    padding: 2px;
-    margin: 0 8px 0 0;
-    border-radius: 50%;
-    transition: all 150ms ease-out 0s;
-    border: var(--yoast-border-default);
-    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
-    position: relative;
-    overflow: hidden;
-    cursor: pointer;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	width: 18px;
+	height: 18px;
+	padding: 2px;
+	margin: 0 8px 0 0;
+	border-radius: 50%;
+	transition: border-color 150ms ease-out 0s;
+	border: var(--yoast-border-default);
+	box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+	position: relative;
+	overflow: hidden;
+	cursor: pointer;
+}
+
+.yoast-field-group__radiobutton input[type='radio']:focus,
+.yoast-field-group__radiobutton input[type='radio']:checked:focus {
+	box-shadow: var(--yoast-color-focus);
+	outline: none;
 }
 
 .yoast-field-group__radiobutton input[type='radio']:checked {
@@ -33,19 +39,19 @@
 	background-color: inherit;
 }
 
-.yoast-field-group__radiobutton input[type='radio']:checked:before {
-	display: none;
+.yoast-field-group__radiobutton input[type='radio']:after {
+	background-color: transparent;
+	transition: background-color 150ms ease-out 0s;
+	width: 10px;
+	height: 10px;
+	position: absolute;
+	left: 3px;
+	top: 3px;
+	content: "";
+	display: block;
+	border-radius: 50%;
 }
 
 .yoast-field-group__radiobutton input[type='radio']:checked:after {
-    background: var(--yoast-color-primary);
-    width: 10px;
-    height: 10px;
-    background: var(--yoast-color-primary);
-    position: absolute;
-    left: 3px;
-    top: 3px;
-    content: "";
-    display: block;
-    border-radius: 50%;
+	background-color: var(--yoast-color-primary);
 }

--- a/packages/components/src/radiobutton/radiobutton.html
+++ b/packages/components/src/radiobutton/radiobutton.html
@@ -19,8 +19,10 @@
 	<link rel='stylesheet' href='../base/typography.css' type='text/css' media='all'/>
 	<link rel='stylesheet' href='../base/borders.css' type='text/css' media='all'/>
 	<link rel='stylesheet' href='../base/utility.css' type='text/css' media='all'/>
+	<link rel='stylesheet' href='../base/icons.css' type='text/css' media='all'/>
 
 	<link rel='stylesheet' href='../field-group/field-group.css' type='text/css' media='all'/>
+	<link rel='stylesheet' href='../help-icon/help-icon.css' type='text/css' media='all'/>
 	<link rel='stylesheet' href='radiobutton.css' type='text/css' media='all'/>
 
 </head>


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* Fixes a bug where the checkbox and radio button components didn't have a focus style.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

The easiest way to check the focus style is by checking their actual usage in the plugins. By doing so, we also make sure there are no conflicts with other inherited CSS and the focus style works correctly in the WordPress context.

- switch your local clone of the JS repo to this branch 
- yarn link Yoast SEO to the monorepo: `yarn link-monorepo`
- build and activate Yoast SEO 
- build and activate Local SEO (latest trunk) 
- in the Local SEO settings make sure "My business has multiple locations" is set to YES: this will enable the Location custom post type 
- create a new Location or edit an existing one 
- make sure to hard-refresh your browser's cache, just in case

**Checkbox:**
- in the Yoast Local SEO meta box, go to the Opening Hours tab 
- click on one of the "Open 24 hours" checkboxes 
- see the focus style 
- use the Tab key to navigate to one of the following "Open 24 hours" checkboxes 
- see the focus style 
- while the checkbox is focused, press the Spacebar key to check the checkbox 
- see the focus style in the "checked" state 
- check the focus style matches the design: https://www.sketch.com/s/092f0bd9-9efe-4f13-a4c3-56af30a83504/a/wLLK7Dp#Inspector

**Radio button:**
- in the Yoast SEO meta box 
- expand the "Advanced" panel 
- use the Tab key to navigate to the first radio button below "Should search engines follow links on this Location"
- see the focus style 
- use the right arrow key to select the "No" radio button 
- see the focus style 
- click the "Yes" unselected radio button and keep your mouse button/trackpad pressed (click and do not release yet) 
- see the focus style in the "unchecked" state 


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [QAK-2652]

[QAK-2652]: https://yoast.atlassian.net/browse/QAK-2652