### PR TITLE
Always add 'yoast-inner-container' classes on the frontend.

### DIFF
--- a/packages/schema-blocks/src/instructions/blocks/ClassName.ts
+++ b/packages/schema-blocks/src/instructions/blocks/ClassName.ts
@@ -15,6 +15,17 @@ class ClassName extends BlockInstruction {
 	edit( props: RenderEditProps ): string {
 		return props.className;
 	}
+
+	/**
+	 * Always add the "yoast-inner-container" class
+	 * on the frontend, so the Twenty Twenty One
+	 * theme works correctly.
+	 *
+	 * @returns "yoast-inner-container"
+	 */
+	save(): "yoast-inner-container" {
+		return "yoast-inner-container";
+	}
 }
 
 BlockInstruction.register( "class-name", ClassName );

--- a/packages/schema-blocks/src/instructions/blocks/ClassName.ts
+++ b/packages/schema-blocks/src/instructions/blocks/ClassName.ts
@@ -4,7 +4,7 @@ import { RenderEditProps } from "../../core/blocks/BlockDefinition";
 /**
  * ClassName instruction.
  */
-class ClassName extends BlockInstruction {
+export default class ClassName extends BlockInstruction {
 	/**
 	 * Renders the class name.
 	 *

--- a/packages/schema-blocks/tests/instructions/blocks/ClassName.test.ts
+++ b/packages/schema-blocks/tests/instructions/blocks/ClassName.test.ts
@@ -1,5 +1,5 @@
 import ClassName from "../../../src/instructions/blocks/ClassName";
-import { RenderEditProps } from "../../../dist/core/blocks/BlockDefinition";
+import { RenderEditProps } from "../../../src/core/blocks/BlockDefinition";
 
 describe( "The ClassName instruction", () => {
 	it( "can correctly render in the editor", () => {

--- a/packages/schema-blocks/tests/instructions/blocks/ClassName.test.ts
+++ b/packages/schema-blocks/tests/instructions/blocks/ClassName.test.ts
@@ -1,0 +1,24 @@
+import ClassName from "../../../src/instructions/blocks/ClassName";
+import { RenderEditProps } from "../../../dist/core/blocks/BlockDefinition";
+
+describe( "The ClassName instruction", () => {
+	it( "can correctly render in the editor", () => {
+		const className = new ClassName( 10, { name: "some_name" } );
+
+		const props: RenderEditProps = {
+			attributes: {},
+			clientId: "",
+			isSelected: false,
+			setAttributes: jest.fn(),
+			className: "class-name",
+		};
+
+		expect( className.edit( props ) ).toEqual( "class-name" );
+	} );
+
+	it( "can correctly render on the frontend", () => {
+		const className = new ClassName( 10, { name: "some_name" } );
+
+		expect( className.save() ).toEqual( "yoast-inner-container" );
+	} );
+} );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Fixes the styling of block instructions for the Twenty Twenty One WordPress theme.

## Relevant technical choices:

* Adding a class name that contains `inner-container` fixes a styling issue in Twenty Twenty One where only the blocks that are a direct descendant of the post content got margins.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### For acceptance:
* Checkout the release branch (`release/15.9`) on WordPress SEO Premium.
* Make sure that you have linked this monorepo branch.
* Build the JavaScript / TypeScript as you normally would (in the `schema-blocks` package and in the plugin). 
* Make sure that you have the Twenty Twenty One theme active in your WP installation.
* Create a new post in your WP installation.
* Add a new job posting block.
* Fill out the job posting block so we have some content to show on the frontend.
* Add other blocks to the post (like h4's, paragraphs, lists), so we have other elements to compare the styling with.
* Save and publish the post.
* Check the content of the job posting block on the frontend.
	* Its inner blocks should have the same styling as other blocks in the post.

### For QA:
* Make sure that you have the Twenty Twenty One theme active in your WP installation.
* Create a new post in your WP installation.
* Add a new job posting block.
* Fill out the job posting block, so we have some content to show on the frontend.
* Add other blocks to the post (like h4's, paragraphs, lists), so we have other elements to compare the styling with.
* Save and publish the post.
* Check the content of the job posting block on the frontend.
	* Its inner blocks should have the same styling as the other blocks in the post.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Make a quick smoke check with other theme's, like Twenty Twenty or Twenty Nineteen, to see if the job posting block still has correct styling (e.g. the same as the theme itself).

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
