### PR TITLE
Show an orange bullet in the sidebar analysis when a recommended block is removed

### DIFF
--- a/packages/schema-blocks/src/core/Definition.ts
+++ b/packages/schema-blocks/src/core/Definition.ts
@@ -1,6 +1,6 @@
-import { BlockValidation, BlockValidationResult } from "./validation";
-import { BlockInstance } from "@wordpress/blocks";
-import { isArray, mergeWith } from "lodash";
+import {BlockValidation, BlockValidationResult} from "./validation";
+import {BlockInstance} from "@wordpress/blocks";
+import {isArray, mergeWith} from "lodash";
 import Instruction from "./Instruction";
 import Leaf from "./Leaf";
 import logger from "../functions/logger";

--- a/packages/schema-blocks/src/core/Definition.ts
+++ b/packages/schema-blocks/src/core/Definition.ts
@@ -4,6 +4,7 @@ import { isArray, mergeWith } from "lodash";
 import Instruction from "./Instruction";
 import Leaf from "./Leaf";
 import logger from "../functions/logger";
+import {BlockType} from "./validation/BlockValidationResult";
 
 export type DefinitionClass<T extends Definition> = {
 	new( separator: string, template?: string, instructions?: Record<string, Instruction>, tree?: Leaf ): T;
@@ -80,7 +81,7 @@ export default abstract class Definition {
 			return null;
 		}
 
-		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown );
+		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown, BlockType.Unknown );
 
 		logger.startGroup( `Validation results: ${ blockInstance.name }` );
 

--- a/packages/schema-blocks/src/core/Definition.ts
+++ b/packages/schema-blocks/src/core/Definition.ts
@@ -4,7 +4,7 @@ import { isArray, mergeWith } from "lodash";
 import Instruction from "./Instruction";
 import Leaf from "./Leaf";
 import logger from "../functions/logger";
-import { BlockType } from "./validation/BlockValidationResult";
+import { BlockPresence } from "./validation/BlockValidationResult";
 
 export type DefinitionClass<T extends Definition> = {
 	new( separator: string, template?: string, instructions?: Record<string, Instruction>, tree?: Leaf ): T;
@@ -81,7 +81,7 @@ export default abstract class Definition {
 			return null;
 		}
 
-		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown, BlockType.Unknown );
+		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown, BlockPresence.Unknown );
 
 		logger.startGroup( `Validation results: ${ blockInstance.name }` );
 

--- a/packages/schema-blocks/src/core/Definition.ts
+++ b/packages/schema-blocks/src/core/Definition.ts
@@ -1,10 +1,10 @@
-import {BlockValidation, BlockValidationResult} from "./validation";
-import {BlockInstance} from "@wordpress/blocks";
-import {isArray, mergeWith} from "lodash";
+import { BlockValidation, BlockValidationResult } from "./validation";
+import { BlockInstance } from "@wordpress/blocks";
+import { isArray, mergeWith } from "lodash";
 import Instruction from "./Instruction";
 import Leaf from "./Leaf";
 import logger from "../functions/logger";
-import {BlockType} from "./validation/BlockValidationResult";
+import { BlockType } from "./validation/BlockValidationResult";
 
 export type DefinitionClass<T extends Definition> = {
 	new( separator: string, template?: string, instructions?: Record<string, Instruction>, tree?: Leaf ): T;

--- a/packages/schema-blocks/src/core/Instruction.ts
+++ b/packages/schema-blocks/src/core/Instruction.ts
@@ -1,6 +1,7 @@
 import { BlockInstance } from "@wordpress/blocks";
 import logger from "../functions/logger";
 import { BlockValidationResult, BlockValidation } from "./validation";
+import {BlockType} from "./validation/BlockValidationResult";
 export type InstructionPrimitive = string | number | boolean;
 export type InstructionValue = InstructionPrimitive | InstructionObject | InstructionArray;
 export type InstructionArray = readonly InstructionValue[];
@@ -60,7 +61,7 @@ export default abstract class Instruction {
 	 * @returns {BlockValidationResult} The validation result.
 	 */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
-		return new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown );
+		return new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown, BlockType.Unknown );
 	}
 
 	/**

--- a/packages/schema-blocks/src/core/Instruction.ts
+++ b/packages/schema-blocks/src/core/Instruction.ts
@@ -1,7 +1,7 @@
 import { BlockInstance } from "@wordpress/blocks";
 import logger from "../functions/logger";
 import { BlockValidationResult, BlockValidation } from "./validation";
-import {BlockType} from "./validation/BlockValidationResult";
+import { BlockType } from "./validation/BlockValidationResult";
 export type InstructionPrimitive = string | number | boolean;
 export type InstructionValue = InstructionPrimitive | InstructionObject | InstructionArray;
 export type InstructionArray = readonly InstructionValue[];

--- a/packages/schema-blocks/src/core/Instruction.ts
+++ b/packages/schema-blocks/src/core/Instruction.ts
@@ -1,7 +1,7 @@
 import { BlockInstance } from "@wordpress/blocks";
 import logger from "../functions/logger";
 import { BlockValidationResult, BlockValidation } from "./validation";
-import { BlockType } from "./validation/BlockValidationResult";
+import { BlockPresence } from "./validation/BlockValidationResult";
 export type InstructionPrimitive = string | number | boolean;
 export type InstructionValue = InstructionPrimitive | InstructionObject | InstructionArray;
 export type InstructionArray = readonly InstructionValue[];
@@ -61,7 +61,7 @@ export default abstract class Instruction {
 	 * @returns {BlockValidationResult} The validation result.
 	 */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
-		return new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown, BlockType.Unknown );
+		return new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown, BlockPresence.Unknown );
 	}
 
 	/**

--- a/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
+++ b/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
@@ -7,6 +7,7 @@ import Instruction, { InstructionOptions } from "../Instruction";
 import { attributeExists, attributeNotEmpty } from "../../functions/validators";
 import validateMany from "../../functions/validators/validateMany";
 import logger from "../../functions/logger";
+import { BlockType } from "../validation/BlockValidationResult";
 
 export type BlockInstructionClass = {
 	new( id: number, options: InstructionOptions ): BlockInstruction;
@@ -78,16 +79,16 @@ export default abstract class BlockInstruction extends Instruction {
 	 * @returns {BlockValidationResult} The validation result.
 	 */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
-		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Skipped );
+		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Skipped, BlockType.Unknown );
 
 		if ( this.options && this.options.required === true ) {
 			const attributeValid = attributeExists( blockInstance, this.options.name as string ) &&
 						           attributeNotEmpty( blockInstance, this.options.name as string );
 			if ( attributeValid ) {
-				validation.issues.push( new BlockValidationResult( blockInstance.clientId, this.options.name, BlockValidation.Valid ) );
+				validation.issues.push( new BlockValidationResult( blockInstance.clientId, this.options.name, BlockValidation.Valid, BlockType.Unknown ) );
 			} else {
 				logger.warning( "block " + blockInstance.name + " has a required attributes " + this.options.name + " but it is missing or empty" );
-				validation.issues.push( new BlockValidationResult( blockInstance.clientId, this.options.name, BlockValidation.MissingAttribute ) );
+				validation.issues.push( new BlockValidationResult( blockInstance.clientId, this.options.name, BlockValidation.MissingAttribute, BlockType.Unknown ) );
 				validation.result = BlockValidation.Invalid;
 			}
 		} else {

--- a/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
+++ b/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
@@ -1,10 +1,10 @@
 import BlockLeaf from "./BlockLeaf";
-import { RenderSaveProps, RenderEditProps } from "./BlockDefinition";
-import { ReactElement } from "@wordpress/element";
-import { BlockConfiguration, BlockInstance } from "@wordpress/blocks";
-import { BlockValidationResult, BlockValidation } from "../validation";
-import Instruction, { InstructionOptions } from "../Instruction";
-import { attributeExists, attributeNotEmpty } from "../../functions/validators";
+import {RenderEditProps, RenderSaveProps} from "./BlockDefinition";
+import {ReactElement} from "@wordpress/element";
+import {BlockConfiguration, BlockInstance} from "@wordpress/blocks";
+import {BlockValidation, BlockValidationResult} from "../validation";
+import Instruction, {InstructionOptions} from "../Instruction";
+import {attributeExists, attributeNotEmpty} from "../../functions/validators";
 import validateMany from "../../functions/validators/validateMany";
 import logger from "../../functions/logger";
 import { BlockType } from "../validation/BlockValidationResult";

--- a/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
+++ b/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
@@ -85,10 +85,12 @@ export default abstract class BlockInstruction extends Instruction {
 			const attributeValid = attributeExists( blockInstance, this.options.name as string ) &&
 						           attributeNotEmpty( blockInstance, this.options.name as string );
 			if ( attributeValid ) {
-				validation.issues.push( new BlockValidationResult( blockInstance.clientId, this.options.name, BlockValidation.Valid, BlockType.Unknown ) );
+				validation.issues.push( new BlockValidationResult( blockInstance.clientId, this.options.name,
+					BlockValidation.Valid, BlockType.Unknown ) );
 			} else {
 				logger.warning( "block " + blockInstance.name + " has a required attributes " + this.options.name + " but it is missing or empty" );
-				validation.issues.push( new BlockValidationResult( blockInstance.clientId, this.options.name, BlockValidation.MissingAttribute, BlockType.Unknown ) );
+				validation.issues.push( new BlockValidationResult( blockInstance.clientId, this.options.name,
+					BlockValidation.MissingAttribute, BlockType.Unknown ) );
 				validation.result = BlockValidation.Invalid;
 			}
 		} else {

--- a/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
+++ b/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
@@ -1,10 +1,10 @@
 import BlockLeaf from "./BlockLeaf";
-import {RenderEditProps, RenderSaveProps} from "./BlockDefinition";
-import {ReactElement} from "@wordpress/element";
-import {BlockConfiguration, BlockInstance} from "@wordpress/blocks";
-import {BlockValidation, BlockValidationResult} from "../validation";
-import Instruction, {InstructionOptions} from "../Instruction";
-import {attributeExists, attributeNotEmpty} from "../../functions/validators";
+import { RenderEditProps, RenderSaveProps } from "./BlockDefinition";
+import { ReactElement } from "@wordpress/element";
+import { BlockConfiguration, BlockInstance } from "@wordpress/blocks";
+import { BlockValidation, BlockValidationResult } from "../validation";
+import Instruction, { InstructionOptions } from "../Instruction";
+import { attributeExists, attributeNotEmpty } from "../../functions/validators";
 import validateMany from "../../functions/validators/validateMany";
 import logger from "../../functions/logger";
 import { BlockType } from "../validation/BlockValidationResult";

--- a/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
+++ b/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
@@ -7,7 +7,7 @@ import Instruction, { InstructionOptions } from "../Instruction";
 import { attributeExists, attributeNotEmpty } from "../../functions/validators";
 import validateMany from "../../functions/validators/validateMany";
 import logger from "../../functions/logger";
-import { BlockType } from "../validation/BlockValidationResult";
+import { BlockPresence } from "../validation/BlockValidationResult";
 
 export type BlockInstructionClass = {
 	new( id: number, options: InstructionOptions ): BlockInstruction;
@@ -79,18 +79,18 @@ export default abstract class BlockInstruction extends Instruction {
 	 * @returns {BlockValidationResult} The validation result.
 	 */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
-		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Skipped, BlockType.Unknown );
+		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Skipped, BlockPresence.Unknown );
 
 		if ( this.options && this.options.required === true ) {
 			const attributeValid = attributeExists( blockInstance, this.options.name as string ) &&
 						           attributeNotEmpty( blockInstance, this.options.name as string );
 			if ( attributeValid ) {
 				validation.issues.push( new BlockValidationResult( blockInstance.clientId, this.options.name,
-					BlockValidation.Valid, BlockType.Unknown ) );
+					BlockValidation.Valid, BlockPresence.Unknown ) );
 			} else {
 				logger.warning( "block " + blockInstance.name + " has a required attributes " + this.options.name + " but it is missing or empty" );
 				validation.issues.push( new BlockValidationResult( blockInstance.clientId, this.options.name,
-					BlockValidation.MissingAttribute, BlockType.Unknown ) );
+					BlockValidation.MissingAttribute, BlockPresence.Unknown ) );
 				validation.result = BlockValidation.Invalid;
 			}
 		} else {

--- a/packages/schema-blocks/src/core/schema/SchemaInstruction.ts
+++ b/packages/schema-blocks/src/core/schema/SchemaInstruction.ts
@@ -2,6 +2,7 @@ import { SchemaValue, SchemaDefinitionConfiguration } from "./SchemaDefinition";
 import Instruction, { InstructionOptions } from "../Instruction";
 import { BlockInstance } from "@wordpress/blocks";
 import { BlockValidation, BlockValidationResult } from "../validation";
+import { BlockType } from "../validation/BlockValidationResult";
 
 export type SchemaInstructionClass = { new( id: number, options: InstructionOptions ): SchemaInstruction };
 
@@ -39,6 +40,6 @@ export default abstract class SchemaInstruction extends Instruction {
 	 * @returns {BlockValidationResult} The validation results.
 	 */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
-		return new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Valid );
+		return new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Valid, BlockType.Unknown );
 	}
 }

