### PR TITLE
Add Czech transition words

### DIFF
--- a/packages/yoastseo/src/languageProcessing/languages/cz/Researcher.js
+++ b/packages/yoastseo/src/languageProcessing/languages/cz/Researcher.js
@@ -3,6 +3,8 @@ import AbstractResearcher from "../../AbstractResearcher";
 // All config
 import stopWords from "./config/stopWords";
 import { all as functionWords } from "./config/functionWords";
+import transitionWords from "./config/transitionWords";
+import twoPartTransitionWords from "./config/twoPartTransitionWords";
 
 // All helpers
 import getSentenceParts from "./helpers/getSentenceParts";
@@ -24,6 +26,8 @@ export default class Researcher extends AbstractResearcher {
 			passiveConstructionType: "periphrastic",
 			stopWords,
 			functionWords,
+			transitionWords,
+			twoPartTransitionWords,
 		} );
 
 		Object.assign( this.helpers, {

--- a/packages/yoastseo/src/languageProcessing/languages/cz/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/cz/config/functionWords.js
@@ -64,11 +64,14 @@ const prepositions = [ "během", "bez", "blízko", "do", "od", "okolo", "kolem",
 	"navzdor", "navzdory", "krom, vedle", "kromě, vedle", "místo", "namísto", "ohledně", "podél", "pomocí", "oproti", "naproti",
 	"proti", "prostřednictvím", "s", "u", "vlivem", "vyjma", "využitím", "stran", "díky", "kvůli", "podle", "vůči", "na", "té",
 	"o", "pro", "přes", "za", "po", "v", "ve", "mezi", "s", "se", "nad", "pod", "před", "mimo", "skrz", "při", "jako", "asi",
-	"spolu", "dokud", "ven", "běž", "odkud", "ode", "nahoře", "nahoru", "dovnitř", "dne" ];
+	"spolu", "dokud", "ven", "běž", "odkud", "ode", "nahoře", "nahoru", "dovnitř", "dne", "beze", "napříč", "versus", "via",
+	"vně", "dovnitř", "vpředu", "vůkol", "vespod", "opodál", "vepředu", "svrchu", "vnitř", "zprostřed", "naspodu", "zdéli",
+	"okol", "podál", "naspod", "kontra", "vespodu", "zponad", "ponad", "nadtož", "kolkolem", "zdélí", "veskrz", "popod",
+	"daleko", "vůkolem"];
 
 const conjunctions = [ "a", "i", "aby", "ale", "že", "protože", "neboť", "když", "až", "jestli", "jestliže", "pokud", "kdyby",
 	"nebo", "anebo", "či", "proto", "který", "jenž", "aniž", "než", "tak", "takže", "kvůli", "kdybych", "ach", "zdá", "zatím",
-	"během", "kdybyste" ];
+	"během", "kdybyste", "jakožto", "jakož", "neb" ];
 
 const interviewVerbs = [ "řekl", "říkala", "řekla", "řekne", "říkal", "říká", "podle", "neřekl", "říkat", "chtějí", "neviděl",
 	"vypadáš", "mluvil", "rozumím", "znám", "cítím", "nemyslím", "víme", "nevěřím" ];

