### PR TITLE
Shows a link in the warning

### DIFF
--- a/packages/schema-blocks/css/schema-blocks.css
+++ b/packages/schema-blocks/css/schema-blocks.css
@@ -50,6 +50,11 @@
 	color: #0073aa;
 }
 
+.wp-block .yoast-warning-block > .yoast-warning-block-message > a {
+	text-decoration: underline;
+	color: #0073aa;
+}
+
 .yoast-warning-block > div > button:not(:last-child) {
 	margin-right: 24px;
 }

--- a/packages/schema-blocks/src/functions/gutenberg/watchers/warningWatcher.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watchers/warningWatcher.ts
@@ -55,7 +55,7 @@ function getDefaultWarningMessage( blockTitle: string, warningType: WarningType 
 					"yoast-schema-blocks",
 				),
 				blockTitle,
-				'<a href=" ' + ( window as any ).yoastSchemaBlocks.requiredLink + '" target="_blank">',
+				'<a href="' + ( window as any ).yoastSchemaBlocks.requiredLink + '" target="_blank">',
 				"</a>",
 			);
 		}
@@ -68,7 +68,7 @@ function getDefaultWarningMessage( blockTitle: string, warningType: WarningType 
 					"yoast-schema-blocks",
 				),
 				blockTitle,
-				'<a href=" ' + ( window as any ).yoastSchemaBlocks.recommendedLink + '" target="_blank">',
+				'<a href="' + ( window as any ).yoastSchemaBlocks.recommendedLink + '" target="_blank">',
 				"</a>",
 			);
 		}

--- a/packages/schema-blocks/src/functions/gutenberg/watchers/warningWatcher.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watchers/warningWatcher.ts
@@ -47,25 +47,29 @@ function getInnerBlocksInstruction( blockName: string ): InnerBlocks | null {
 function getDefaultWarningMessage( blockTitle: string, warningType: WarningType ): string {
 	switch ( warningType ) {
 		case WarningType.BLOCK_REQUIRED: {
-			/* translators: %s expands to the block name that is removed. */
+			/* translators: %1$s: the block name that is removed, %2$s: the anchor to a page about required blocks, %3$s the closing anchor tag. */
 			return sprintf(
 				__(
-					"You've just removed the ‘%s’ block, but this is a required block for Schema output. " +
+					"You've just removed the ‘%1$s’ block, but this is a %2$srequired block for Schema output%3$s. " +
 					"Without this block no Schema will be generated. Are you sure you want to do this?",
 					"yoast-schema-blocks",
 				),
 				blockTitle,
+				'<a href=" ' + ( window as any ).yoastSchemaBlocks.requiredLink + '" target="_blank">',
+				"</a>",
 			);
 		}
 		case WarningType.BLOCK_RECOMMENDED: {
-			/* translators: %s expands to the block name that is removed. */
+			/* translators: %1$s: the block name that is removed, %2$s: the anchor to a page about recommended blocks, %3$s the closing anchor tag. */
 			return sprintf(
 				__(
-					"You've just removed the ‘%s’ block, but this is a recommended block for Schema output. " +
+					"You've just removed the ‘%1$s’ block, but this is a %2$srecommended block for Schema output%3$s. " +
 					"Are you sure you want to do this?",
 					"yoast-schema-blocks",
 				),
 				blockTitle,
+				'<a href=" ' + ( window as any ).yoastSchemaBlocks.recommendedLink + '" target="_blank">',
+				"</a>",
 			);
 		}
 	}

--- a/packages/schema-blocks/tests/functions/gutenberg/watchers/warningWatcher.test.ts
+++ b/packages/schema-blocks/tests/functions/gutenberg/watchers/warningWatcher.test.ts
@@ -10,7 +10,13 @@ import { RequiredBlock, RequiredBlockOption } from "../../../../src/core/validat
 
 jest.mock( "@wordpress/i18n", () => ( {
 	__: jest.fn( text => text ),
-	sprintf: jest.fn( ( text, value ) => text.replace( "%s", value ) ),
+	sprintf: jest.fn( ( text, value, value2, value3 ) => {
+		text = text.replace( "%1$s", value );
+		text = text.replace( "%2$s", value2 );
+		text = text.replace( "%3$s", value3 );
+
+		return text;
+	} ),
 } ) );
 
 jest.mock( "@wordpress/block-editor", () => ( {
@@ -53,6 +59,11 @@ jest.mock( "@yoast/components", () => {
 		SvgIcon: jest.fn(),
 	};
 } );
+
+( window as any ).yoastSchemaBlocks = {
+	requiredLink: "https://yoa.st/required-fields",
+	recommendedLink: "https://yoa.st/recommended-fields",
+};
 
 describe( "The warning watcher", () => {
 	it( "adds warnings when required blocks are removed", () => {
@@ -106,7 +117,8 @@ describe( "The warning watcher", () => {
 					innerBlocks: [],
 					name: "yoast/ingredients",
 				},
-				warningText: "You've just removed the ‘Ingredients’ block, but this is a required block for Schema output. " +
+				warningText: "You've just removed the ‘Ingredients’ block, but this is a " +
+					"<a href=\"https://yoa.st/required-fields\" target=\"_blank\">required block for Schema output</a>. " +
 					"Without this block no Schema will be generated. Are you sure you want to do this?",
 			},
 		);
@@ -164,7 +176,9 @@ describe( "The warning watcher", () => {
 					name: "yoast/ingredients",
 				},
 				// eslint-disable-next-line max-len
-				warningText: "You've just removed the ‘Ingredients’ block, but this is a recommended block for Schema output. Are you sure you want to do this?",
+				warningText: "You've just removed the ‘Ingredients’ block, but this is a " +
+					"<a href=\"https://yoa.st/recommended-fields\" target=\"_blank\">recommended block for Schema output</a>. " +
+					"Are you sure you want to do this?",
 			},
 		);
 		expect( dispatch ).toBeCalled();


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [schema-blocks] Fixes a bug where the link to additional information in the warning was missing.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test this against https://github.com/Yoast/wordpress-seo/pull/16822 and the trunk of Yoast SEO Premium.
* Add the jobs block to a post
* Remove the title or description. You will see an error with a link. Navigate to that link and see that you get navigated to the yoast.com help page. The page itself probably doesn't exist yet. But the url should be like this `https://yoast.com/help/required-recommended-optional-fields....` with some additional UTM tags. Note the `&utm_term=required%20block`
* Now remove the requirements block for example
* You will get an warning about the removal of a recommended block. This block also should have a link that navigates to `https://yoast.com/help/required-recommended-optional-fields....` and see that there is a `utm_term=recommended%20block`

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
