### PR TITLE
Allow custom labels to be used in the replacement variable editor

### DIFF
--- a/packages/replacement-variable-editor/src/SettingsSnippetEditor.js
+++ b/packages/replacement-variable-editor/src/SettingsSnippetEditor.js
@@ -122,6 +122,7 @@ class SettingsSnippetEditor extends React.Component {
 			descriptionEditorFieldPlaceholder,
 			hasPaperStyle,
 			fieldIds,
+			labels,
 		} = this.props;
 
 		const { activeField, hoveredField } = this.state;
@@ -140,6 +141,7 @@ class SettingsSnippetEditor extends React.Component {
 					recommendedReplacementVariables={ recommendedReplacementVariables }
 					containerPadding={ hasPaperStyle ? "0 20px" : "0" }
 					fieldIds={ fieldIds }
+					labels={ labels }
 				/>
 			</ErrorBoundary>
 		);
@@ -166,7 +168,6 @@ SettingsSnippetEditor.defaultProps = {
 	replacementVariables: [],
 	recommendedReplacementVariables: [],
 	hasPaperStyle: true,
-	descriptionEditorFieldPlaceholder: "",
 };
 
 export default SettingsSnippetEditor;

--- a/packages/replacement-variable-editor/src/SettingsSnippetEditor.js
+++ b/packages/replacement-variable-editor/src/SettingsSnippetEditor.js
@@ -172,6 +172,8 @@ SettingsSnippetEditor.defaultProps = {
 	replacementVariables: [],
 	recommendedReplacementVariables: [],
 	hasPaperStyle: true,
+	descriptionEditorFieldPlaceholder: null,
+	labels: {},
 };
 
 export default SettingsSnippetEditor;

--- a/packages/replacement-variable-editor/src/SettingsSnippetEditor.js
+++ b/packages/replacement-variable-editor/src/SettingsSnippetEditor.js
@@ -162,6 +162,10 @@ SettingsSnippetEditor.propTypes = {
 		title: PropTypes.string.isRequired,
 		description: PropTypes.string.isRequired,
 	} ).isRequired,
