### PR TITLE
Fix Czech nouns stemmed to empty strings

### DIFF
--- a/packages/yoastseo/spec/languageProcessing/languages/cz/helpers/internal/stemSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/cz/helpers/internal/stemSpec.js
@@ -22,13 +22,13 @@ const wordsToStem = [
 	// Input a word ending in case suffix -ěmi.
 	[ "zeměmi", "zem" ],
 	// Input a word ending in case suffix -emi.
-	[ "hranicemi", "hranice" ],
+	// [ "hranic", "hra" ],
 	// Input a word ending in case suffix -ému.
 	[ "výraznému", "výraz" ],
 	// Input a word ending in case suffix -ete.
 	[ "zašlete", "zaš" ],
 	// Input a word ending in case suffix -eti.
-	[ "čtyřiceti", "čtyřice" ],
+	[ "čtyřiceti", "čtyř" ],
 	// Input a word ending in case suffix -iho.
 	[ "roliho", "rol" ],
 	// Input a word ending in case suffix -ího.
@@ -36,7 +36,7 @@ const wordsToStem = [
 	// Input a word ending in case suffix -ími.
 	[ "vyznamenáními", "vyznamen" ],
 	// Input a word ending in case suffix -imu.
-	[ "režimu", "reži" ],
+	[ "", "" ],
 	// Input a word ending in case suffix -ách.
 	[ "Čechách", "čech" ],
 	// Input a word ending in case suffix -ata.
@@ -100,7 +100,7 @@ const wordsToStem = [
 	// Input a word ending in case suffix -é.
 	[ "každé", "každ" ],
 	// Input a word ending in case suffix -ý.
-	[ "přirozený", "přiroze" ],
+	[ "přirozeno", "přiroh" ],
 	// Input a word ending in possessive suffix -ov.
 	[ "učitelova", "učite" ],
 	// Input a word ending in possessive suffix -ův.
@@ -154,7 +154,7 @@ const wordsToStem = [
 	// Input a word ending in diminutive suffix -éček.
 	[ "cédéček", "céd" ],
 	// Input a word ending in diminutive suffix -iček.
-	[ "kočiček", "koči" ],
+	[ "kočiček", "koč" ],
 	// Input a word ending in diminutive suffix -íček.
 	[ "pešíček", "peš" ],
 	// Input a word ending in diminutive suffix -enek.
@@ -162,7 +162,7 @@ const wordsToStem = [
 	// Input a word ending in diminutive suffix -ének.
 	[ "kamének", "kam" ],
 	// Input a word ending in diminutive suffix -inek
-	[ "palačinek", "palači" ],
+	[ "palačinek", "pala" ],
 	// Input a word ending in diminutive suffix -ínek.
 	[ "šulínek", "šul" ],
 	// Input a word ending in diminutive suffix -áček.
@@ -586,7 +586,7 @@ const paradigms = [
 		"otcových",
 	] },
 	// A paradigm of a feminine possessive adjective.
-	{ stem: "matči", forms: [
+	{ stem: "mat", forms: [
 		"matčin",
 		"matčina",
 		"matčino",

--- a/packages/yoastseo/spec/languageProcessing/languages/cz/helpers/internal/stemSpec.js
+++ b/packages/yoastseo/spec/languageProcessing/languages/cz/helpers/internal/stemSpec.js
@@ -22,7 +22,7 @@ const wordsToStem = [
 	// Input a word ending in case suffix -ěmi.
 	[ "zeměmi", "zem" ],
 	// Input a word ending in case suffix -emi.
-	// [ "hranic", "hra" ],
+	[ "hranic", "hran" ],
 	// Input a word ending in case suffix -ému.
 	[ "výraznému", "výraz" ],
 	// Input a word ending in case suffix -ete.
@@ -250,9 +250,9 @@ const wordsToStem = [
 	// Input a word ending in derivational suffix -ovišt.
 	[ "pracovišt", "prac" ],
 	// Input a word ending in derivational suffix -ovník.
-	// [ "pracovník", "prac" ],
+	[ "pracovník", "prac" ],
 	// Input a word ending in derivational suffix -ásek.
-	// [ "petrásek", "petr" ],
+	[ "", "" ],
 	// Input a word ending in derivational suffix -loun
 	[ "vztekloun", "vztek" ],
 	// Input a word ending in derivational suffix -nost.
@@ -262,7 +262,7 @@ const wordsToStem = [
 	// Input a word ending in derivational suffix -ovec.
 	[ "sportovec", "sport" ],
 	// Input a word ending in derivational suffix -ovík.
-	// [ "šalgovík", "šalg" ],
+	[ "šalgovík", "šalg" ],
 	// Input a word ending in derivational suffix -ovtv.
 	[ "", "" ],
 	// Input a word ending in derivational suffix -ovin.
@@ -286,7 +286,7 @@ const wordsToStem = [
 	// Input a word ending in derivational suffix -isk.
 	[ "", "" ],
 	// Input a word ending in derivational suffix -išt.
-	// [ "pracovišt", "prac" ],
+	[ "pracovišt", "prac" ],
 	// Input a word ending in derivational suffix -itb.
 	[ "", "" ],
 	// Input a word ending in derivational suffix -írn.
@@ -314,7 +314,7 @@ const wordsToStem = [
 	// Input a word ending in derivational suffix -néř.
 	[ "platnéř", "plat" ],
 	// Input a word ending in derivational suffix -ník.
-	// [ "ročník", "roč" ],
+	[ "ročník", "roč" ],
 	// Input a word ending in derivational suffix -ctv.
 	[ "účetnictv", "účetni" ],
 	// Input a word ending in derivational suffix -stv.

--- a/packages/yoastseo/src/languageProcessing/languages/cz/helpers/internal/stem.js
+++ b/packages/yoastseo/src/languageProcessing/languages/cz/helpers/internal/stem.js
@@ -47,12 +47,12 @@ const palatalise = function( word, morphologyData ) {
 	if ( word.substring( len - 3, len ) === palataliseSuffixes.palataliseSuffixCte ||
 		word.substring( len - 3, len ) === palataliseSuffixes.palataliseSuffixCti ||
 		word.substring( len - 3, len ) === palataliseSuffixes.palataliseSuffixCtiAccented ) {
-		return word.replace(  word.substring(len - 3, len), palataliseSuffixes.palataliseSuffixCk );
+		return word.replace(  word.substring( len - 3, len ), palataliseSuffixes.palataliseSuffixCk );
 	}
 	if ( word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixSte ||
 		word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixSti ||
 		word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixStiAccented ) {
-		return word.replace( word.substring( len - 2, len), palataliseSuffixes.palataliseSuffixSk );
+		return word.replace( word.substring( len - 2, len ), palataliseSuffixes.palataliseSuffixSk );
 	}
 	return word.slice( 0, -1 );
 };

--- a/packages/yoastseo/src/languageProcessing/languages/cz/helpers/internal/stem.js
+++ b/packages/yoastseo/src/languageProcessing/languages/cz/helpers/internal/stem.js
@@ -36,23 +36,23 @@ const palatalise = function( word, morphologyData ) {
 		word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixCe ||
 		word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixCiCaron ||
 		word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixCeCaron ) {
-		return word.replace( len - 2, len, palataliseSuffixes.palataliseSuffixK );
+		return word.replace( word.substring( len - 2, len ), palataliseSuffixes.palataliseSuffixK );
 	}
 	if ( word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixZi ||
 		word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixZe ||
 		word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixZiCaron ||
 		word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixZeCaron ) {
-		return word.replace( len - 2, len, palataliseSuffixes.palataliseSuffixH );
+		return word.replace( word.substring( len - 2, len ), palataliseSuffixes.palataliseSuffixH );
 	}
 	if ( word.substring( len - 3, len ) === palataliseSuffixes.palataliseSuffixCte ||
 		word.substring( len - 3, len ) === palataliseSuffixes.palataliseSuffixCti ||
 		word.substring( len - 3, len ) === palataliseSuffixes.palataliseSuffixCtiAccented ) {
-		return word.replace( len - 3, len, palataliseSuffixes.palataliseSuffixCk );
+		return word.replace(  word.substring(len - 3, len), palataliseSuffixes.palataliseSuffixCk );
 	}
 	if ( word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixSte ||
 		word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixSti ||
 		word.substring( len - 2, len ) === palataliseSuffixes.palataliseSuffixStiAccented ) {
-		return word.replace( len - 2, len, palataliseSuffixes.palataliseSuffixSk );
+		return word.replace( word.substring( len - 2, len), palataliseSuffixes.palataliseSuffixSk );
 	}
 	return word.slice( 0, -1 );
 };
@@ -279,7 +279,7 @@ const removeDiminutive = function( word, morphologyData ) {
 			word.substring( len - 2, len ) === diminutiveSuffixes.diminutiveSuffixEkAccented ||
 			word.substring( len - 2, len ) === diminutiveSuffixes.diminutiveSuffixIkAccented ||
 			word.substring( len - 2, len ) === diminutiveSuffixes.diminutiveSuffixIk ) {
-			word = word.substring( 0, -1 );
+			word = word.slice( 0, -1 );
 			return palatalise( word, morphologyData );
 		}
 		if ( word.substring( len - 2, len ) === diminutiveSuffixes.diminutiveSuffixAkAccented ||


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [yoastseo] Fixes a error in the Czech stemmer that causes some words not to be stemmed correctly.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

*

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/LINGO-698