--- a/packages/yoastseo/src/languageProcessing/languages/cz/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/cz/config/functionWords.js
@@ -40,7 +40,7 @@ const interrogatives = [ "co", "čí", "čím", "jak", "jaký", "jaké", "kde", 
 
 const quantifiers = [ "nějaký", "nějaká", "nějaké", "žádný", "nijaký", "lecjaký", "ledajaký", "ledasjaký", "kdejaký",
 	"kdekterý", "všelijaký", "veškerý", "pár", "hodně", "celý", "tolik", "celou", "celé", "oba", "buď", "zbytek", "žádná",
-	"nějakou" ];
+	"nějakou", "spoustu", "několik" ];
 
 const reflexivePronouns = [ "se", "si", "sebe", "sobě", "sebou",
 	// Reflexive possessive.
@@ -58,13 +58,14 @@ const indefinitePronouns = [ "někdo", "někoho", "někomu", "někom", "někým"
 	"odkudsi", "odnikud", "odevšad", "kdesi", "všechen", "málokdo", "máloco", "málokterý", "zřídkakdo", "zřídkaco", "sotvakdo",
 	"sotvaco", "sotva který", "každý", "každá", "každé", "každého", "každému", "každému", "každou", "každém", "každým", "každí",
 	"každých", "každým", "každými", "všechen", "všechna", "všechno", "vše", "všeho", "vší", "všemu", "všechnu", "vším",
-	"všichni", "všechny", "všech", "všem", "všemi", "takový", "takové ", "takového", "takovou", "cokoliv", "jiného", "jiný" ];
+	"všichni", "všechny", "všech", "všem", "všemi", "takový", "takové ", "takového", "takovou", "cokoliv", "jiného", "jiný",
+	"taková", "jiné", "odtud" ];
 
 const prepositions = [ "během", "bez", "blízko", "do", "od", "okolo", "kolem", "u", "vedle", "z", "ze", "k", "ke", "kvůli",
 	"navzdor", "navzdory", "krom, vedle", "kromě, vedle", "místo", "namísto", "ohledně", "podél", "pomocí", "oproti", "naproti",
 	"proti", "prostřednictvím", "s", "u", "vlivem", "vyjma", "využitím", "stran", "díky", "kvůli", "podle", "vůči", "na", "té",
 	"o", "pro", "přes", "za", "po", "v", "ve", "mezi", "s", "se", "nad", "pod", "před", "mimo", "skrz", "při", "jako", "asi",
-	"spolu", "dokud", "ven", "běž", "odkud", "ode", "nahoře", "nahoru", "dovnitř", "dne", "beze", "napříč", "versus", "via",
+	"dokud", "ven", "běž", "odkud", "ode", "nahoře", "nahoru", "dovnitř", "dne", "beze", "napříč", "versus", "via",
 	"vně", "dovnitř", "vpředu", "vůkol", "vespod", "opodál", "vepředu", "svrchu", "vnitř", "zprostřed", "naspodu", "zdéli",
 	"okol", "podál", "naspod", "kontra", "vespodu", "zponad", "ponad", "nadtož", "kolkolem", "zdélí", "veskrz", "popod",
 	"daleko", "vůkolem"];
@@ -74,9 +75,10 @@ const conjunctions = [ "a", "i", "aby", "ale", "že", "protože", "neboť", "kdy
 	"během", "kdybyste", "jakožto", "jakož", "neb" ];
 
 const interviewVerbs = [ "řekl", "říkala", "řekla", "řekne", "říkal", "říká", "podle", "neřekl", "říkat", "chtějí", "neviděl",
-	"vypadáš", "mluvil", "rozumím", "znám", "cítím", "nemyslím", "víme", "nevěřím" ];
+	"vypadáš", "mluvil", "rozumím", "znám", "cítím", "nemyslím", "víme", "nevěřím", "myslíte" ];
 
-const intensifiers = [ "jasně", "velmi", "vůbec", "přesně", "určitě", "úplně", "samozřejmě", "docela", "skutečně", "rozhodně " ];
+const intensifiers = [ "jasně", "velmi", "vůbec", "přesně", "určitě", "úplně", "samozřejmě", "docela", "skutečně", "rozhodně",
+	"vážně", "spolu", "jistě", "naprosto", "velice", "hrozně", "strašně", "opravdu" ];
 
 const auxiliariesAndDelexicalizedVerbs = [ "mělo", "přijít", "podívat", "dělej", "dá", "dala", "přijde", "stojí",
 	"udělám", "mohlo", "nechte", "nemáme", "dám", "přišla", "dělal", "dejte" ];