--- a/packages/schema-blocks/src/core/schema/SchemaInstruction.ts
+++ b/packages/schema-blocks/src/core/schema/SchemaInstruction.ts
@@ -1,4 +1,4 @@
-import { SchemaValue, SchemaDefinitionConfiguration } from "./SchemaDefinition";
+import { SchemaDefinitionConfiguration, SchemaValue } from "./SchemaDefinition";
 import Instruction, { InstructionOptions } from "../Instruction";
 import { BlockInstance } from "@wordpress/blocks";
 import { BlockValidation, BlockValidationResult } from "../validation";

--- a/packages/schema-blocks/src/core/schema/SchemaInstruction.ts
+++ b/packages/schema-blocks/src/core/schema/SchemaInstruction.ts
@@ -2,7 +2,7 @@ import { SchemaDefinitionConfiguration, SchemaValue } from "./SchemaDefinition";
 import Instruction, { InstructionOptions } from "../Instruction";
 import { BlockInstance } from "@wordpress/blocks";
 import { BlockValidation, BlockValidationResult } from "../validation";
-import { BlockType } from "../validation/BlockValidationResult";
+import { BlockPresence } from "../validation/BlockValidationResult";
 
 export type SchemaInstructionClass = { new( id: number, options: InstructionOptions ): SchemaInstruction };
 
@@ -40,6 +40,6 @@ export default abstract class SchemaInstruction extends Instruction {
 	 * @returns {BlockValidationResult} The validation results.
 	 */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
-		return new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Valid, BlockType.Unknown );
+		return new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Valid, BlockPresence.Unknown );
 	}
 }

