### PR TITLE
Removes the prepare hook in the package.json.

### DIFF
--- a/packages/schema-blocks/package.json
+++ b/packages/schema-blocks/package.json
@@ -57,11 +57,10 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
-    "prepare": "yarn build",
     "lint": "eslint \"src/**\"",
     "lint-fix": "eslint \"src/**\" --fix",
     "test": "jest",
-    "prepublishOnly": "rm -rf dist && tsc && mkdir dist/css && cp -r css/*.css dist/css && cp package.json dist/package.json && json -I -f dist/package.json -e \"this.main='index.js'\""
+    "prepublishOnly": "rm -rf dist && yarn build && mkdir dist/css && cp -r css/*.css dist/css && cp package.json dist/package.json && json -I -f dist/package.json -e \"this.main='index.js'\""
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Removes the `prepare` hook inside the `package.json`.
* [@yoast/schema-blocks] Replaces the calls to `tsc` in the `prepublishOnly` hook with `yarn build`.

## Relevant technical choices:

* The `prepare` hook is run by `yarn` after every `yarn` / `yarn install`. We only need to build it before publishing, so on the `prepublishOnly` hook (see [the lifecycle scripts docs for NPM/Yarn](https://docs.npmjs.com/cli/v6/using-npm/scripts#life-cycle-scripts)).
* This fixes a bug in wordpress-seo that [builds the schema-blocks twice when it's not been built yet, on a linked monorepo](https://github.com/Yoast/wordpress-seo/blob/trunk/config/grunt/task-config/shell.js#L211).
	* Once on `yarn install` and once on `yarn build`.	

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run a `yarn` inside of the `schema-blocks` package.
* It should **not** build the TypeScript (e.g. run `tsc`).
* Remove the `dist` folder.
* Run a `yarn prepublishOnly` inside of the `schema-blocks` package.
* Check the contents of the `dist` folder. It should contain the compiled TypeScript files (in the form of JavaScript files + TypeScript type definition files, ending in `.d.ts`).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
