### PR TITLE
Show a placeholder first instead of setting todays date as default

### DIFF
--- a/packages/schema-blocks/src/instructions/blocks/Date.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/Date.tsx
@@ -3,6 +3,7 @@ import { BlockConfiguration } from "@wordpress/blocks";
 import { DateTimePicker, Dropdown } from "@wordpress/components";
 import { createElement, useState } from "@wordpress/element";
 import { __experimentalGetSettings, dateI18n, getDate, format } from "@wordpress/date";
+import { __ } from "@wordpress/i18n";
 
 // Internal imports.
 import BlockInstruction from "../../core/blocks/BlockInstruction";
@@ -33,10 +34,9 @@ export default class Date extends BlockInstruction {
 
 		const [ selectedDate, setSelectedDate ] = useState( currentlySelectedDate );
 
-		if ( ! attributes[ this.options.name ] ) {
-			setAttributes( {
-				[ this.options.name ]: format( "Y-m-d", getDate() ),
-			} );
+		let currentValue = __( "Select a date", "yoast-schema-blocks" );
+		if ( attributes[ this.options.name ] ) {
+			currentValue = format( "Y-m-d", getDate() );
 		}
 
 		/**
@@ -45,7 +45,8 @@ export default class Date extends BlockInstruction {
 		 * @param dateTime The selected date and time in the form 'yyyy-MM-ddThh:mm:ss' (only the date part is used).
 		 */
 		const setDate = useCallback( ( dateTime: string ) => {
-			const date = dateTime.split( "T" )[ 0 ];
+			const date = dateTime ? dateTime.split( "T" )[ 0 ] : null;
+
 			setAttributes( {
 				[ this.options.name ]: date,
 			} );
@@ -64,7 +65,7 @@ export default class Date extends BlockInstruction {
 				onClick={ renderProps.onToggle }
 				aria-expanded={ renderProps.isOpen }
 			>
-				{ selectedDate }
+				{ currentValue }
 			</button>;
 		}, [ selectedDate ] );
 
@@ -76,7 +77,7 @@ export default class Date extends BlockInstruction {
 		const renderContent = useCallback( (): JSX.Element => {
 			return <div className="yoast-block-date-picker">
 				<DateTimePicker
-					currentDate={ selectedDate }
+					currentDate={ attributes[ this.options.name ] ? selectedDate : null }
 					onChange={ setDate }
 				/>
 			</div>;
@@ -116,6 +117,10 @@ export default class Date extends BlockInstruction {
 	 */
 	save( props: RenderSaveProps ): JSX.Element {
 		const date = props.attributes[ this.options.name ] as string;
+
+		if ( ! date ) {
+			return null;
+		}
 
 		const dateFormat = Date.getDateFormat();
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [schema-blocks | Yoast SEO Free] Sets a placeholder with `Select a date` instead of using todays date as default.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Insert the job block
* See that expires on has `Select a date` as value
* Click on that value and pick a date.
* Save it and see the date being saved.
* In the editor click the date and presser `Reset` in the right corner at the bottom of the date picker
* Save it and see no date being saved. 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