--- a/packages/schema-blocks/src/core/validation/BlockValidation.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidation.ts
@@ -1,4 +1,3 @@
-
 export enum BlockValidation {
 	/** This block was skipped during validation, on purpose. If you ever see this value, that's a bug.  */
 	Skipped = -2,

--- a/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
@@ -2,10 +2,10 @@ import { BlockValidation } from ".";
 import { BlockInstance } from "@wordpress/blocks";
 
 export enum BlockType {
-	Required,
-	Recommended,
-	Optional,
-	Unknown
+	Required = "REQUIRED",
+	Recommended = "RECOMMENDED",
+	Optional = "OPTIONAL",
+	Unknown = "UNKNOWN"
 }
 
 /**

--- a/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
@@ -1,6 +1,13 @@
 import { BlockValidation } from ".";
 import { BlockInstance } from "@wordpress/blocks";
 
+export enum BlockType {
+	Required,
+	Recommended,
+	Optional,
+	Unknown
+}
+
 /**
  * Contains the result of a block validation.
  */
@@ -21,6 +28,11 @@ export class BlockValidationResult {
 	public result: BlockValidation;
 
 	/**
+	 * The block type.
+	 */
+	public blockType: BlockType;
+
+	/**
 	 * The validation issues for this block's innerblocks or attributes, if any.
 	 */
 	public issues: BlockValidationResult[]
@@ -29,11 +41,13 @@ export class BlockValidationResult {
 	 * @param clientId The clientId of the validated block.
 	 * @param name     The name of the validated block.
 	 * @param result   The validation result.
+	 * @param blockType
 	 */
-	constructor( clientId: string, name: string, result: BlockValidation ) {
-		this.name = name;
+	constructor( clientId: string, name: string, result: BlockValidation, blockType: BlockType ) {
 		this.clientId = clientId;
+		this.name = name;
 		this.result = result;
+		this.blockType = blockType;
 		this.issues = [];
 	}
 
@@ -50,6 +64,7 @@ export class BlockValidationResult {
 			blockInstance.clientId,
 			name || blockInstance.name,
 			BlockValidation.MissingAttribute,
+			BlockType.Unknown,
 		);
 	}
 
@@ -66,6 +81,7 @@ export class BlockValidationResult {
 			blockInstance.clientId,
 			name || blockInstance.name,
 			BlockValidation.Valid,
+			BlockType.Unknown,
 		);
 	}
 }

--- a/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
@@ -16,7 +16,7 @@ export class BlockValidationResult {
 	public clientId: string;
 
 	/**
-	 * The validation result;
+	 * The validation result.
 	 */
 	public result: BlockValidation;
 

--- a/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
@@ -1,7 +1,7 @@
 import { BlockValidation } from ".";
 import { BlockInstance } from "@wordpress/blocks";
 
-export enum BlockType {
+export enum BlockPresence {
 	Required = "required",
 	Recommended = "recommended",
 	Optional = "optional",
@@ -28,9 +28,9 @@ export class BlockValidationResult {
 	public result: BlockValidation;
 
 	/**
-	 * The block type.
+	 * The block presence.
 	 */
-	public blockType: BlockType;
+	public blockPresence: BlockPresence;
 
 	/**
 	 * The validation issues for this block's innerblocks or attributes, if any.
@@ -41,13 +41,13 @@ export class BlockValidationResult {
 	 * @param clientId  The clientId of the validated block.
 	 * @param name      The name of the validated block.
 	 * @param result    The validation result.
-	 * @param blockType The block type.
+	 * @param blockPresence The block type.
 	 */
-	constructor( clientId: string, name: string, result: BlockValidation, blockType: BlockType ) {
+	constructor( clientId: string, name: string, result: BlockValidation, blockPresence: BlockPresence ) {
 		this.clientId = clientId;
 		this.name = name;
 		this.result = result;
-		this.blockType = blockType;
+		this.blockPresence = blockPresence;
 		this.issues = [];
 	}
 
@@ -64,7 +64,7 @@ export class BlockValidationResult {
 			blockInstance.clientId,
 			name || blockInstance.name,
 			BlockValidation.MissingAttribute,
-			BlockType.Unknown,
+			BlockPresence.Unknown,
 		);
 	}
 
@@ -81,7 +81,7 @@ export class BlockValidationResult {
 			blockInstance.clientId,
 			name || blockInstance.name,
 			BlockValidation.Valid,
-			BlockType.Unknown,
+			BlockPresence.Unknown,
 		);
 	}
 }

--- a/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
@@ -2,10 +2,10 @@ import { BlockValidation } from ".";
 import { BlockInstance } from "@wordpress/blocks";
 
 export enum BlockType {
-	Required = "REQUIRED",
-	Recommended = "RECOMMENDED",
-	Optional = "OPTIONAL",
-	Unknown = "UNKNOWN"
+	Required = "required",
+	Recommended = "recommended",
+	Optional = "optional",
+	Unknown = "unknown"
 }
 
 /**

--- a/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
@@ -38,10 +38,10 @@ export class BlockValidationResult {
 	public issues: BlockValidationResult[]
 
 	/**
-	 * @param clientId The clientId of the validated block.
-	 * @param name     The name of the validated block.
-	 * @param result   The validation result.
-	 * @param blockType
+	 * @param clientId  The clientId of the validated block.
+	 * @param name      The name of the validated block.
+	 * @param result    The validation result.
+	 * @param blockType The block type.
 	 */
 	constructor( clientId: string, name: string, result: BlockValidation, blockType: BlockType ) {
 		this.clientId = clientId;

--- a/packages/schema-blocks/src/core/validation/RecommendedBlock.ts
+++ b/packages/schema-blocks/src/core/validation/RecommendedBlock.ts
@@ -1,5 +1,6 @@
 import { InstructionOptions } from "../Instruction";
 import { SuggestedBlockProperties } from "./SuggestedBlockProperties";
+import { RequiredBlockOption } from "./RequiredBlockOption";
 
 /**
  * Defines a recommended innerblock.
@@ -7,4 +8,5 @@ import { SuggestedBlockProperties } from "./SuggestedBlockProperties";
 export type RecommendedBlock = InstructionOptions & SuggestedBlockProperties & {
 	name: string;
 	warning?: string;
+	option: RequiredBlockOption;
 }

--- a/packages/schema-blocks/src/core/validation/RecommendedBlock.ts
+++ b/packages/schema-blocks/src/core/validation/RecommendedBlock.ts
@@ -1,6 +1,6 @@
 import { InstructionOptions } from "../Instruction";
-import { SuggestedBlockProperties } from "./SuggestedBlockProperties";
 import { RequiredBlockOption } from "./RequiredBlockOption";
+import { SuggestedBlockProperties } from "./SuggestedBlockProperties";
 
 /**
  * Defines a recommended innerblock.

--- a/packages/schema-blocks/src/core/validation/RecommendedBlock.ts
+++ b/packages/schema-blocks/src/core/validation/RecommendedBlock.ts
@@ -1,5 +1,4 @@
 import { InstructionOptions } from "../Instruction";
-import { RequiredBlockOption } from "./RequiredBlockOption";
 import { SuggestedBlockProperties } from "./SuggestedBlockProperties";
 
 /**
@@ -8,5 +7,4 @@ import { SuggestedBlockProperties } from "./SuggestedBlockProperties";
 export type RecommendedBlock = InstructionOptions & SuggestedBlockProperties & {
 	name: string;
 	warning?: string;
-	option: RequiredBlockOption;
 }

--- a/packages/schema-blocks/src/core/validation/RequiredBlock.ts
+++ b/packages/schema-blocks/src/core/validation/RequiredBlock.ts
@@ -1,5 +1,5 @@
-import { RequiredBlockOption } from ".";
 import { InstructionOptions } from "../Instruction";
+import { RequiredBlockOption } from ".";
 import { SuggestedBlockProperties } from "./SuggestedBlockProperties";
 
 /**

--- a/packages/schema-blocks/src/functions/gutenberg/watch.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watch.ts
@@ -7,6 +7,7 @@ import { getBlockDefinition } from "../../core/blocks/BlockDefinitionRepository"
 import { BlockValidation, BlockValidationResult } from "../../core/validation";
 import storeBlockValidation from "./storeBlockValidation";
 import logger from "../logger";
+import {BlockType} from "../../core/validation/BlockValidationResult";
 
 let updatingSchema = false;
 let previousRootBlocks: BlockInstance[];
@@ -104,7 +105,7 @@ export function validateBlocks( blocks: BlockInstance[] ): BlockValidationResult
 			validations.push( definition.validate( block ) );
 		} else {
 			logger.warning( "Unable to validate block of type [" + block.name + "] " + block.clientId );
-			validations.push( new BlockValidationResult( block.clientId, block.name, BlockValidation.Unknown ) );
+			validations.push( new BlockValidationResult( block.clientId, block.name, BlockValidation.Unknown, BlockType.Unknown ) );
 
 			// Recursively validate all blocks' innerblocks.
 			if ( block.innerBlocks && block.innerBlocks.length > 0 ) {

--- a/packages/schema-blocks/src/functions/gutenberg/watch.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watch.ts
@@ -7,7 +7,7 @@ import { getBlockDefinition } from "../../core/blocks/BlockDefinitionRepository"
 import { BlockValidation, BlockValidationResult } from "../../core/validation";
 import storeBlockValidation from "./storeBlockValidation";
 import logger from "../logger";
-import { BlockType } from "../../core/validation/BlockValidationResult";
+import { BlockPresence } from "../../core/validation/BlockValidationResult";
 
 let updatingSchema = false;
 let previousRootBlocks: BlockInstance[];
@@ -105,7 +105,7 @@ export function validateBlocks( blocks: BlockInstance[] ): BlockValidationResult
 			validations.push( definition.validate( block ) );
 		} else {
 			logger.warning( "Unable to validate block of type [" + block.name + "] " + block.clientId );
-			validations.push( new BlockValidationResult( block.clientId, block.name, BlockValidation.Unknown, BlockType.Unknown ) );
+			validations.push( new BlockValidationResult( block.clientId, block.name, BlockValidation.Unknown, BlockPresence.Unknown ) );
 
 			// Recursively validate all blocks' innerblocks.
 			if ( block.innerBlocks && block.innerBlocks.length > 0 ) {

--- a/packages/schema-blocks/src/functions/gutenberg/watch.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watch.ts
@@ -7,7 +7,7 @@ import { getBlockDefinition } from "../../core/blocks/BlockDefinitionRepository"
 import { BlockValidation, BlockValidationResult } from "../../core/validation";
 import storeBlockValidation from "./storeBlockValidation";
 import logger from "../logger";
-import {BlockType} from "../../core/validation/BlockValidationResult";
+import { BlockType } from "../../core/validation/BlockValidationResult";
 
 let updatingSchema = false;
 let previousRootBlocks: BlockInstance[];

--- a/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebarPresenter.tsx
+++ b/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebarPresenter.tsx
@@ -11,7 +11,7 @@ import { SvgIcon } from "@yoast/components";
  * Renders warnings and appenders for any block's InnerBlocks.
  *
  * @param currentBlock The innerblocks instance.
- * @param options The InnerBlocksInstructionOptions of the innerblock.
+ * @param options      The InnerBlocksInstructionOptions of the innerblock.
  *
  * @returns {ReactElement[]} React Elements representing the sidebar elements for these innerblocks.
  */

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -4,6 +4,7 @@ import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 import { BlockValidationResult } from "../../core/validation";
 import { BlockValidation } from "../../core/validation";
+import { BlockType } from "../../core/validation/BlockValidationResult";
 
 const analysisMessageTemplates: Record<number, string> = {
 	[ BlockValidation.MissingBlock ]: "The '{child}' block is {status} but missing.",
@@ -114,10 +115,11 @@ export function createAnalysisMessages( validation: BlockValidationResult ): sid
 			name: sanitizeBlockName( issue.name ),
 			parent: sanitizeParentName( parent ),
 			result: issue.result,
-			status: "required",
+			status: issue.blockType,
 		} ) );
+
 	const messages = messageData.map( msg => {
-		return { text: replaceVariables( msg ), color: "red" } as sidebarWarning;
+		return { text: replaceVariables( msg ), color: ( msg.status === BlockType.Recommended ? "orange" : "red" ) } as sidebarWarning;
 	} );
 
 	const conclusion = getAnalysisConclusion( validation.result, messageData );

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -94,7 +94,7 @@ function getAnalysisConclusion( validation: BlockValidation, issues: analysisIss
  *
  * @param validation The root validation result.
  *
- * @return all validation results.
+ * @return All validation results.
  */
 function getAllDescendantIssues( validation: BlockValidationResult ): BlockValidationResult[] {
 	let results = [ validation ];

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -4,7 +4,7 @@ import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 import { BlockValidationResult } from "../../core/validation";
 import { BlockValidation } from "../../core/validation";
-import { BlockType } from "../../core/validation/BlockValidationResult";
+import { BlockPresence } from "../../core/validation/BlockValidationResult";
 
 const analysisMessageTemplates: Record<number, string> = {
 	[ BlockValidation.MissingBlock ]: "The '{child}' block is {status} but missing.",
@@ -65,7 +65,7 @@ export function replaceVariables( issue: analysisIssue ): string {
  */
 function getAnalysisConclusion( validation: BlockValidation, issues: analysisIssue[] ): sidebarWarning {
 	// Show a red bullet when not all required blocks have been completed.
-	if ( issues.some( issue => issue.result === BlockValidation.MissingBlock && issue.status === BlockType.Required ||
+	if ( issues.some( issue => issue.result === BlockValidation.MissingBlock && issue.status === BlockPresence.Required ||
 		issue.result === BlockValidation.MissingAttribute ) ) {
 		return {
 			text: __( "Not all required blocks have been completed! No " + issues[ 0 ].parent +
@@ -76,7 +76,7 @@ function getAnalysisConclusion( validation: BlockValidation, issues: analysisIss
 
 	// Show a green bullet when all required blocks have been completed.
 	const requiredBlockIssues = issues.filter( issue => {
-		return issue.status === BlockType.Required;
+		return issue.status === BlockPresence.Required;
 	} );
 
 	if ( validation === BlockValidation.Valid ||
@@ -121,11 +121,11 @@ export function createAnalysisMessages( validation: BlockValidationResult ): sid
 			name: sanitizeBlockName( issue.name ),
 			parent: sanitizeParentName( parent ),
 			result: issue.result,
-			status: issue.blockType,
+			status: issue.blockPresence,
 		} ) );
 
 	const messages = messageData.map( msg => {
-		return { text: replaceVariables( msg ), color: ( msg.status === BlockType.Recommended ? "orange" : "red" ) } as sidebarWarning;
+		return { text: replaceVariables( msg ), color: ( msg.status === BlockPresence.Recommended ? "orange" : "red" ) } as sidebarWarning;
 	} );
 
 	const conclusion = getAnalysisConclusion( validation.result, messageData );

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -68,7 +68,7 @@ function getAnalysisConclusion( validation: BlockValidation, issues: analysisIss
 	if ( issues.some( issue => issue.result === BlockValidation.MissingBlock && issue.status === BlockType.Required ||
 		issue.result === BlockValidation.MissingAttribute ) ) {
 		return {
-			text: __( "Not all required blocks are completed! No " + issues[ 0 ].parent +
+			text: __( "Not all required blocks have been completed! No " + issues[ 0 ].parent +
 				" schema will be generated for your page.", "wpseo-schema-blocks" ),
 			color: "red",
 		} as sidebarWarning;
@@ -83,7 +83,7 @@ function getAnalysisConclusion( validation: BlockValidation, issues: analysisIss
 		requiredIssues.every( issue => issue.result !== BlockValidation.MissingAttribute &&
 			issue.result !== BlockValidation.MissingBlock ) ) {
 		return {
-			text: __( "Good job! All required blocks are completed.", "wpseo-schema-blocks" ),
+			text: __( "Good job! All required blocks have been completed.", "wpseo-schema-blocks" ),
 			color: "green",
 		} as sidebarWarning;
 	}

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -75,12 +75,12 @@ function getAnalysisConclusion( validation: BlockValidation, issues: analysisIss
 	}
 
 	// Show a green bullet when all required blocks have been completed.
-	const requiredIssues = issues.filter( issue => {
+	const requiredBlockIssues = issues.filter( issue => {
 		return issue.status === BlockType.Required;
 	} );
 
 	if ( validation === BlockValidation.Valid ||
-		requiredIssues.every( issue => issue.result !== BlockValidation.MissingAttribute &&
+		requiredBlockIssues.every( issue => issue.result !== BlockValidation.MissingAttribute &&
 			issue.result !== BlockValidation.MissingBlock ) ) {
 		return {
 			text: __( "Good job! All required blocks have been completed.", "wpseo-schema-blocks" ),

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -64,7 +64,8 @@ export function replaceVariables( issue: analysisIssue ): string {
  * @returns {sidebarWarning} Any analysis conclusions that should be in the footer.
  */
 function getAnalysisConclusion( validation: BlockValidation, issues: analysisIssue[] ): sidebarWarning {
-	if ( issues.some( issue => issue.result === BlockValidation.MissingBlock ||
+	// Show a red bullet when not all required blocks have been completed.
+	if ( issues.some( issue => issue.result === BlockValidation.MissingBlock && issue.status === BlockType.Required ||
 		issue.result === BlockValidation.MissingAttribute ) ) {
 		return {
 			text: __( "Not all required blocks are completed! No " + issues[ 0 ].parent +
@@ -73,8 +74,13 @@ function getAnalysisConclusion( validation: BlockValidation, issues: analysisIss
 		} as sidebarWarning;
 	}
 
+	// Show a green bullet when all required blocks have been completed.
+	const requiredIssues = issues.filter( issue => {
+		return issue.status === BlockType.Required;
+	} );
+
 	if ( validation === BlockValidation.Valid ||
-		issues.every( issue => issue.result !== BlockValidation.MissingAttribute &&
+		requiredIssues.every( issue => issue.result !== BlockValidation.MissingAttribute &&
 			issue.result !== BlockValidation.MissingBlock ) ) {
 		return {
 			text: __( "Good job! All required blocks are completed.", "wpseo-schema-blocks" ),

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -7,7 +7,7 @@ import { BlockValidation } from "../../core/validation";
 import { BlockPresence } from "../../core/validation/BlockValidationResult";
 
 const analysisMessageTemplates: Record<number, string> = {
-	[ BlockValidation.MissingBlock ]: "The '{child}' block is {status} but missing.",
+	[ BlockValidation.MissingBlock ]: "The '{child}' block is {presence} but missing.",
 	[ BlockValidation.MissingAttribute ]: "The '{child}' block is empty.",
 };
 
@@ -17,7 +17,7 @@ type analysisIssue = {
 	name: string;
 	parent: string;
 	result: BlockValidation;
-	status: string;
+	presence: string;
 };
 
 export type sidebarWarning = {
@@ -52,7 +52,7 @@ export function replaceVariables( issue: analysisIssue ): string {
 	const warning = get( analysisMessageTemplates, issue.result, "" );
 	return warning.replace( "{parent}", __( issue.parent, "wpseo-schema-blocks" ) )
 		.replace( "{child}", __( issue.name, "wpseo-schema-blocks" ) )
-		.replace( "{status}", __( issue.status, "wpseo-schema-blocks" ) );
+		.replace( "{presence}", __( issue.presence, "wpseo-schema-blocks" ) );
 }
 
 /**
@@ -65,7 +65,7 @@ export function replaceVariables( issue: analysisIssue ): string {
  */
 function getAnalysisConclusion( validation: BlockValidation, issues: analysisIssue[] ): sidebarWarning {
 	// Show a red bullet when not all required blocks have been completed.
-	if ( issues.some( issue => issue.result === BlockValidation.MissingBlock && issue.status === BlockPresence.Required ||
+	if ( issues.some( issue => issue.result === BlockValidation.MissingBlock && issue.presence === BlockPresence.Required ||
 		issue.result === BlockValidation.MissingAttribute ) ) {
 		return {
 			text: __( "Not all required blocks have been completed! No " + issues[ 0 ].parent +
@@ -76,7 +76,7 @@ function getAnalysisConclusion( validation: BlockValidation, issues: analysisIss
 
 	// Show a green bullet when all required blocks have been completed.
 	const requiredBlockIssues = issues.filter( issue => {
-		return issue.status === BlockPresence.Required;
+		return issue.presence === BlockPresence.Required;
 	} );
 
 	if ( validation === BlockValidation.Valid ||
@@ -121,11 +121,11 @@ export function createAnalysisMessages( validation: BlockValidationResult ): sid
 			name: sanitizeBlockName( issue.name ),
 			parent: sanitizeParentName( parent ),
 			result: issue.result,
-			status: issue.blockPresence,
+			presence: issue.blockPresence,
 		} ) );
 
 	const messages = messageData.map( msg => {
-		return { text: replaceVariables( msg ), color: ( msg.status === BlockPresence.Recommended ? "orange" : "red" ) } as sidebarWarning;
+		return { text: replaceVariables( msg ), color: ( msg.presence === BlockPresence.Recommended ? "orange" : "red" ) } as sidebarWarning;
 	} );
 
 	const conclusion = getAnalysisConclusion( validation.result, messageData );

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -12,6 +12,7 @@ import recurseOverBlocks from "../blocks/recurseOverBlocks";
 import { getInnerblocksByName } from "../innerBlocksHelper";
 import logger from "../logger";
 import isValidResult from "./isValidResult";
+import { BlockType } from "../../core/validation/BlockValidationResult";
 
 /**
  * Finds all blocks that should be in the inner blocks, but aren't.
@@ -29,7 +30,7 @@ function findMissingBlocks( existingRequiredBlocks: BlockInstance[], requiredBlo
 
 	// These blocks should've existed, but they don't.
 	return missingRequiredBlocks.map( missingBlock =>
-		new BlockValidationResult( null, missingBlock.name, BlockValidation.MissingBlock ) );
+		new BlockValidationResult( null, missingBlock.name, BlockValidation.MissingBlock, BlockType.Unknown ) );
 }
 
 /**
@@ -56,7 +57,7 @@ function findRedundantBlocks( existingRequiredBlocks: BlockInstance[], requiredB
 
 			existingSingletons.forEach( ( block: BlockInstance ) => {
 				if ( block.name === blockName ) {
-					validationResults.push( new BlockValidationResult( block.clientId, blockName, BlockValidation.TooMany ) );
+					validationResults.push( new BlockValidationResult( block.clientId, blockName, BlockValidation.TooMany, BlockType.Unknown ) );
 				}
 			} );
 		}
@@ -82,7 +83,7 @@ function validateInnerblockTree( blockInstance: BlockInstance ): BlockValidation
 			validations.push( definition.validate( block ) );
 		} else {
 			logger.warning( "Block definition for '" + block.name + "' is not registered." );
-			validations.push( new BlockValidationResult( block.clientId, block.name, BlockValidation.Unknown ) );
+			validations.push( new BlockValidationResult( block.clientId, block.name, BlockValidation.Unknown, BlockType.Unknown ) );
 		}
 	} );
 	return validations;

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -17,16 +17,16 @@ import { BlockType } from "../../core/validation/BlockValidationResult";
 /**
  * Finds all blocks that should/could be in the inner blocks, but aren't.
  *
- * @param existingBlocks The actual array of all inner blocks.
- * @param possibleBlocks All of the blocks that should occur (required), or could occur (recommended) in the inner blocks.
- * @param blockType      The block type.
+ * @param existingBlocksOfType The actual array of all inner blocks.
+ * @param allBlocksOfType      All of the blocks that should occur (required), or could occur (recommended) in the inner blocks.
+ * @param blockType            The block type.
  *
  * @returns {BlockValidationResult[]} The names of blocks that should/could occur but don't, with reason 'MissingBlock'.
  */
-function findMissingBlocks( existingBlocks: BlockInstance[], possibleBlocks: RequiredBlock[], blockType: BlockType ): BlockValidationResult[] {
-	const missingBlocks = possibleBlocks.filter( possibleBlock => {
-		// If there are not any blocks with the name of a possible block, that possible block is missing.
-		return ! existingBlocks.some( block => block.name === possibleBlock.name );
+function findMissingBlocks( existingBlocksOfType: BlockInstance[], allBlocksOfType: RequiredBlock[], blockType: BlockType ): BlockValidationResult[] {
+	const missingBlocks = allBlocksOfType.filter( blockOfType => {
+		// If, in the existing blocks, there are not any blocks with the name of blockOfType, that block is missing.
+		return ! existingBlocksOfType.some( block => block.name === blockOfType.name );
 	} );
 
 	// These blocks should've existed, but they don't.
@@ -108,7 +108,7 @@ function validateInnerBlocks( blockInstance: BlockInstance, requiredBlocks: Requ
 	// Find all instances of required block types.
 	const existingRequiredBlocks = getInnerblocksByName( blockInstance, requiredBlockKeys );
 
-	// Find all required block types that do not occur in existingBlocks.
+	// Find all required block types that do not occur in existingRequiredBlocks.
 	validationResults.push( ...findMissingBlocks( existingRequiredBlocks, requiredBlocks, BlockType.Required ) );
 
 	// Find all required block types that allow only one occurrence.
@@ -117,7 +117,7 @@ function validateInnerBlocks( blockInstance: BlockInstance, requiredBlocks: Requ
 	// Find all instances of recommended block types.
 	const existingRecommendedBlocks = getInnerblocksByName( blockInstance, recommendedBlockKeys );
 
-	// Find all required block types that do not occur in existingBlocks.
+	// Find all recommended block types that do not occur in existingRecommendedBlocks.
 	validationResults.push( ...findMissingBlocks( existingRecommendedBlocks, recommendedBlocks, BlockType.Recommended ) );
 
 	// Let all innerblocks validate themselves.

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -19,10 +19,11 @@ import { BlockType } from "../../core/validation/BlockValidationResult";
  *
  * @param existingBlocks The actual array of all inner blocks.
  * @param possibleBlocks All of the blocks that should occur (required), or could occur (recommended) in the inner blocks.
+ * @param blockType      The block type.
  *
  * @returns {BlockValidationResult[]} The names of blocks that should/could occur but don't, with reason 'MissingBlock'.
  */
-function findMissingBlocks( existingBlocks: BlockInstance[], possibleBlocks: RequiredBlock[] ): BlockValidationResult[] {
+function findMissingBlocks( existingBlocks: BlockInstance[], possibleBlocks: RequiredBlock[], blockType: BlockType ): BlockValidationResult[] {
 	const missingBlocks = possibleBlocks.filter( possibleBlock => {
 		// If there are not any blocks with the name of a possible block, that possible block is missing.
 		return ! existingBlocks.some( block => block.name === possibleBlock.name );
@@ -30,7 +31,7 @@ function findMissingBlocks( existingBlocks: BlockInstance[], possibleBlocks: Req
 
 	// These blocks should've existed, but they don't.
 	return missingBlocks.map( missingBlock =>
-		new BlockValidationResult( null, missingBlock.name, BlockValidation.MissingBlock, BlockType.Unknown ) );
+		new BlockValidationResult( null, missingBlock.name, BlockValidation.MissingBlock, blockType ) );
 }
 
 /**
@@ -108,7 +109,7 @@ function validateInnerBlocks( blockInstance: BlockInstance, requiredBlocks: Requ
 	const existingRequiredBlocks = getInnerblocksByName( blockInstance, requiredBlockKeys );
 
 	// Find all required block types that do not occur in existingBlocks.
-	validationResults.push( ...findMissingBlocks( existingRequiredBlocks, requiredBlocks ) );
+	validationResults.push( ...findMissingBlocks( existingRequiredBlocks, requiredBlocks, BlockType.Required ) );
 
 	// Find all required block types that allow only one occurrence.
 	validationResults.push( ...findRedundantBlocks( existingRequiredBlocks, requiredBlocks ) );
@@ -117,7 +118,7 @@ function validateInnerBlocks( blockInstance: BlockInstance, requiredBlocks: Requ
 	const existingRecommendedBlocks = getInnerblocksByName( blockInstance, recommendedBlockKeys );
 
 	// Find all required block types that do not occur in existingBlocks.
-	validationResults.push( ...findMissingBlocks( existingRecommendedBlocks, recommendedBlocks ) );
+	validationResults.push( ...findMissingBlocks( existingRecommendedBlocks, recommendedBlocks, BlockType.Recommended ) );
 
 	// Let all innerblocks validate themselves.
 	// We differentiate between blocks that are internally valid but are not valid in the context of the innerblock.

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -15,21 +15,21 @@ import isValidResult from "./isValidResult";
 import { BlockType } from "../../core/validation/BlockValidationResult";
 
 /**
- * Finds all blocks that should be in the inner blocks, but aren't.
+ * Finds all blocks that should/could be in the inner blocks, but aren't.
  *
- * @param existingRequiredBlocks The actual array of all inner blocks.
- * @param requiredBlocks         All of the blocks that should occur in the inner blocks.
+ * @param existingBlocks The actual array of all inner blocks.
+ * @param possibleBlocks All of the blocks that should occur (required), or could occur (recommended) in the inner blocks.
  *
- * @returns {BlockValidationResult[]} The names of blocks that should occur but don't, with reason 'MissingBlock'.
+ * @returns {BlockValidationResult[]} The names of blocks that should/could occur but don't, with reason 'MissingBlock'.
  */
-function findMissingBlocks( existingRequiredBlocks: BlockInstance[], requiredBlocks: RequiredBlock[] ): BlockValidationResult[] {
-	const missingRequiredBlocks = requiredBlocks.filter( requiredBlock => {
-		// If there are not any blocks with the name of a required block, that required block is missing.
-		return ! existingRequiredBlocks.some( block => block.name === requiredBlock.name );
+function findMissingBlocks( existingBlocks: BlockInstance[], possibleBlocks: RequiredBlock[] ): BlockValidationResult[] {
+	const missingBlocks = possibleBlocks.filter( possibleBlock => {
+		// If there are not any blocks with the name of a possible block, that possible block is missing.
+		return ! existingBlocks.some( block => block.name === possibleBlock.name );
 	} );
 
 	// These blocks should've existed, but they don't.
-	return missingRequiredBlocks.map( missingBlock =>
+	return missingBlocks.map( missingBlock =>
 		new BlockValidationResult( null, missingBlock.name, BlockValidation.MissingBlock, BlockType.Unknown ) );
 }
 

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -2,11 +2,11 @@ import { BlockInstance } from "@wordpress/blocks";
 import { countBy } from "lodash";
 import { getBlockDefinition } from "../../core/blocks/BlockDefinitionRepository";
 import {
-	RequiredBlockOption,
 	BlockValidation,
-	RequiredBlock,
 	BlockValidationResult,
 	RecommendedBlock,
+	RequiredBlock,
+	RequiredBlockOption,
 } from "../../core/validation";
 import recurseOverBlocks from "../blocks/recurseOverBlocks";
 import { getInnerblocksByName } from "../innerBlocksHelper";

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -12,7 +12,7 @@ import recurseOverBlocks from "../blocks/recurseOverBlocks";
 import { getInnerblocksByName } from "../innerBlocksHelper";
 import logger from "../logger";
 import isValidResult from "./isValidResult";
-import { BlockType } from "../../core/validation/BlockValidationResult";
+import { BlockPresence } from "../../core/validation/BlockValidationResult";
 
 /**
  * Finds all blocks that should/could be in the inner blocks, but aren't.
@@ -24,7 +24,7 @@ import { BlockType } from "../../core/validation/BlockValidationResult";
  * @returns {BlockValidationResult[]} The names of blocks that should/could occur but don't, with reason 'MissingBlock'.
  */
 function findMissingBlocks( existingBlocksOfType: BlockInstance[], allBlocksOfType: RequiredBlock[] | RecommendedBlock[],
-	blockType: BlockType ): BlockValidationResult[] {
+	blockType: BlockPresence ): BlockValidationResult[] {
 	const missingBlocks = allBlocksOfType.filter( blockOfType => {
 		// If, in the existing blocks, there are not any blocks with the name of blockOfType, that block is missing.
 		return ! existingBlocksOfType.some( block => block.name === blockOfType.name );
@@ -59,7 +59,7 @@ function findRedundantBlocks( existingRequiredBlocks: BlockInstance[], requiredB
 
 			existingSingletons.forEach( ( block: BlockInstance ) => {
 				if ( block.name === blockName ) {
-					validationResults.push( new BlockValidationResult( block.clientId, blockName, BlockValidation.TooMany, BlockType.Unknown ) );
+					validationResults.push( new BlockValidationResult( block.clientId, blockName, BlockValidation.TooMany, BlockPresence.Unknown ) );
 				}
 			} );
 		}
@@ -85,7 +85,7 @@ function validateInnerblockTree( blockInstance: BlockInstance ): BlockValidation
 			validations.push( definition.validate( block ) );
 		} else {
 			logger.warning( "Block definition for '" + block.name + "' is not registered." );
-			validations.push( new BlockValidationResult( block.clientId, block.name, BlockValidation.Unknown, BlockType.Unknown ) );
+			validations.push( new BlockValidationResult( block.clientId, block.name, BlockValidation.Unknown, BlockPresence.Unknown ) );
 		}
 	} );
 	return validations;
@@ -111,7 +111,7 @@ function validateInnerBlocks( blockInstance: BlockInstance, requiredBlocks: Requ
 	const existingRequiredBlocks = getInnerblocksByName( blockInstance, requiredBlockKeys );
 
 	// Find all required block types that do not occur in existingRequiredBlocks.
-	validationResults.push( ...findMissingBlocks( existingRequiredBlocks, requiredBlocks, BlockType.Required ) );
+	validationResults.push( ...findMissingBlocks( existingRequiredBlocks, requiredBlocks, BlockPresence.Required ) );
 
 	// Find all required block types that allow only one occurrence.
 	validationResults.push( ...findRedundantBlocks( existingRequiredBlocks, requiredBlocks ) );
@@ -120,7 +120,7 @@ function validateInnerBlocks( blockInstance: BlockInstance, requiredBlocks: Requ
 	const existingRecommendedBlocks = getInnerblocksByName( blockInstance, recommendedBlockKeys );
 
 	// Find all recommended block types that do not occur in existingRecommendedBlocks.
-	validationResults.push( ...findMissingBlocks( existingRecommendedBlocks, recommendedBlocks, BlockType.Recommended ) );
+	validationResults.push( ...findMissingBlocks( existingRecommendedBlocks, recommendedBlocks, BlockPresence.Recommended ) );
 
 	// Let all innerblocks validate themselves.
 	// We differentiate between blocks that are internally valid but are not valid in the context of the innerblock.

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -17,22 +17,22 @@ import { BlockPresence } from "../../core/validation/BlockValidationResult";
 /**
  * Finds all blocks that should/could be in the inner blocks, but aren't.
  *
- * @param existingBlocksOfType The actual array of all inner blocks.
- * @param allBlocksOfType      All of the blocks that should occur (required), or could occur (recommended) in the inner blocks.
- * @param blockType            The block type.
+ * @param existingBlocks The actual array of all inner blocks.
+ * @param allBlocks      All of the blocks that should occur (required), or could occur (recommended) in the inner blocks.
+ * @param blockPresence  The block presence.
  *
  * @returns {BlockValidationResult[]} The names of blocks that should/could occur but don't, with reason 'MissingBlock'.
  */
-function findMissingBlocks( existingBlocksOfType: BlockInstance[], allBlocksOfType: RequiredBlock[] | RecommendedBlock[],
-	blockType: BlockPresence ): BlockValidationResult[] {
-	const missingBlocks = allBlocksOfType.filter( blockOfType => {
-		// If, in the existing blocks, there are not any blocks with the name of blockOfType, that block is missing.
-		return ! existingBlocksOfType.some( block => block.name === blockOfType.name );
+function findMissingBlocks( existingBlocks: BlockInstance[], allBlocks: RequiredBlock[] | RecommendedBlock[],
+	blockPresence: BlockPresence ): BlockValidationResult[] {
+	const missingBlocks = allBlocks.filter( block => {
+		// If, in the existing blocks, there are not any blocks with the name of block, that block is missing.
+		return ! existingBlocks.some( existingBlock => existingBlock.name === block.name );
 	} );
 
 	// These blocks should've existed, but they don't.
 	return missingBlocks.map( missingBlock =>
-		new BlockValidationResult( null, missingBlock.name, BlockValidation.MissingBlock, blockType ) );
+		new BlockValidationResult( null, missingBlock.name, BlockValidation.MissingBlock, blockPresence ) );
 }
 
 /**

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -93,9 +93,9 @@ function validateInnerblockTree( blockInstance: BlockInstance ): BlockValidation
 /**
  * Validates all inner blocks recursively and returns all invalid blocks.
  *
- * @param blockInstance  The block whose inner blocks need to be validated.
- * @param requiredBlocks Requirements of the blocks that should occur in the inner blocks.
- * @param recommendedBlocks
+ * @param blockInstance     The block whose inner blocks need to be validated.
+ * @param requiredBlocks    The inner blocks that are required.
+ * @param recommendedBlocks The inner blocks that are recommended.
  *
  * @returns {BlockValidationResult[]} The names and reasons of the inner blocks that are invalid.
  */

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -23,7 +23,7 @@ import { BlockType } from "../../core/validation/BlockValidationResult";
  *
  * @returns {BlockValidationResult[]} The names of blocks that should/could occur but don't, with reason 'MissingBlock'.
  */
-function findMissingBlocks( existingBlocksOfType: BlockInstance[], allBlocksOfType: RequiredBlock[], blockType: BlockType ): BlockValidationResult[] {
+function findMissingBlocks( existingBlocksOfType: BlockInstance[], allBlocksOfType: RequiredBlock[] | RecommendedBlock[], blockType: BlockType ): BlockValidationResult[] {
 	const missingBlocks = allBlocksOfType.filter( blockOfType => {
 		// If, in the existing blocks, there are not any blocks with the name of blockOfType, that block is missing.
 		return ! existingBlocksOfType.some( block => block.name === blockOfType.name );

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -45,7 +45,7 @@ function findMissingBlocks( existingBlocksOfType: BlockInstance[], allBlocksOfTy
  */
 function findRedundantBlocks( existingRequiredBlocks: BlockInstance[], requiredBlocks: RequiredBlock[] ): BlockValidationResult[] {
 	const validationResults: BlockValidationResult[] = [];
-	const singletons = requiredBlocks.filter( block => block.option === RequiredBlockOption.One );
+	const singletons = requiredBlocks.filter( block => block.option !== RequiredBlockOption.Multiple );
 
 	if ( singletons.length > 0 ) {
 		// Count the occurrences of each block so we can find all keys that have too many occurrences.

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -23,7 +23,8 @@ import { BlockType } from "../../core/validation/BlockValidationResult";
  *
  * @returns {BlockValidationResult[]} The names of blocks that should/could occur but don't, with reason 'MissingBlock'.
  */
-function findMissingBlocks( existingBlocksOfType: BlockInstance[], allBlocksOfType: RequiredBlock[] | RecommendedBlock[], blockType: BlockType ): BlockValidationResult[] {
+function findMissingBlocks( existingBlocksOfType: BlockInstance[], allBlocksOfType: RequiredBlock[] | RecommendedBlock[],
+	blockType: BlockType ): BlockValidationResult[] {
 	const missingBlocks = allBlocksOfType.filter( blockOfType => {
 		// If, in the existing blocks, there are not any blocks with the name of blockOfType, that block is missing.
 		return ! existingBlocksOfType.some( block => block.name === blockOfType.name );
@@ -99,7 +100,8 @@ function validateInnerblockTree( blockInstance: BlockInstance ): BlockValidation
  *
  * @returns {BlockValidationResult[]} The names and reasons of the inner blocks that are invalid.
  */
-function validateInnerBlocks( blockInstance: BlockInstance, requiredBlocks: RequiredBlock[] = [], recommendedBlocks: RecommendedBlock[] = [] ): BlockValidationResult[]  {
+function validateInnerBlocks( blockInstance: BlockInstance, requiredBlocks: RequiredBlock[] = [],
+							  recommendedBlocks: RecommendedBlock[] = [] ): BlockValidationResult[]  {
 	const requiredBlockKeys = requiredBlocks.map( rblock => rblock.name );
 	const recommendedBlockKeys = recommendedBlocks.map( rblock => rblock.name );
 

--- a/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
@@ -11,6 +11,7 @@ import validateMany from "../../functions/validators/validateMany";
 import { innerBlocksSidebar } from "../../functions/presenters/InnerBlocksSidebarPresenter";
 import { InnerBlocksInstructionOptions } from "./InnerBlocksInstructionOptions";
 import BlockLeaf from "../../core/blocks/BlockLeaf";
+import {BlockType} from "../../core/validation/BlockValidationResult";
 
 /**
  * Custom props for InnerBlocks.
@@ -152,7 +153,7 @@ export default class InnerBlocks extends BlockInstruction {
 	 * @returns {BlockValidationResult} The validation result.
 	 */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
-		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown );
+		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown, BlockType.Unknown );
 		validation.issues = validateInnerBlocks( blockInstance, this.options.requiredBlocks, this.options.recommendedBlocks );
 
 		return validateMany( validation );

--- a/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
@@ -153,7 +153,8 @@ export default class InnerBlocks extends BlockInstruction {
 	 */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
 		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown );
-		validation.issues = validateInnerBlocks( blockInstance, this.options.requiredBlocks );
+		validation.issues = validateInnerBlocks( blockInstance, this.options.requiredBlocks, this.options.recommendedBlocks );
+
 		return validateMany( validation );
 	}
 }

--- a/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
@@ -11,7 +11,7 @@ import validateMany from "../../functions/validators/validateMany";
 import { innerBlocksSidebar } from "../../functions/presenters/InnerBlocksSidebarPresenter";
 import { InnerBlocksInstructionOptions } from "./InnerBlocksInstructionOptions";
 import BlockLeaf from "../../core/blocks/BlockLeaf";
-import { BlockType } from "../../core/validation/BlockValidationResult";
+import { BlockPresence } from "../../core/validation/BlockValidationResult";
 
 /**
  * Custom props for InnerBlocks.
@@ -153,7 +153,7 @@ export default class InnerBlocks extends BlockInstruction {
 	 * @returns {BlockValidationResult} The validation result.
 	 */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
-		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown, BlockType.Unknown );
+		const validation = new BlockValidationResult( blockInstance.clientId, blockInstance.name, BlockValidation.Unknown, BlockPresence.Unknown );
 		validation.issues = validateInnerBlocks( blockInstance, this.options.requiredBlocks, this.options.recommendedBlocks );
 
 		return validateMany( validation );

--- a/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
@@ -11,7 +11,7 @@ import validateMany from "../../functions/validators/validateMany";
 import { innerBlocksSidebar } from "../../functions/presenters/InnerBlocksSidebarPresenter";
 import { InnerBlocksInstructionOptions } from "./InnerBlocksInstructionOptions";
 import BlockLeaf from "../../core/blocks/BlockLeaf";
-import {BlockType} from "../../core/validation/BlockValidationResult";
+import { BlockType } from "../../core/validation/BlockValidationResult";
 
 /**
  * Custom props for InnerBlocks.

--- a/packages/schema-blocks/tests/core/Definition.test.ts
+++ b/packages/schema-blocks/tests/core/Definition.test.ts
@@ -2,7 +2,7 @@ import BlockInstruction from "../../src/core/blocks/BlockInstruction";
 import Definition from "../../src/core/Definition";
 import { BlockValidation, BlockValidationResult } from "../../src/core/validation";
 import { BlockConfiguration, BlockInstance } from "@wordpress/blocks";
-import { BlockType } from "../../src/core/validation/BlockValidationResult";
+import { BlockPresence } from "../../src/core/validation/BlockValidationResult";
 
 /**
  * Test class, to be able to test the methods in the abstract Definition class.
@@ -52,7 +52,7 @@ class TestInstruction extends BlockInstruction {
      * @returns {BlockValidationResult[]} The constructor parameter wrapped in an array.
      */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
-		return new BlockValidationResult( "id" + this.id, "test", this.result, BlockType.Required );
+		return new BlockValidationResult( "id" + this.id, "test", this.result, BlockPresence.Required );
 	}
 	/* eslint-enable @typescript-eslint/no-unused-vars */
 }

--- a/packages/schema-blocks/tests/core/Definition.test.ts
+++ b/packages/schema-blocks/tests/core/Definition.test.ts
@@ -2,6 +2,8 @@ import BlockInstruction from "../../src/core/blocks/BlockInstruction";
 import Definition from "../../src/core/Definition";
 import { BlockValidation, BlockValidationResult } from "../../src/core/validation";
 import { BlockConfiguration, BlockInstance } from "@wordpress/blocks";
+import { BlockType } from "../../src/core/validation/BlockValidationResult";
+
 /**
  * Test class, to be able to test the methods in the abstract Definition class.
  */
@@ -50,7 +52,7 @@ class TestInstruction extends BlockInstruction {
      * @returns {BlockValidationResult[]} The constructor parameter wrapped in an array.
      */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
-		return new BlockValidationResult( "id" + this.id, "test", this.result );
+		return new BlockValidationResult( "id" + this.id, "test", this.result, BlockType.Required );
 	}
 	/* eslint-enable @typescript-eslint/no-unused-vars */
 }

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -150,4 +150,10 @@ describe( "The getWarnings method ", () => {
 			color: "red",
 		} );
 	} );
+
+	it( "creates no output when the validation results cannot be retrieved.", () => {
+		const result = getWarnings( "123" );
+
+		expect( result ).toBeNull();
+	} );
 } );

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -72,6 +72,20 @@ describe( "The createAnalysisMessages method ", () => {
 			},
 		);
 	} );
+
+	it( "creates a warning for missing recommended blocks, but when all the required blocks are present " +
+		"the conclusion should still be green.", () => {
+		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockType.Recommended );
+		testcase.issues.push( new BlockValidationResult( null, "missing recommended block", BlockValidation.MissingBlock, BlockType.Recommended ) );
+		testcase.issues.push( new BlockValidationResult( null, "missing recommended block 2", BlockValidation.MissingBlock, BlockType.Recommended ) );
+
+		const result = createAnalysisMessages( testcase );
+
+		expect( result.length ).toEqual( 3 );
+		expect( result[ 0 ] ).toEqual( { text: "The 'missing recommended block' block is recommended but missing.", color: "orange" } );
+		expect( result[ 1 ] ).toEqual( { text: "The 'missing recommended block 2' block is recommended but missing.", color: "orange" } );
+		expect( result[ 2 ] ).toEqual( { text: "Good job! All required blocks have been completed.", color: "green" } );
+	} );
 } );
 
 describe( "The sanitizeBlockName method ", () => {

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -1,6 +1,6 @@
 import { BlockValidation, BlockValidationResult } from "../../../src/core/validation";
 import getWarnings, { createAnalysisMessages, sanitizeBlockName } from "../../../src/functions/presenters/SidebarWarningPresenter";
-import { BlockType } from "../../../src/core/validation/BlockValidationResult";
+import { BlockPresence } from "../../../src/core/validation/BlockValidationResult";
 
 const validations: Record<string, BlockValidationResult> = {};
 const blockTypes: Record<string, string> = {};
@@ -26,7 +26,7 @@ jest.mock( "@wordpress/data", () => {
 
 describe( "The createAnalysisMessages method ", () => {
 	it( "creates a compliment for valid blocks.", () => {
-		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Valid, BlockType.Required );
+		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Valid, BlockPresence.Required );
 
 		const result = createAnalysisMessages( testcase );
 
@@ -34,7 +34,7 @@ describe( "The createAnalysisMessages method ", () => {
 	} );
 
 	it( "creates a compliment for validation results we have no copy for.", () => {
-		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Skipped, BlockType.Required );
+		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Skipped, BlockPresence.Required );
 
 		const result = createAnalysisMessages( testcase );
 
@@ -42,8 +42,8 @@ describe( "The createAnalysisMessages method ", () => {
 	} );
 
 	it( "creates warning messages for missing attributes, with a footer message.", () => {
-		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockType.Required );
-		testcase.issues.push( new BlockValidationResult( null, "missingblockattribute", BlockValidation.MissingAttribute, BlockType.Required ) );
+		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockPresence.Required );
+		testcase.issues.push( new BlockValidationResult( null, "missingblockattribute", BlockValidation.MissingAttribute, BlockPresence.Required ) );
 
 		const result = createAnalysisMessages( testcase );
 
@@ -58,8 +58,8 @@ describe( "The createAnalysisMessages method ", () => {
 	} );
 
 	it( "creates warning messages for missing required blocks, with a footer message.", () => {
-		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockType.Required );
-		testcase.issues.push( new BlockValidationResult( null, "missingblock", BlockValidation.MissingBlock, BlockType.Required ) );
+		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockPresence.Required );
+		testcase.issues.push( new BlockValidationResult( null, "missingblock", BlockValidation.MissingBlock, BlockPresence.Required ) );
 
 		const result = createAnalysisMessages( testcase );
 
@@ -75,9 +75,9 @@ describe( "The createAnalysisMessages method ", () => {
 
 	it( "creates a warning for missing recommended blocks, but when all the required blocks are present " +
 		"the conclusion should still be green.", () => {
-		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockType.Recommended );
-		testcase.issues.push( new BlockValidationResult( null, "missing recommended block", BlockValidation.MissingBlock, BlockType.Recommended ) );
-		testcase.issues.push( new BlockValidationResult( null, "missing recommended block 2", BlockValidation.MissingBlock, BlockType.Recommended ) );
+		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockPresence.Recommended );
+		testcase.issues.push( new BlockValidationResult( null, "missing recommended block", BlockValidation.MissingBlock, BlockPresence.Recommended ) );
+		testcase.issues.push( new BlockValidationResult( null, "missing recommended block 2", BlockValidation.MissingBlock, BlockPresence.Recommended ) );
 
 		const result = createAnalysisMessages( testcase );
 
@@ -114,7 +114,7 @@ describe( "The sanitizeBlockName method ", () => {
 
 describe( "The getWarnings method ", () => {
 	it( "creates a compliment for required valid blocks.", () => {
-		validations[ "1" ] = new BlockValidationResult( "1", "myBlock", BlockValidation.Valid, BlockType.Required );
+		validations[ "1" ] = new BlockValidationResult( "1", "myBlock", BlockValidation.Valid, BlockPresence.Required );
 
 		const result = getWarnings( "1" );
 
@@ -122,10 +122,10 @@ describe( "The getWarnings method ", () => {
 	} );
 
 	it( "creates a compliment if we do not have copy for any of the validations of the required blocks.", () => {
-		const testcase = new BlockValidationResult( "1", "myBlock", BlockValidation.Invalid, BlockType.Required );
-		testcase.issues.push( new BlockValidationResult( "2", "innerblock1", BlockValidation.Skipped, BlockType.Required ) );
-		testcase.issues.push( new BlockValidationResult( "3", "anotherinnerblock", BlockValidation.TooMany, BlockType.Required ) );
-		testcase.issues.push( new BlockValidationResult( "4", "anotherinnerblock", BlockValidation.Unknown, BlockType.Required ) );
+		const testcase = new BlockValidationResult( "1", "myBlock", BlockValidation.Invalid, BlockPresence.Required );
+		testcase.issues.push( new BlockValidationResult( "2", "innerblock1", BlockValidation.Skipped, BlockPresence.Required ) );
+		testcase.issues.push( new BlockValidationResult( "3", "anotherinnerblock", BlockValidation.TooMany, BlockPresence.Required ) );
+		testcase.issues.push( new BlockValidationResult( "4", "anotherinnerblock", BlockValidation.Unknown, BlockPresence.Required ) );
 		validations[ "1" ] = testcase;
 
 		const result = getWarnings( "1" );
@@ -134,8 +134,8 @@ describe( "The getWarnings method ", () => {
 	} );
 
 	it( "creates a warning for a required block with validation problems.", () => {
-		const testcase = new BlockValidationResult( "1", "myBlock", BlockValidation.Invalid, BlockType.Required );
-		testcase.issues.push( new BlockValidationResult( "2", "innerblock1", BlockValidation.MissingBlock, BlockType.Required ) );
+		const testcase = new BlockValidationResult( "1", "myBlock", BlockValidation.Invalid, BlockPresence.Required );
+		testcase.issues.push( new BlockValidationResult( "2", "innerblock1", BlockValidation.MissingBlock, BlockPresence.Required ) );
 		validations[ "1" ] = testcase;
 
 		const result = getWarnings( "1" );

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -1,5 +1,6 @@
 import { BlockValidation, BlockValidationResult } from "../../../src/core/validation";
 import getWarnings, { createAnalysisMessages, sanitizeBlockName } from "../../../src/functions/presenters/SidebarWarningPresenter";
+import { BlockType } from "../../../src/core/validation/BlockValidationResult";
 
 const validations: Record<string, BlockValidationResult> = {};
 const blockTypes: Record<string, string> = {};
@@ -25,7 +26,7 @@ jest.mock( "@wordpress/data", () => {
 
 describe( "The createAnalysisMessages method ", () => {
 	it( "creates a compliment for valid blocks.", () => {
-		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Valid );
+		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Valid, BlockType.Required );
 
 		const result = createAnalysisMessages( testcase );
 
@@ -33,7 +34,7 @@ describe( "The createAnalysisMessages method ", () => {
 	} );
 
 	it( "creates a compliment for validation results we have no copy for.", () => {
-		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Skipped );
+		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Skipped, BlockType.Required );
 
 		const result = createAnalysisMessages( testcase );
 
@@ -41,8 +42,8 @@ describe( "The createAnalysisMessages method ", () => {
 	} );
 
 	it( "creates warning messages for missing attributes, with a footer message.", () => {
-		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid );
-		testcase.issues.push( new BlockValidationResult( null, "missingblockattribute", BlockValidation.MissingAttribute ) );
+		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockType.Required );
+		testcase.issues.push( new BlockValidationResult( null, "missingblockattribute", BlockValidation.MissingAttribute, BlockType.Required ) );
 
 		const result = createAnalysisMessages( testcase );
 
@@ -56,9 +57,9 @@ describe( "The createAnalysisMessages method ", () => {
 		);
 	} );
 
-	it( "creates warning messages for missing blocks, with a footer message.", () => {
-		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid );
-		testcase.issues.push( new BlockValidationResult( null, "missingblock", BlockValidation.MissingBlock ) );
+	it( "creates warning messages for missing required blocks, with a footer message.", () => {
+		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockType.Required );
+		testcase.issues.push( new BlockValidationResult( null, "missingblock", BlockValidation.MissingBlock, BlockType.Required ) );
 
 		const result = createAnalysisMessages( testcase );
 
@@ -98,19 +99,19 @@ describe( "The sanitizeBlockName method ", () => {
 } );
 
 describe( "The getWarnings method ", () => {
-	it( "creates a compliment for valid blocks.", () => {
-		validations[ "1" ] = new BlockValidationResult( "1", "myBlock", BlockValidation.Valid );
+	it( "creates a compliment for required valid blocks.", () => {
+		validations[ "1" ] = new BlockValidationResult( "1", "myBlock", BlockValidation.Valid, BlockType.Required );
 
 		const result = getWarnings( "1" );
 
 		expect( result ).toEqual( [ { text: "Good job! All required blocks have been completed.", color: "green" } ] );
 	} );
 
-	it( "creates a compliment if we do not have copy for any of the validations.", () => {
-		const testcase = new BlockValidationResult( "1", "myBlock", BlockValidation.Invalid );
-		testcase.issues.push( new BlockValidationResult( "2", "innerblock1", BlockValidation.Skipped ) );
-		testcase.issues.push( new BlockValidationResult( "3", "anotherinnerblock", BlockValidation.TooMany ) );
-		testcase.issues.push( new BlockValidationResult( "4", "anotherinnerblock", BlockValidation.Unknown ) );
+	it( "creates a compliment if we do not have copy for any of the validations of the required blocks.", () => {
+		const testcase = new BlockValidationResult( "1", "myBlock", BlockValidation.Invalid, BlockType.Required );
+		testcase.issues.push( new BlockValidationResult( "2", "innerblock1", BlockValidation.Skipped, BlockType.Required ) );
+		testcase.issues.push( new BlockValidationResult( "3", "anotherinnerblock", BlockValidation.TooMany, BlockType.Required ) );
+		testcase.issues.push( new BlockValidationResult( "4", "anotherinnerblock", BlockValidation.Unknown, BlockType.Required ) );
 		validations[ "1" ] = testcase;
 
 		const result = getWarnings( "1" );
@@ -118,9 +119,9 @@ describe( "The getWarnings method ", () => {
 		expect( result ).toEqual( [ { text: "Good job! All required blocks have been completed.", color: "green" } ] );
 	} );
 
-	it( "creates a warning for a block with validation problems.", () => {
-		const testcase = new BlockValidationResult( "1", "myBlock", BlockValidation.Invalid );
-		testcase.issues.push( new BlockValidationResult( "2", "innerblock1", BlockValidation.MissingBlock ) );
+	it( "creates a warning for a required block with validation problems.", () => {
+		const testcase = new BlockValidationResult( "1", "myBlock", BlockValidation.Invalid, BlockType.Required );
+		testcase.issues.push( new BlockValidationResult( "2", "innerblock1", BlockValidation.MissingBlock, BlockType.Required ) );
 		validations[ "1" ] = testcase;
 
 		const result = getWarnings( "1" );

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -29,7 +29,7 @@ describe( "The createAnalysisMessages method ", () => {
 
 		const result = createAnalysisMessages( testcase );
 
-		expect( result ).toEqual( [ { text: "Good job! All required blocks are completed.", color: "green" } ] );
+		expect( result ).toEqual( [ { text: "Good job! All required blocks have been completed.", color: "green" } ] );
 	} );
 
 	it( "creates a compliment for validation results we have no copy for.", () => {
@@ -37,7 +37,7 @@ describe( "The createAnalysisMessages method ", () => {
 
 		const result = createAnalysisMessages( testcase );
 
-		expect( result ).toEqual( [ { text: "Good job! All required blocks are completed.", color: "green" } ] );
+		expect( result ).toEqual( [ { text: "Good job! All required blocks have been completed.", color: "green" } ] );
 	} );
 
 	it( "creates warning messages for missing attributes, with a footer message.", () => {
@@ -50,7 +50,7 @@ describe( "The createAnalysisMessages method ", () => {
 		expect( result[ 0 ] ).toEqual( { text: "The 'missingblockattribute' block is empty.", color: "red" } );
 		expect( result[ 1 ] ).toEqual(
 			{
-				text: "Not all required blocks are completed! No mijnblock schema will be generated for your page.",
+				text: "Not all required blocks have been completed! No mijnblock schema will be generated for your page.",
 				color: "red",
 			},
 		);
@@ -66,7 +66,7 @@ describe( "The createAnalysisMessages method ", () => {
 		expect( result[ 0 ] ).toEqual( { text: "The 'missingblock' block is required but missing.", color: "red" } );
 		expect( result[ 1 ] ).toEqual(
 			{
-				text: "Not all required blocks are completed! No mijnblock schema will be generated for your page.",
+				text: "Not all required blocks have been completed! No mijnblock schema will be generated for your page.",
 				color: "red",
 			},
 		);
@@ -103,7 +103,7 @@ describe( "The getWarnings method ", () => {
 
 		const result = getWarnings( "1" );
 
-		expect( result ).toEqual( [ { text: "Good job! All required blocks are completed.", color: "green" } ] );
+		expect( result ).toEqual( [ { text: "Good job! All required blocks have been completed.", color: "green" } ] );
 	} );
 
 	it( "creates a compliment if we do not have copy for any of the validations.", () => {
@@ -115,7 +115,7 @@ describe( "The getWarnings method ", () => {
 
 		const result = getWarnings( "1" );
 
-		expect( result ).toEqual( [ { text: "Good job! All required blocks are completed.", color: "green" } ] );
+		expect( result ).toEqual( [ { text: "Good job! All required blocks have been completed.", color: "green" } ] );
 	} );
 
 	it( "creates a warning for a block with validation problems.", () => {
@@ -131,7 +131,7 @@ describe( "The getWarnings method ", () => {
 			color: "red",
 		} );
 		expect( result[ 1 ] ).toEqual( {
-			text: "Not all required blocks are completed! No myblock schema will be generated for your page.",
+			text: "Not all required blocks have been completed! No myblock schema will be generated for your page.",
 			color: "red",
 		} );
 	} );

--- a/packages/schema-blocks/tests/functions/validators/innerBlocksValid.test.ts
+++ b/packages/schema-blocks/tests/functions/validators/innerBlocksValid.test.ts
@@ -1,8 +1,8 @@
 import "../../matchMedia.mock";
 import { BlockInstance } from "@wordpress/blocks";
 import {
-	BlockValidationResult,
 	BlockValidation,
+	BlockValidationResult,
 	RequiredBlock,
 	RequiredBlockOption,
 	RecommendedBlock,
@@ -183,7 +183,7 @@ describe( "The findRedundantBlocks function", () => {
 		];
 
 		// Act.
-		const result = innerBlocksValid.findRedundantBlocks( existingRequiredBlocks, requiredBlocks );
+		const result = innerBlocksValid.findRedundantBlocks( existingRequiredBlocks, requiredBlocks, BlockPresence.Required );
 
 		// Assert.
 		expect( result.length ).toEqual( 2 );
@@ -218,7 +218,7 @@ describe( "The findRedundantBlocks function", () => {
 		];
 
 		// Act.
-		const result: BlockValidationResult[] = innerBlocksValid.findRedundantBlocks( existingBlocks, requiredBlocks );
+		const result: BlockValidationResult[] = innerBlocksValid.findRedundantBlocks( existingBlocks, requiredBlocks, BlockPresence.Required );
 
 		// Assert.
 		expect( result.length ).toEqual( 0 );

--- a/packages/schema-blocks/tests/functions/validators/innerBlocksValid.test.ts
+++ b/packages/schema-blocks/tests/functions/validators/innerBlocksValid.test.ts
@@ -1,6 +1,12 @@
 import "../../matchMedia.mock";
 import { BlockInstance } from "@wordpress/blocks";
-import { BlockValidationResult, BlockValidation, RequiredBlock, RequiredBlockOption } from "../../../src/core/validation";
+import {
+	BlockValidationResult,
+	BlockValidation,
+	RequiredBlock,
+	RequiredBlockOption,
+	RecommendedBlock,
+} from "../../../src/core/validation";
 import BlockDefinition from "../../../src/core/blocks/BlockDefinition";
 import * as innerBlocksValid from "../../../src/functions/validators/innerBlocksValid";
 import * as blockDefinitionRepository from "../../../src/core/blocks/BlockDefinitionRepository";
@@ -92,6 +98,32 @@ describe( "The findMissingBlocks function", () => {
 
 		// Act.
 		const result: BlockValidationResult[] = innerBlocksValid.findMissingBlocks( existingRequiredBlocks, requiredBlocks, BlockType.Required );
+
+		// Assert.
+		expect( result.length ).toEqual( 1 );
+		expect( result[ 0 ].name ).toEqual( "missingblock" );
+		expect( result[ 0 ].result ).toEqual( BlockValidation.MissingBlock );
+	} );
+
+	it( "creates a BlockValidationResult with reason 'MissingBlock' when a recommended block is missing.", () => {
+		// Arrange.
+		const recommendedBlocks: RecommendedBlock[] = [
+			{
+				name: "existingRecommendedBlock",
+			} as RecommendedBlock,
+			{
+				name: "missingblock",
+			} as RecommendedBlock,
+		];
+		const existingRecommendedBlocks: BlockInstance[] = [
+			{
+				name: "existingRecommendedBlock",
+			} as BlockInstance,
+		];
+
+		// Act.
+		const result: BlockValidationResult[] = innerBlocksValid.findMissingBlocks( existingRecommendedBlocks, recommendedBlocks,
+			BlockType.Recommended );
 
 		// Assert.
 		expect( result.length ).toEqual( 1 );

--- a/packages/schema-blocks/tests/functions/validators/innerBlocksValid.test.ts
+++ b/packages/schema-blocks/tests/functions/validators/innerBlocksValid.test.ts
@@ -10,7 +10,7 @@ import {
 import BlockDefinition from "../../../src/core/blocks/BlockDefinition";
 import * as innerBlocksValid from "../../../src/functions/validators/innerBlocksValid";
 import * as blockDefinitionRepository from "../../../src/core/blocks/BlockDefinitionRepository";
-import { BlockType } from "../../../src/core/validation/BlockValidationResult";
+import { BlockPresence } from "../../../src/core/validation/BlockValidationResult";
 
 const mockBlockRegistry: Record<string, BlockDefinition> = {};
 const getBlockDefinitionMock = jest.spyOn( blockDefinitionRepository, "getBlockDefinition" );
@@ -34,13 +34,13 @@ function FakeBlockDefinition( clientId: string, name: string, expectedValue: Blo
 	return {
 		name: name,
 		validate: () => {
-			const output = new BlockValidationResult( clientId, name, expectedValue, BlockType.Required );
+			const output = new BlockValidationResult( clientId, name, expectedValue, BlockPresence.Required );
 			if ( expectedValue === BlockValidation.Valid || expectedValue === BlockValidation.Unknown ) {
 				return output;
 			}
 			output.result = BlockValidation.Invalid;
 			output.issues.push( new BlockValidationResult( "child_or_attribute_id_" + name, "child_or_attribute_name_" +
-				name, expectedValue, BlockType.Required ) );
+				name, expectedValue, BlockPresence.Required ) );
 			return output;
 		},
 	} as unknown as BlockDefinition;
@@ -70,7 +70,7 @@ describe( "The BlockValidationResult constructor", () => {
 	it( "creates a valid BlockValidationResult", () => {
 		for ( let i = 0; i < createBlockValidationResultTestArrangement.length; i++ ) {
 			const input = createBlockValidationResultTestArrangement[ i ];
-			const result = new BlockValidationResult( "clientId", input.name, input.reason, BlockType.Required );
+			const result = new BlockValidationResult( "clientId", input.name, input.reason, BlockPresence.Required );
 			expect( result.name ).toEqual( input.name );
 			expect( result.result ).toEqual( input.reason );
 		}
@@ -97,7 +97,7 @@ describe( "The findMissingBlocks function", () => {
 		];
 
 		// Act.
-		const result: BlockValidationResult[] = innerBlocksValid.findMissingBlocks( existingRequiredBlocks, requiredBlocks, BlockType.Required );
+		const result: BlockValidationResult[] = innerBlocksValid.findMissingBlocks( existingRequiredBlocks, requiredBlocks, BlockPresence.Required );
 
 		// Assert.
 		expect( result.length ).toEqual( 1 );
@@ -123,7 +123,7 @@ describe( "The findMissingBlocks function", () => {
 
 		// Act.
 		const result: BlockValidationResult[] = innerBlocksValid.findMissingBlocks( existingRecommendedBlocks, recommendedBlocks,
-			BlockType.Recommended );
+			BlockPresence.Recommended );
 
 		// Assert.
 		expect( result.length ).toEqual( 1 );
@@ -155,7 +155,7 @@ describe( "The findMissingBlocks function", () => {
 		];
 
 		// Act.
-		const result: BlockValidationResult[] = innerBlocksValid.findMissingBlocks( existingRequiredBlocks, requiredBlocks, BlockType.Required );
+		const result: BlockValidationResult[] = innerBlocksValid.findMissingBlocks( existingRequiredBlocks, requiredBlocks, BlockPresence.Required );
 
 		// Assert.
 		expect( result.length ).toEqual( 0 );

--- a/packages/schema-blocks/tests/functions/validators/validateMany.test.ts
+++ b/packages/schema-blocks/tests/functions/validators/validateMany.test.ts
@@ -1,15 +1,15 @@
 import "../../matchMedia.mock";
 import { BlockValidation, BlockValidationResult } from "../../../src/core/validation";
 import validateMany from "../../../src/functions/validators/validateMany";
-import { BlockType } from "../../../src/core/validation/BlockValidationResult";
+import { BlockPresence } from "../../../src/core/validation/BlockValidationResult";
 
 describe( "The validateMany function", () => {
 	it( "considers a group of Valid and Unknown blocks to be Valid.", () => {
 		// Arrange.
-		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown, BlockType.Required );
+		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown, BlockPresence.Required );
 		validation.issues = [
-			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Valid, BlockType.Required ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.Unknown, BlockType.Required ),
+			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Valid, BlockPresence.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.Unknown, BlockPresence.Required ),
 		];
 
 		// Act.
@@ -23,12 +23,12 @@ describe( "The validateMany function", () => {
 
 	it( "considers a group of non-Valid blocks to be Invalid.", () => {
 		// Arrange.
-		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown, BlockType.Required );
+		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown, BlockPresence.Required );
 		validation.issues = [
-			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Invalid, BlockType.Required ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingAttribute, BlockType.Required ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingBlock, BlockType.Required ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.TooMany, BlockType.Required ),
+			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Invalid, BlockPresence.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingAttribute, BlockPresence.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingBlock, BlockPresence.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.TooMany, BlockPresence.Required ),
 		];
 
 		// Act.
@@ -42,14 +42,14 @@ describe( "The validateMany function", () => {
 
 	it( "considers a mix of Valid and non-Valid blocks to be Invalid.", () => {
 		// Arrange.
-		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown, BlockType.Required );
+		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown, BlockPresence.Required );
 		validation.issues = [
-			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Valid, BlockType.Required ),
-			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Unknown, BlockType.Required ),
-			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Invalid, BlockType.Required ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingAttribute, BlockType.Required ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingBlock, BlockType.Required ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.TooMany, BlockType.Required ),
+			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Valid, BlockPresence.Required ),
+			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Unknown, BlockPresence.Required ),
+			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Invalid, BlockPresence.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingAttribute, BlockPresence.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingBlock, BlockPresence.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.TooMany, BlockPresence.Required ),
 		];
 
 		// Act.

--- a/packages/schema-blocks/tests/functions/validators/validateMany.test.ts
+++ b/packages/schema-blocks/tests/functions/validators/validateMany.test.ts
@@ -1,14 +1,15 @@
 import "../../matchMedia.mock";
 import { BlockValidation, BlockValidationResult } from "../../../src/core/validation";
 import validateMany from "../../../src/functions/validators/validateMany";
+import { BlockType } from "../../../src/core/validation/BlockValidationResult";
 
 describe( "The validateMany function", () => {
 	it( "considers a group of Valid and Unknown blocks to be Valid.", () => {
 		// Arrange.
-		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown );
+		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown, BlockType.Required );
 		validation.issues = [
-			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Valid ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.Unknown ),
+			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Valid, BlockType.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.Unknown, BlockType.Required ),
 		];
 
 		// Act.
@@ -22,12 +23,12 @@ describe( "The validateMany function", () => {
 
 	it( "considers a group of non-Valid blocks to be Invalid.", () => {
 		// Arrange.
-		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown );
+		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown, BlockType.Required );
 		validation.issues = [
-			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Invalid ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingAttribute ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingBlock ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.TooMany ),
+			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Invalid, BlockType.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingAttribute, BlockType.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingBlock, BlockType.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.TooMany, BlockType.Required ),
 		];
 
 		// Act.
@@ -41,14 +42,14 @@ describe( "The validateMany function", () => {
 
 	it( "considers a mix of Valid and non-Valid blocks to be Invalid.", () => {
 		// Arrange.
-		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown );
+		const validation = new BlockValidationResult( "validatedId", "validatedBlock", BlockValidation.Unknown, BlockType.Required );
 		validation.issues = [
-			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Valid ),
-			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Unknown ),
-			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Invalid ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingAttribute ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingBlock ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.TooMany ),
+			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Valid, BlockType.Required ),
+			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Unknown, BlockType.Required ),
+			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Invalid, BlockType.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingAttribute, BlockType.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingBlock, BlockType.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.TooMany, BlockType.Required ),
 		];
 
 		// Act.


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [schema-blocks] Adds an orange bullet to the `Analysis` in the side bar when a recommended block is removed.

## Relevant technical choices:

* I added an `enum Blocktype` in `BlockValidationResult.ts`, which holds the different block types (required, recommended, optional, and for the time being, also unknown).
* I added a `blockType` parameter to the `BlockValidationResult` class, with the type being `BlockType`.
* As a result, everywhere where the `BlockVariationResult` class is instantiated, it needs to be passed a `blockType` parameter.
* This is why I also added `unknown` as a value to the enum; I'm passing `unknown` to all instantiations of `BlockValidationResult` which are outside the scope of this PR. We could look into fixing this, but I'm not sure it worth the time investment right now. The thing is that we don't know the block type for many block instances, since the block templates themselves don't pass their own block type (instead, it is listed in `job-posting.block.php` what is the block type for each block).
* The `validateInnerBlocks` function in `innerBlocksValid.ts` now also calls the `findMissingBlocks` function for recommended blocks (it used to call this function only for required blocks).
* I did some renames in the `findMissingBlocks` function to reflect this.
* For each missing/removed block, the `findMissingBlocks` function adds the block type to the `BlockValidationResult`. These results will be used in the sidebar (as the `status` of the `messageData` in `SidebarWarningPresenter.ts`) to show the appropriate warning.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add the Yoast Job Posting block.
* See that there are no orange bullets in the `Analysis` in the side bar, because all the recommended blocks are present upon initialization.
* You should see a red bullet saying "Not all required blocks are complete! No job posting schema will be generated for your page." (this is because title, description and location have not yet been filled in).

**Test scenario 7**
* Remove a recommended block, for example the 'Requirements'.
* See an orange bullet and the text: "The 'Requirements' block is recommended but missing.":
    <img width="175" alt="Screenshot 2021-03-23 at 15 21 24" src="https://user-images.githubusercontent.com/20280513/112161436-70bde280-8beb-11eb-99d3-1ebb1f4b9c46.png">

* See that the Requirements block is greyed out and can be added:
    <img width="202" alt="Screenshot 2021-03-23 at 15 21 49" src="https://user-images.githubusercontent.com/20280513/112161492-7fa49500-8beb-11eb-9845-8779a951e405.png">

* Remove another recommended block and see another orange bullet appear (with the right text).
* The red bullet saying "Not all required blocks are complete! No job posting schema will be generated for your page." should still be present.

**Test scenario 8**
* Fill in the title, description and location.
* The red bullet should become green and say: "Good job! All required blocks are complete.".
* You should still see one or more orange bullets corresponding to the recommended blocks you have removed.
* Remove a required block and see that there are now two red bullets: one saying which block is missing, and one saying that not all required blocks are completed.

**Test Schema output**
* Fill in a recommended block and see that it is present in the Schema output.

**Note** that scenarios 7 and 8 both contain a line regarding the color of the emoticon in the pre-publish check; I didn't solve that yet as there is a separate ticket for this task: https://yoast.atlassian.net/browse/P2-789.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-706