@@ -87,13 +89,14 @@ const generalAdjectivesAdverbs = [
 	"ostatní", "velký", "starý", "líp", "malé", "špatný", "lépe", "hlavní", "právo", "úžasné", "pěkný", "stejné", "spousta",
 	"skvělá", "dobrej", "horší", "novou", "stará", "nového", "nejdřív", "druhou", "naposledy", "hezký", "dlouhý", "dobrý",
 	"malý", "těžký", "velký", "zlý", "delší", "lepší", "menší", "těžší", "větší", "horší", "nejdelší", "nejlepší", "nejmenší",
-	"nejtěžší", "největší", "nejhorší",
+	"nejtěžší", "největší", "nejhorší", "pěkně",
 	// General adverbs.
-	"všelijak", "nějak", "jaksi", "tak nějak", "ijak", "nikterak", "akkoli", "akkoliv", "kdejak", "už", "jen", "tady", "teď",
-	"ještě", "možná", "nikdy", "ani", "taky", "pak", "opravdu", "trochu", "prostě", "víc", "jenom", "další", "právě", "zpátky",
-	"vždycky", "pryč", "zase", "někdy", "také", "chvíli", "znovu", "snad", "třeba", "stále", "zrovna", "příliš", "nějak", "vždy",
-	"skoro", "kolem", "později", "zpět", "najednou", "támhle", "někam", "hlavně", "často", "občas", "společně", "dokonce", "zde",
-	"aspoň", "jediný", "pouze", "stačí", "mnohem", "zas", "nikam", "dávno", "již", "dvakrát", "vzhůru", "pomalu", "bohužel" ];
+	"všelijak", "nějak", "jaksi", "tak nějak", "ijak", "nikterak", "akkoli", "akkoliv", "kdejak", "už", "jen", "tady",
+	"teď", "ještě", "možná", "nikdy", "ani", "taky", "pak", "trochu", "prostě", "víc", "jenom", "další", "právě", "zpátky",
+	"vždycky", "pryč", "zase", "někdy", "také", "chvíli", "znovu", "snad", "třeba", "stále", "zrovna", "příliš", "nějak",
+	"vždy", "skoro", "kolem", "později", "zpět", "najednou", "támhle", "někam", "hlavně", "často", "občas", "společně",
+	"dokonce", "zde", "aspoň", "jediný", "pouze", "stačí", "mnohem", "zas", "nikam", "dávno", "již", "dvakrát", "vzhůru",
+	"pomalu", "bohužel", "raději", "nejspíš", "náhodou", "okamžitě" ];
 
 const interjections = [ "jo", "hej", "oh", "uh ", "hele", "fajn", "ok", "proboha", "ah", "okay" ];
 

