### PR TITLE
Generating instruction IDs now skips IDs that also occur in the separator.

### DIFF
--- a/packages/schema-blocks/tests/functions/process.test.ts
+++ b/packages/schema-blocks/tests/functions/process.test.ts
@@ -3,7 +3,7 @@ import "../matchMedia.mock";
 import process, { processBlock } from "../../src/functions/process";
 import BlockDefinition from "../../src/core/blocks/BlockDefinition";
 import BlockInstruction from "../../src/core/blocks/BlockInstruction";
-import  "../../src/instructions/blocks/InnerBlocks";
+import "../../src/instructions/blocks/InnerBlocks";
 import InnerBlocks from "../../src/instructions/blocks/InnerBlocks";
 import { RequiredBlock, RequiredBlockOption } from "../../src/core/validation";
 
@@ -19,8 +19,8 @@ describe( "the process function", () => {
 			'template=[ [ "yoast/ingredients", { "value": [ "ingredient 1", "ingredient 2" ]} ], [ "yoast/ingredients", {} ]] ' +
 			'appender="button" appenderLabel="Add to recipe" }}';
 		const expected = {
-			0: {
-				id: 0,
+			1: {
+				id: 1,
 				options: {
 					allowedBlocks: [
 						"core/paragraph",
@@ -29,7 +29,7 @@ describe( "the process function", () => {
 					],
 					appender: "button",
 					appenderLabel: "Add to recipe",
-    		        name: "inner-blocks",
+					name: "inner-blocks",
 					template: [
 						[
 							"yoast/ingredients",


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [yoast-components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Fixes a bug where the editor would crash when a separator would be generated that clashes with a generated ID in the schema template.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

### For acceptance test

#### Reproducing the bug
* Checkout the release branch.
* Manually trigger a clash between the generated separator and the generated IDs by limiting the separators from which the code can choose:
	* E.g. replace [this line](https://github.com/Yoast/javascript/blob/develop/packages/schema-blocks/src/core/schema/SchemaDefinition.ts#L24) with this:
	```ts
	public static separatorCharacters = [ "48" ];
	```
* Checkout the release branch on WordPress SEO Premium.
* Build the JavaScript of the `schema-blocks` package and the plugin.
* Create a new post.
* Add a job posting block to the post.
* Check the browser console. You should see this log + error:
```
cannot render value  undefined
Uncaught TypeError: Cannot read property 'render' of undefined
```
* Update one off the blocks in the job posting.
	* E.g. change the Employment to Part-time.
* Publish the post.
* Check the generated schema on the frontend.
	* No `JobPosting` schema is generated / the changes you made are not reflected.	

#### Checking if the bug is fixed
* Checkout this branch.
* Manually trigger a clash between the generated separator and the generated IDs by limiting the separators from which the code can choose:
	* E.g. replace [this line](https://github.com/Yoast/javascript/blob/develop/packages/schema-blocks/src/core/schema/SchemaDefinition.ts#L24) with this:
	```ts
	public static separatorCharacters = [ "48" ];
	```
* Checkout the release branch on WordPress SEO Premium.
* Build the JavaScript of the `schema-blocks` package and the plugin.
* Create a new post.
* Add a job posting block to the post.
* Check the browser console. You should **not** see the error above.
* Update one off the blocks in the job posting.
	* E.g. change the Employment to Part-time.
* Publish the post.
* Check the generated schema on the frontend.
	* The correct `JobPosting` schema should have been generated.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
