### PR TITLE
Use proper textdomains

### DIFF
--- a/packages/schema-blocks/src/blocks/warning-block/edit.ts
+++ b/packages/schema-blocks/src/blocks/warning-block/edit.ts
@@ -47,7 +47,7 @@ export function edit( props: RenderEditProps ): JSX.Element {
 								removeBlock( clientId );
 							},
 						},
-						__( "Yes", "wordpress-seo" ),
+						__( "Yes", "yoast-schema-blocks" ),
 					),
 					createElement(
 						"button",
@@ -57,7 +57,7 @@ export function edit( props: RenderEditProps ): JSX.Element {
 								restoreBlock( clientId, removedBlock as BlockInstance );
 							},
 						},
-						__( "No, please undo this", "wordpress-seo" ),
+						__( "No, please undo this", "yoast-schema-blocks" ),
 					),
 				],
 			),

--- a/packages/schema-blocks/src/functions/gutenberg/watchers/warningWatcher.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watchers/warningWatcher.ts
@@ -47,6 +47,7 @@ function getInnerBlocksInstruction( blockName: string ): InnerBlocks | null {
 function getDefaultWarningMessage( blockTitle: string, warningType: WarningType ): string {
 	switch ( warningType ) {
 		case WarningType.BLOCK_REQUIRED: {
+			/* translators: %s expands to the block name that is removed. */
 			return sprintf(
 				__(
 					"You've just removed the ‘%s’ block, but this is a required block for Schema output. " +
@@ -57,6 +58,7 @@ function getDefaultWarningMessage( blockTitle: string, warningType: WarningType 
 			);
 		}
 		case WarningType.BLOCK_RECOMMENDED: {
+			/* translators: %s expands to the block name that is removed. */
 			return sprintf(
 				__(
 					"You've just removed the ‘%s’ block, but this is a recommended block for Schema output. " +

--- a/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
@@ -139,10 +139,10 @@ export default class InnerBlocks extends BlockInstruction {
 		const elements: ReactElement[] = [];
 
 		if ( this.options.requiredBlocks ) {
-			elements.push( BlockSuggestions( __( "Required Blocks", "wpseo-schema-blocks" ), currentBlock, this.options.requiredBlocks ) );
+			elements.push( BlockSuggestions( __( "Required Blocks", "yoast-schema-blocks" ), currentBlock, this.options.requiredBlocks ) );
 		}
 		if ( this.options.recommendedBlocks ) {
-			elements.push( BlockSuggestions( __( "Recommended Blocks", "wpseo-schema-blocks" ),  currentBlock, this.options.recommendedBlocks ) );
+			elements.push( BlockSuggestions( __( "Recommended Blocks", "yoast-schema-blocks" ), currentBlock, this.options.recommendedBlocks ) );
 		}
 
 		if ( elements.length === 0 ) {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [schema-blocks | Yoast SEO Free] Make sure that everything is translatable. 

## Relevant technical choices:

* Decided to skip `console.log` like messages from being translated. Their purpose is best if they are understandable when providing users support. Also these messages will be adapted by a logger and shouldn't be visible for users by default.
* Used `yoast-schema-blocks` as textdomain, because this fits the pattern used elsewhere on the monorepo. I've seen yoast-components as textdomain.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* There are only changes in text domains. When testing this against https://github.com/Yoast/wordpress-seo/pull/16647  you can verify that the translator comments are adapted by the pot file.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