--- a/packages/yoastseo/src/languageProcessing/languages/cz/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/cz/config/functionWords.js
@@ -85,7 +85,9 @@ const generalAdjectivesAdverbs = [
 	// General adjective.
 	"dobře", "dobrý", "dobrá", "dobré", "dost", "dlouho", "dlouha", "nejlepší", "poslední", "rychle", "lepší", "vlastní",
 	"ostatní", "velký", "starý", "líp", "malé", "špatný", "lépe", "hlavní", "právo", "úžasné", "pěkný", "stejné", "spousta",
-	"skvělá", "dobrej", "horší", "novou", "stará", "nového", "nejdřív", "druhou", "naposledy", "hezký",
+	"skvělá", "dobrej", "horší", "novou", "stará", "nového", "nejdřív", "druhou", "naposledy", "hezký", "dlouhý", "dobrý",
+	"malý", "těžký", "velký", "zlý", "delší", "lepší", "menší", "těžší", "větší", "horší", "nejdelší", "nejlepší", "nejmenší",
+	"nejtěžší", "největší", "nejhorší",
 	// General adverbs.
 	"všelijak", "nějak", "jaksi", "tak nějak", "ijak", "nikterak", "akkoli", "akkoliv", "kdejak", "už", "jen", "tady", "teď",
 	"ještě", "možná", "nikdy", "ani", "taky", "pak", "opravdu", "trochu", "prostě", "víc", "jenom", "další", "právě", "zpátky",

--- a/packages/yoastseo/src/languageProcessing/languages/cz/config/functionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/cz/config/functionWords.js
@@ -68,7 +68,7 @@ const prepositions = [ "během", "bez", "blízko", "do", "od", "okolo", "kolem",
 	"dokud", "ven", "běž", "odkud", "ode", "nahoře", "nahoru", "dovnitř", "dne", "beze", "napříč", "versus", "via",
 	"vně", "dovnitř", "vpředu", "vůkol", "vespod", "opodál", "vepředu", "svrchu", "vnitř", "zprostřed", "naspodu", "zdéli",
 	"okol", "podál", "naspod", "kontra", "vespodu", "zponad", "ponad", "nadtož", "kolkolem", "zdélí", "veskrz", "popod",
-	"daleko", "vůkolem"];
+	"daleko", "vůkolem" ];
 
 const conjunctions = [ "a", "i", "aby", "ale", "že", "protože", "neboť", "když", "až", "jestli", "jestliže", "pokud", "kdyby",
 	"nebo", "anebo", "či", "proto", "který", "jenž", "aniž", "než", "tak", "takže", "kvůli", "kdybych", "ach", "zdá", "zatím",

--- a/packages/yoastseo/src/languageProcessing/languages/cz/config/transitionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/cz/config/transitionWords.js
@@ -1,0 +1,24 @@
+/** @module config/transitionWords */
+
+export const singleWords = [ "předtím", "vždyť", "definitely", "konečně", "jasné", "možné", "ale", "demzufolge", "však",
+	"ačkoliv", "protože", "ovšem", "zkrátka", "potom", "stejně", "tím", "jinak", "zatímco", "když", "co", "kdežto", "ačkoli",
+	"přestože", "čas", "chvíle", "chvilka", "avšak", "jenže", "nicméně", "přitom", "aniž", "a", "proto", "tedy", "teda",
+	"totiž", "mimoto", "čímž", "což", "než", "nejenže", "také", "jenom", "přesto", "jak", "jelikož", "takže", "zda", "sice",
+	"tudíž", "jakoby", "nýbrž", "neboli", "jen", "čili", "pak", "jenomže", "kdežto", "leč", "poněvadž", "třeba", "přece",
+	"nežli", "zdali", "buďto", "totiž", "jenom", "leda", "pakliže", "třebaže", "jakože", "jakkoli", "nechť", "sotva", "kterak",
+	"sic", "jakkoliv", "ledaže", "ježto", "třebas", "jakž", "pakli", "zdalipak", "takž", "jakže", "pokavaď", "jakby", "pokudž",
+	"sotvaže", "pokad", "kdyžtě", "mezitímco", "buďsi", "byťsi", "pokadž", "tedyť", "buďže", "dle", "vzhledem", "místo", "vedle",
+	"okolo", "uprostřed", "namísto", "navzdory", "krom", "poblíž", "blízko", "nedaleko", "začátkem", "naproti", "počátkem",
+	"počínaje", "postupem", "vlivem", "vyjma", "následkem", "dík", "zpoza", "zásluhou", "nevyjímaje", "doprostřed", "zpod",
+	"zespoda", "závěrem", "úvodem", "přese", "prostřed", "nepočítaje", "úměrně", "vprostřed", "navrch", "vevnitř", "zespodu",
+	"poblíže", "počínajíc", "nadtoť", "zpozad", "vyjímaje", "začínaje", "zespod", "navrchu", "vyjímajíc", "navzdor",
+	"veprostřed", "končíc", "začínajíc", "nepočítajíc", "zvíce", "vprostředku", "opodále", "podále", "naprostřed" ];
+
+export const multipleWords = [ "a proto", "i když", "i přestože", "z tohoto důvodu", "kromě toho", "nějaký čas", "k tomu",
+	"na jedné straně", "stručně řečeno", "jinými slovy", "důvod je", "důvodem je", "hlavně protože", "možným důvodem je",
+	"a potom", "mimo to", "z uvedených důvodů", "z těchto důvodů", "důvod je jednoduchý", "teprve potom", "hlavní důvod proč",
+	"nejdřív potom", "přesto však", "ale zároveň", "ale také", "během toho" ];
+
+export const allWords = singleWords.concat( multipleWords );
+
+export default allWords;

--- a/packages/yoastseo/src/languageProcessing/languages/cz/config/transitionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/cz/config/transitionWords.js
@@ -11,8 +11,10 @@ export const singleWords = [ "předtím", "vždyť", "definitely", "konečně", 
 	"okolo", "uprostřed", "namísto", "navzdory", "krom", "poblíž", "blízko", "nedaleko", "začátkem", "naproti", "počátkem",
 	"počínaje", "postupem", "vlivem", "vyjma", "následkem", "dík", "zpoza", "zásluhou", "nevyjímaje", "doprostřed", "zpod",
 	"zespoda", "závěrem", "úvodem", "přese", "prostřed", "nepočítaje", "úměrně", "vprostřed", "navrch", "vevnitř", "zespodu",
-	"poblíže", "počínajíc", "nadtoť", "zpozad", "vyjímaje", "začínaje", "zespod", "navrchu", "vyjímajíc", "navzdor",
-	"veprostřed", "končíc", "začínajíc", "nepočítajíc", "zvíce", "vprostředku", "opodále", "podále", "naprostřed" ];
+	"poblíže", "počínajíc", "nadtoť", "zpozad", "vyjímaje", "začínaje", "zespod", "navrchu", "vyjímajíc", "navzdor", "dál",
+	"veprostřed", "končíc", "začínajíc", "nepočítajíc", "zvíce", "vprostředku", "opodále", "podále", "naprostřed", "vlastně",
+	"podle", "samozřejmě", "vždyť", "zatím", "dřív", "radši", "spíš", "poprvé", "nakonec", "navíc", "záleží", "zbytek", "kým",
+	"jakmile", "skutečně", "tentokrát", "představit", "jménem" ];
 
 export const multipleWords = [ "a proto", "i když", "i přestože", "z tohoto důvodu", "kromě toho", "nějaký čas", "k tomu",
 	"na jedné straně", "stručně řečeno", "jinými slovy", "důvod je", "důvodem je", "hlavně protože", "možným důvodem je",

--- a/packages/yoastseo/src/languageProcessing/languages/cz/config/twoPartTransitionWords.js
+++ b/packages/yoastseo/src/languageProcessing/languages/cz/config/twoPartTransitionWords.js
@@ -1,0 +1,8 @@
+/** @module config/twoPartTransitionWords */
+
+/**
+ * Returns an array with two-part transition words to be used by the assessments.
+ * @type {Array} The array filled with two-part transition words.
+ */
+export default [ [ "buď", "nebo" ], [ "buď", "anebo" ], [ "ani", "ani" ], [ "nejen", "ale i" ], [ "jak", "tak" ],
+	[ "sice", "ale" ], [ "sice", "však" ], [ "jednak", "jednak" ] ];


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Adds the transition words list for Czech and improves the list of function words with the most common irregular comparatives.
* [Yoast SEO Free] Implements the transition words assessment for Czech.



## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

Set your website to Czech.
To create a Czech text you can use the [Czech Wikipedia](https://cs.wikipedia.org/wiki/%C4%8Ce%C5%A1tina)
In Yoast Seo Free:
- Create a new post and add this text containing the transition words `předtím` and `pak`:
`předtím byli přátelé, pak se přesunuli odděleně`
- The assessment bullet should be green and read: Transition words: Well done!
- Out of the two sentences, both should be highlighted.
- Add this text containing the transition word `pak`:
`byli přátelé, pak se přesunuli odděleně`
- Out of the two sentences, only the second should be highlighted.

Note: It's currently not possible to test these steps in the content-analysis app


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-624