### PR TITLE
Remove keyphrase highlighting from the mobile meta description

### DIFF
--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -721,7 +721,7 @@ export default class SnippetPreview extends PureComponent {
 							</MobileDescriptionImageContainer>
 						}
 						{ renderedDate }
-						{ highlightWords( locale, wordsToHighlight, this.getDescription() ) }
+						{ this.getDescription() }
 					</MobileDescription>
 				</MobileDescriptionWithCaret>
 			);
@@ -764,7 +764,6 @@ export default class SnippetPreview extends PureComponent {
 			<section>
 				<Container
 					id="yoast-snippet-preview-container"
-					onMouseLeave={ this.onMouseLeave }
 					/*
 					 * MobileContainer doesn't use the width prop: avoid to
 					 * render an invalid `width` HTML attribute on the DOM node.


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/search-metadata-previews] Removes the keyphrase highlighting in the mobile meta description to reflect new Google behavior.
* [Yoast SEO] Removes the keyphrase highlighting in the mobile meta description to reflect new Google behavior.

## Relevant technical choices:

* Codescout: removed the unexisting `this.onMouseLeave` passed to the container. I tried the actual `onMouseLeave` from the props too, but that didn't fix the bug when you move switch from a field fast (that would probably needs hover or something more intense). Therefor, removing seems best.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Edit a post
* Fill in the meta description
* Set a keyphrase that is in the meta description
* Ensure it is not highlighted
* Switch to desktop view
* The keyphrase should be highlighted

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P1-393