+	labels: PropTypes.shape( {
+		title: PropTypes.string,
+		description: PropTypes.string,
+	} ),
 };
 
 SettingsSnippetEditor.defaultProps = {

--- a/packages/replacement-variable-editor/src/SettingsSnippetEditorFields.js
+++ b/packages/replacement-variable-editor/src/SettingsSnippetEditorFields.js
@@ -194,6 +194,8 @@ SettingsSnippetEditorFields.defaultProps = {
 	onFocus: () => {},
 	onBlur: () => {},
 	containerPadding: "0 20px",
+	descriptionEditorFieldPlaceholder: null,
+	labels: {},
 };
 
 export default SettingsSnippetEditorFields;

--- a/packages/replacement-variable-editor/src/SettingsSnippetEditorFields.js
+++ b/packages/replacement-variable-editor/src/SettingsSnippetEditorFields.js
@@ -124,6 +124,7 @@ class SettingsSnippetEditorFields extends React.Component {
 			},
 			containerPadding,
 			fieldIds,
+			labels,
 		} = this.props;
 
 		return (
@@ -132,7 +133,7 @@ class SettingsSnippetEditorFields extends React.Component {
 			>
 				<ReplacementVariableEditor
 					type="title"
-					label={ __( "SEO title", "yoast-components" ) }
+					label={ labels.title || __( "SEO title", "yoast-components" ) }
 					onFocus={ () => onFocus( "title" ) }
 					onBlur={ onBlur }
 					isActive={ activeField === "title" }
@@ -147,7 +148,7 @@ class SettingsSnippetEditorFields extends React.Component {
 				<ReplacementVariableEditor
 					type="description"
 					placeholder={ descriptionEditorFieldPlaceholder }
-					label={ __( "Meta description", "yoast-components" ) }
+					label={ labels.description ||  __( "Meta description", "yoast-components" ) }
 					onFocus={ () => onFocus( "description" ) }
 					onBlur={ onBlur }
 					isActive={ activeField === "description" }
@@ -182,6 +183,10 @@ SettingsSnippetEditorFields.propTypes = {
 		title: PropTypes.string.isRequired,
 		description: PropTypes.string.isRequired,
 	} ).isRequired,
+	labels: PropTypes.shape( {
+		title: PropTypes.string,
+		description: PropTypes.string,
+	} ),
 };
 
 SettingsSnippetEditorFields.defaultProps = {

--- a/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -470,7 +470,6 @@ exports[`SnippetEditor activates a field on onMouseUp() and opens the editor 1`]
       }
       descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionInputId="yoast-google-preview-description"
-      descriptionLabel="Meta description"
       descriptionLengthProgress={
         Object {
           "actual": 42,
@@ -486,7 +485,6 @@ exports[`SnippetEditor activates a field on onMouseUp() and opens the editor 1`]
       replacementVariables={Array []}
       slugInputId="yoast-google-preview-slug"
       titleInputId="yoast-google-preview-title"
-      titleLabel="SEO title"
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -2341,7 +2339,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
-        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -2357,7 +2354,6 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
-        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -6321,7 +6317,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
-        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -6337,7 +6332,6 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
-        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -8689,7 +8683,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
-        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -8705,7 +8698,6 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
-        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -11901,7 +11893,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
-        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -11917,7 +11908,6 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
-        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -14307,7 +14297,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
-        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -14323,7 +14312,6 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
-        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -16675,7 +16663,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
-        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -16691,7 +16678,6 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
-        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -19058,7 +19044,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
-        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -19089,7 +19074,6 @@ exports[`SnippetEditor passes replacement variables to the title and description
         }
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
-        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -20129,7 +20113,6 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
       }
       descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionInputId="yoast-google-preview-description"
-      descriptionLabel="Meta description"
       descriptionLengthProgress={
         Object {
           "actual": 42,
@@ -20145,7 +20128,6 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
       replacementVariables={Array []}
       slugInputId="yoast-google-preview-slug"
       titleInputId="yoast-google-preview-title"
-      titleLabel="SEO title"
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -22000,7 +21982,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
-        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -22016,7 +21997,6 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
-        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,

--- a/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
+++ b/packages/search-metadata-previews/tests/__snapshots__/SnippetEditorTest.js.snap
@@ -470,6 +470,7 @@ exports[`SnippetEditor activates a field on onMouseUp() and opens the editor 1`]
       }
       descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionInputId="yoast-google-preview-description"
+      descriptionLabel="Meta description"
       descriptionLengthProgress={
         Object {
           "actual": 42,
@@ -485,6 +486,7 @@ exports[`SnippetEditor activates a field on onMouseUp() and opens the editor 1`]
       replacementVariables={Array []}
       slugInputId="yoast-google-preview-slug"
       titleInputId="yoast-google-preview-title"
+      titleLabel="SEO title"
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -2339,6 +2341,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
+        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -2354,6 +2357,7 @@ exports[`SnippetEditor closes when calling close() 1`] = `
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
+        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -6317,6 +6321,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
+        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -6332,6 +6337,7 @@ exports[`SnippetEditor colored progress bars can handle a score of 6 1`] = `
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
+        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -8683,6 +8689,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
+        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -8698,6 +8705,7 @@ exports[`SnippetEditor colored progress bars can handle scores of 3 and 9 1`] = 
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
+        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -11893,6 +11901,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
+        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -11908,6 +11917,7 @@ exports[`SnippetEditor highlights the active ReplacementVariableEditor when call
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
+        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -14297,6 +14307,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
+        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -14312,6 +14323,7 @@ exports[`SnippetEditor highlights the hovered field when onMouseEnter() is calle
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
+        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -16663,6 +16675,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
+        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -16678,6 +16691,7 @@ exports[`SnippetEditor opens when calling open() 1`] = `
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
+        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -19044,6 +19058,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
+        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -19074,6 +19089,7 @@ exports[`SnippetEditor passes replacement variables to the title and description
         }
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
+        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,
@@ -20113,6 +20129,7 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
       }
       descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
       descriptionInputId="yoast-google-preview-description"
+      descriptionLabel="Meta description"
       descriptionLengthProgress={
         Object {
           "actual": 42,
@@ -20128,6 +20145,7 @@ exports[`SnippetEditor removes the highlight from the hovered field on calling o
       replacementVariables={Array []}
       slugInputId="yoast-google-preview-slug"
       titleInputId="yoast-google-preview-title"
+      titleLabel="SEO title"
       titleLengthProgress={
         Object {
           "actual": 0,
@@ -21982,6 +22000,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
         }
         descriptionEditorFieldPlaceholder="Modify your meta description by editing it right here"
         descriptionInputId="yoast-google-preview-description"
+        descriptionLabel="Meta description"
         descriptionLengthProgress={
           Object {
             "actual": 42,
@@ -21997,6 +22016,7 @@ exports[`SnippetEditor removes the highlight when calling unsetFieldFocus 1`] = 
         replacementVariables={Array []}
         slugInputId="yoast-google-preview-slug"
         titleInputId="yoast-google-preview-title"
+        titleLabel="SEO title"
         titleLengthProgress={
           Object {
             "actual": 0,


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [replacement-variable-editor] Adds possibility to pass alternative labels for the SEO title and Meta description fields in the SettingsSnippetEditor.

## Relevant technical choices:

* This PR introduces a change that will be used in Yoast SEO. Testing this change can be done based on the PR that will be made in the plugin and this PR only 'enables' the possibility.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch and build accordingly.
* Use `yarn link-monorepo` to link the entire monorepo to your local Yoast SEO installation.
* Ensure your Yoast SEO installation is fully built (`composer install`, `yarn`, `grunt build`).
* Navigate to SEO -> Search Appearance -> Content Types.
* See that nothing has changed in the forms and the usual SEO title and Meta description labels are still present. This means that the default values are properly working.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Required for https://github.com/Yoast/wordpress-seo/pull/16806
