### PR TITLE
Add specs for catalan and default researcher and helper

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/_default/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/_default/ResearcherSpec.js
@@ -4,12 +4,8 @@ import Paper from "../../../../src/values/Paper.js";
 describe( "a test for Default Researcher", function() {
 	const researcher = new Researcher( new Paper( "" ) );
 
-	it( "returns true if the inherited Abstract Researcher has a specific research", function() {
-		expect( researcher.hasResearch( "getParagraphLength" ) ).toBe( true );
-	} );
-
 	it( "returns true if the Default Researcher has a specific research", function() {
-		expect( researcher.hasResearch( "functionWordsInKeyphrase" ) ).toBe( true );
+		expect( researcher.hasResearch( "getParagraphLength" ) ).toBe( true );
 	} );
 
 	it( "returns false if the default research is deleted in the Default Researcher", function() {

--- a/packages/yoastseo/spec/languageProcessing/languages/_default/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/_default/ResearcherSpec.js
@@ -1,0 +1,30 @@
+import Researcher from "../../../../src/languageProcessing/languages/_default/Researcher.js";
+import Paper from "../../../../src/values/Paper.js";
+
+describe( "a test for Default Researcher", function() {
+	const researcher = new Researcher( new Paper( "" ) );
+
+	it( "returns true if the inherited Abstract Researcher has a specific research", function() {
+		expect( researcher.hasResearch( "getParagraphLength" ) ).toBe( true );
+	} );
+
+	it( "returns true if the Default Researcher has a specific research", function() {
+		expect( researcher.hasResearch( "functionWordsInKeyphrase" ) ).toBe( true );
+	} );
+
+	it( "returns false if the default research is deleted in the Default Researcher", function() {
+		expect( researcher.getResearch( "getFleschReadingScore" ) ).toBe( false );
+	} );
+
+	it( "returns false if the Default Researcher doesn't have a certain helper", function() {
+		expect( researcher.getHelper( "fleschReadingScore" ) ).toBe( false );
+	} );
+
+	it( "returns false if the Default Researcher doesn't have a certain config", function() {
+		expect( researcher.getConfig( "sentenceLength" ) ).toBe( false );
+	} );
+
+	it( "doesn't stem word if the Default Researcher is used", function() {
+		expect( researcher.getHelper( "getStemmer" )()( "cats" ) ).toBe( "cats" );
+	} );
+} );

--- a/packages/yoastseo/spec/languageProcessing/languages/_default/helpers/getStemmerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/_default/helpers/getStemmerSpec.js
@@ -1,0 +1,7 @@
+import getStemmer from "../../../../../src/languageProcessing/languages/_default/helpers/getStemmer";
+
+describe( "Test for the base stemmer where it returns the input word", () => {
+	it( "returns the input word", () => {
+		expect( getStemmer()( "cats" ) ).toBe( "cats" );
+	} );
+} );

--- a/packages/yoastseo/spec/languageProcessing/languages/ca/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ca/ResearcherSpec.js
@@ -12,7 +12,7 @@ describe( "a test for the Catalan Researcher", function() {
 	} );
 
 	it( "returns true if the Catalan Researcher has a specific research", function() {
-		expect( researcher.hasResearch( "functionWordsInKeyphrase" ) ).toBe( true );
+		expect( researcher.hasResearch( "findTransitionWords" ) ).toBe( true );
 	} );
 
 	it( "returns false if the default research is deleted in the Catalan Researcher", function() {

--- a/packages/yoastseo/spec/languageProcessing/languages/ca/ResearcherSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ca/ResearcherSpec.js
@@ -1,0 +1,49 @@
+import Researcher from "../../../../src/languageProcessing/languages/ca/Researcher.js";
+import Paper from "../../../../src/values/Paper.js";
+import sentenceLength from "../../../../src/languageProcessing/languages/ca/config/sentenceLength";
+import transitionWords from "../../../../src/languageProcessing/languages/ca/config/transitionWords";
+import twoPartTransitionWords from "../../../../src/languageProcessing/languages/ca/config/twoPartTransitionWords";
+
+describe( "a test for the Catalan Researcher", function() {
+	const researcher = new Researcher( new Paper( "" ) );
+
+	it( "returns true if the inherited Abstract Researcher has a specific research", function() {
+		expect( researcher.hasResearch( "getParagraphLength" ) ).toBe( true );
+	} );
+
+	it( "returns true if the Catalan Researcher has a specific research", function() {
+		expect( researcher.hasResearch( "functionWordsInKeyphrase" ) ).toBe( true );
+	} );
+
+	it( "returns false if the default research is deleted in the Catalan Researcher", function() {
+		expect( researcher.getResearch( "getFleschReadingScore" ) ).toBe( false );
+	} );
+
+	it( "returns false if the Catalan Researcher doesn't have a certain helper", function() {
+		expect( researcher.getHelper( "fleschReadingScore" ) ).toBe( false );
+	} );
+
+	it( "returns false if the Catalan Researcher doesn't have a certain config", function() {
+		expect( researcher.getConfig( "stopWords" ) ).toBe( false );
+	} );
+
+	it( "returns Catalan sentence length", function() {
+		expect( researcher.getConfig( "sentenceLength" ) ).toEqual( sentenceLength );
+	} );
+
+	it( "returns Catalan transition words", function() {
+		expect( researcher.getConfig( "transitionWords" ) ).toEqual( transitionWords );
+	} );
+
+	it( "returns Catalan two-part transition words", function() {
+		expect( researcher.getConfig( "twoPartTransitionWords" ) ).toEqual( twoPartTransitionWords );
+	} );
+
+	it( "returns the Catalan locale", function() {
+		expect( researcher.getConfig( "language" ) ).toEqual( "ca" );
+	} );
+
+	it( "doesn't stem the Catalan word as the Catalan stemmer is not yet available", function() {
+		expect( researcher.getHelper( "getStemmer" )()( "gats" ) ).toEqual( "gats" );
+	} );
+} );

--- a/packages/yoastseo/spec/languageProcessing/languages/ca/helpers/getStemmerSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/ca/helpers/getStemmerSpec.js
@@ -1,0 +1,7 @@
+import getStemmer from "../../../../../src/languageProcessing/languages/ca/helpers/getStemmer";
+
+describe( "Test for the base stemmer where it returns the input word", () => {
+	it( "returns the input word", () => {
+		expect( getStemmer()( "gats" ) ).toBe( "gats" );
+	} );
+} );

--- a/packages/yoastseo/src/languageProcessing/languages/_default/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/_default/Researcher.js
@@ -19,8 +19,8 @@ export default class Researcher extends AbstractResearcher {
 		delete this.defaultResearches.getFleschReadingScore;
 		delete this.defaultResearches.getPassiveVoice;
 		delete this.defaultResearches.getSentenceBeginnings;
-		delete this.defaultResearches.stopWordsInKeyword;
 		delete this.defaultResearches.findTransitionWords;
+		delete this.defaultResearches.functionWordsInKeyphrase;
 
 		Object.assign( this.config, {
 			functionWords: [],

--- a/packages/yoastseo/src/languageProcessing/languages/_default/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/_default/Researcher.js
@@ -1,8 +1,5 @@
 import AbstractResearcher from "../../AbstractResearcher";
 
-// All config
-import sentenceLength from "./config/sentenceLength";
-
 // All helpers
 import getStemmer from "./helpers/getStemmer";
 
@@ -32,7 +29,6 @@ export default class Researcher extends AbstractResearcher {
 
 		Object.assign( this.helpers, {
 			getStemmer,
-			sentenceLength,
 		} );
 	}
 }

--- a/packages/yoastseo/src/languageProcessing/languages/ca/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ca/Researcher.js
@@ -25,6 +25,7 @@ export default class Researcher extends AbstractResearcher {
 		delete this.defaultResearches.getFleschReadingScore;
 		delete this.defaultResearches.getPassiveVoice;
 		delete this.defaultResearches.getSentenceBeginnings;
+		delete this.defaultResearches.functionWordsInKeyphrase;
 
 		Object.assign( this.config, {
 			language: "ca",

--- a/packages/yoastseo/src/languageProcessing/languages/ca/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/ca/Researcher.js
@@ -25,18 +25,17 @@ export default class Researcher extends AbstractResearcher {
 		delete this.defaultResearches.getFleschReadingScore;
 		delete this.defaultResearches.getPassiveVoice;
 		delete this.defaultResearches.getSentenceBeginnings;
-		delete this.defaultResearches.stopWordsInKeyword;
 
 		Object.assign( this.config, {
 			language: "ca",
 			functionWords: [],
 			transitionWords,
 			twoPartTransitionWords,
+			sentenceLength,
 		} );
 
 		Object.assign( this.helpers, {
 			getStemmer,
-			sentenceLength,
 		} );
 	}
 }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds specs for Catalan and Default Researcher and helper files.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-595
