### PR TITLE
Only output Schema when the checks for required blocks are OK

### DIFF
--- a/packages/schema-blocks/src/core/Definition.ts
+++ b/packages/schema-blocks/src/core/Definition.ts
@@ -5,7 +5,7 @@ import Instruction from "./Instruction";
 import Leaf from "./Leaf";
 import logger from "../functions/logger";
 import validateMany from "../functions/validators/validateMany";
-import { getAllDescendantIssues } from "../functions/validators/getAllDescendantIssues";
+import { getAllDescendantIssues } from "../functions/validators";
 
 export type DefinitionClass<T extends Definition> = {
 	new( separator: string, template?: string, instructions?: Record<string, Instruction>, tree?: Leaf ): T;

--- a/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
+++ b/packages/schema-blocks/src/core/blocks/BlockInstruction.ts
@@ -97,7 +97,7 @@ export default abstract class BlockInstruction extends Instruction {
 			}
 		}
 
-		// Blocks with any invalid innerblock should be considerd invalid themselves.
+		// Blocks with any invalid innerblock should be considered invalid themselves.
 		if ( validation.issues.length > 0 ) {
 			return validateMany( validation );
 		}

--- a/packages/schema-blocks/src/core/validation/BlockValidation.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidation.ts
@@ -1,4 +1,3 @@
-
 export enum BlockValidation {
 	/** This block was skipped during validation, on purpose. If you ever see this value, that's a bug.  */
 	Skipped = -2,

--- a/packages/schema-blocks/src/core/validation/BlockValidation.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidation.ts
@@ -1,4 +1,6 @@
 export enum BlockValidation {
+	/** This schema block is defined to recommend a particular inner block, but that block doesn't exist. */
+	MissingRecommendedBlock = -3,
 	/** This block was skipped during validation, on purpose. If you ever see this value, that's a bug.  */
 	Skipped = -2,
 	/** This block doesn't have any code that validates it, so we simply don't know if it's valid or not.  */
@@ -10,7 +12,7 @@ export enum BlockValidation {
 	/** This block has required attributes, but these attributes are missing or empty. */
 	MissingAttribute = 2,
 	/** This schema block is defined to require a particular inner block, but that block doesn't exist. */
-	MissingBlock = 3,
+	MissingRequiredBlock = 3,
 	/** There may be only one of this type of block, but we found more than one. */
 	TooMany = 4,
 }

--- a/packages/schema-blocks/src/functions/gutenberg/watch.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watch.ts
@@ -72,7 +72,7 @@ function generateSchemaForBlocks(
 		const validation = validations.find( v => v.clientId === block.clientId );
 		if ( validation && validation.result > BlockValidation.Valid ) {
 			dispatch( "core/block-editor" ).updateBlockAttributes( block.clientId, { "yoast-schema": null } );
-			return;
+			continue;
 		}
 
 		const definition = schemaDefinitions[ block.name ];

--- a/packages/schema-blocks/src/functions/gutenberg/watch.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watch.ts
@@ -71,7 +71,8 @@ function generateSchemaForBlocks(
 
 		const validation = validations.find( v => v.clientId === block.clientId );
 		if ( validation && validation.result > BlockValidation.Valid ) {
-			continue;
+			dispatch( "core/block-editor" ).updateBlockAttributes( block.clientId, { "yoast-schema": null } );
+			return;
 		}
 
 		const definition = schemaDefinitions[ block.name ];

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -2,8 +2,8 @@ import { getBlockType } from "../BlockHelper";
 import { select } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
-import { BlockValidationResult } from "../../core/validation";
-import { BlockValidation } from "../../core/validation";
+import { BlockValidation, BlockValidationResult } from "../../core/validation";
+import { getAllDescendantIssues } from "../validators/getAllDescendantIssues";
 
 const analysisMessageTemplates: Record<number, string> = {
 	[ BlockValidation.MissingBlock ]: "The '{child}' block is {status} but missing.",
@@ -80,21 +80,6 @@ function getAnalysisConclusion( validation: BlockValidation, issues: analysisIss
 			color: "green",
 		} as sidebarWarning;
 	}
-}
-
-/**
- * Gathers all validation issues recursively and flattens them into one list.
- *
- * @param validation The root validation result.
- *
- * @return all validation results.
- */
-function getAllDescendantIssues( validation: BlockValidationResult ): BlockValidationResult[] {
-	let results = [ validation ];
-	validation.issues.forEach( issue => {
-		results = results.concat( getAllDescendantIssues( issue ) );
-	} );
-	return results;
 }
 
 /**

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -3,7 +3,7 @@ import { select } from "@wordpress/data";
 import { __ } from "@wordpress/i18n";
 import { get } from "lodash";
 import { BlockValidation, BlockValidationResult } from "../../core/validation";
-import { getAllDescendantIssues } from "../validators/getAllDescendantIssues";
+import { getAllDescendantIssues } from "../validators";
 
 const analysisMessageTemplates: Record<number, string> = {
 	[ BlockValidation.MissingBlock ]: "The '{child}' block is {status} but missing.",

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -7,7 +7,8 @@ import { getAllDescendantIssues } from "../validators";
 import { BlockPresence } from "../../core/validation/BlockValidationResult";
 
 const analysisMessageTemplates: Record<number, string> = {
-	[ BlockValidation.MissingBlock ]: "The '{child}' block is {presence} but missing.",
+	[ BlockValidation.MissingRequiredBlock ]: "The '{child}' block is required but missing.",
+	[ BlockValidation.MissingRecommendedBlock ]: "The '{child}' block is recommended but missing.",
 	[ BlockValidation.MissingAttribute ]: "The '{child}' block is empty.",
 };
 
@@ -65,7 +66,7 @@ export function replaceVariables( issue: analysisIssue ): string {
  */
 function getAnalysisConclusion( validation: BlockValidation, issues: analysisIssue[] ): sidebarWarning {
 	// Show a red bullet when not all required blocks have been completed.
-	if ( issues.some( issue => issue.result === BlockValidation.MissingBlock && issue.presence === BlockPresence.Required ||
+	if ( issues.some( issue => issue.result === BlockValidation.MissingRequiredBlock ||
 		issue.result === BlockValidation.MissingAttribute ) ) {
 		return {
 			text: __( "Not all required blocks have been completed! No " + issues[ 0 ].parent +
@@ -74,14 +75,9 @@ function getAnalysisConclusion( validation: BlockValidation, issues: analysisIss
 		} as sidebarWarning;
 	}
 
-	// Show a green bullet when all required blocks have been completed.
-	const requiredBlockIssues = issues.filter( issue => {
-		return issue.presence === BlockPresence.Required;
-	} );
-
 	if ( validation === BlockValidation.Valid ||
-		requiredBlockIssues.every( issue => issue.result !== BlockValidation.MissingAttribute &&
-			issue.result !== BlockValidation.MissingBlock ) ) {
+		issues.every( issue => issue.result !== BlockValidation.MissingAttribute &&
+			issue.result !== BlockValidation.MissingRequiredBlock ) ) {
 		return {
 			text: __( "Good job! All required blocks have been completed.", "wpseo-schema-blocks" ),
 			color: "green",

--- a/packages/schema-blocks/src/functions/validators/getAllDescendantIssues.ts
+++ b/packages/schema-blocks/src/functions/validators/getAllDescendantIssues.ts
@@ -1,0 +1,16 @@
+import { BlockValidationResult } from "../../core/validation";
+
+/**
+ * Gathers all validation issues recursively and flattens them into one list.
+ *
+ * @param validation The root validation result.
+ *
+ * @return all validation results.
+ */
+export function getAllDescendantIssues( validation: BlockValidationResult ): BlockValidationResult[] {
+	let results = [ validation ];
+	validation.issues.forEach( issue => {
+		results = results.concat( getAllDescendantIssues( issue ) );
+	} );
+	return results;
+}

--- a/packages/schema-blocks/src/functions/validators/getAllDescendantIssues.ts
+++ b/packages/schema-blocks/src/functions/validators/getAllDescendantIssues.ts
@@ -7,10 +7,12 @@ import { BlockValidationResult } from "../../core/validation";
  *
  * @return all validation results.
  */
-export function getAllDescendantIssues( validation: BlockValidationResult ): BlockValidationResult[] {
+function getAllDescendantIssues( validation: BlockValidationResult ): BlockValidationResult[] {
 	let results = [ validation ];
 	validation.issues.forEach( issue => {
 		results = results.concat( getAllDescendantIssues( issue ) );
 	} );
 	return results;
 }
+
+export default getAllDescendantIssues;

--- a/packages/schema-blocks/src/functions/validators/index.ts
+++ b/packages/schema-blocks/src/functions/validators/index.ts
@@ -1,11 +1,13 @@
 import attributeExists from "./attributeExists";
 import attributeNotEmpty from "./attributeNotEmpty";
+import getAllDescendantIssues from "./getAllDescendantIssues";
 import getInvalidInnerBlocks from "./innerBlocksValid";
 import isValidResult from "./isValidResult";
 
 export {
 	attributeExists,
 	attributeNotEmpty,
+	getAllDescendantIssues,
 	getInvalidInnerBlocks,
 	isValidResult,
 };

--- a/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
+++ b/packages/schema-blocks/src/functions/validators/innerBlocksValid.ts
@@ -30,9 +30,13 @@ function findMissingBlocks( existingBlocks: BlockInstance[], allBlocks: Required
 		return ! existingBlocks.some( existingBlock => existingBlock.name === block.name );
 	} );
 
+	// Determine which BlockValidation value should be mapped to the new BlockValidationResult.
+	const missingBlockResult = ( blockPresence === BlockPresence.Required ? BlockValidation.MissingRequiredBlock
+		: BlockValidation.MissingRecommendedBlock );
+
 	// These blocks should've existed, but they don't.
 	return missingBlocks.map( missingBlock =>
-		new BlockValidationResult( null, missingBlock.name, BlockValidation.MissingBlock, blockPresence ) );
+		new BlockValidationResult( null, missingBlock.name, missingBlockResult, blockPresence ) );
 }
 
 /**

--- a/packages/schema-blocks/src/functions/validators/isValidResult.ts
+++ b/packages/schema-blocks/src/functions/validators/isValidResult.ts
@@ -8,5 +8,5 @@ import { BlockValidation } from "../../core/validation";
  * @returns {boolean} Whether the result is Valid or Invalid.
 */
 export default function isValidResult( result: BlockValidation ): boolean {
-	return result === BlockValidation.Valid || result === BlockValidation.Unknown;
+	return result === BlockValidation.Valid || result === BlockValidation.Unknown || result === BlockValidation.MissingRecommendedBlock;
 }

--- a/packages/schema-blocks/tests/core/Definition.test.ts
+++ b/packages/schema-blocks/tests/core/Definition.test.ts
@@ -73,7 +73,7 @@ describe( "The Definition class", () => {
 		// Arrange.
 		const testInstructions = {
 			test1: new TestInstruction( "test1", BlockValidation.Valid ),
-			test2: new TestInstruction( "test2", BlockValidation.MissingBlock ),
+			test2: new TestInstruction( "test2", BlockValidation.MissingRequiredBlock ),
 		};
 		const testCase = new TestDefinition( "", "", testInstructions, null );
 
@@ -86,14 +86,14 @@ describe( "The Definition class", () => {
 		expect( result.issues[ 0 ].result ).toEqual( BlockValidation.Valid );
 		expect( result.issues[ 1 ].name ).toEqual( "test" );
 		expect( result.issues[ 1 ].clientId ).toEqual( "id2" );
-		expect( result.issues[ 1 ].result ).toEqual( BlockValidation.MissingBlock );
+		expect( result.issues[ 1 ].result ).toEqual( BlockValidation.MissingRequiredBlock );
 	} );
 
 	it( "configures all known instructions", () => {
 		// Arrange.
 		const testInstructions = {
 			test1: new TestInstruction( "test1", BlockValidation.Valid ),
-			test2: new TestInstruction( "test2", BlockValidation.MissingBlock ),
+			test2: new TestInstruction( "test2", BlockValidation.MissingRequiredBlock ),
 		};
 		const testCase = new TestDefinition( "", "", testInstructions, null );
 

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -65,7 +65,7 @@ describe( "The SidebarWarningPresenter ", () => {
 
 		it( "creates warning messages for missing required blocks, with a footer message.", () => {
 			const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockPresence.Required );
-			testcase.issues.push( BlockValidationResult.MissingRequiredBlock( "missingblock", BlockPresence.Required ) );
+			testcase.issues.push( BlockValidationResult.MissingRequiredBlock( "missingblock" ) );
 
 			const result = createAnalysisMessages( testcase );
 
@@ -85,10 +85,10 @@ describe( "The SidebarWarningPresenter ", () => {
 			"the conclusion should still be green.", () => {
 			const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockPresence.Recommended );
 			testcase.issues.push(
-				BlockValidationResult.MissingRecommendedBlock( "missing recommended block", BlockPresence.Recommended ),
+				BlockValidationResult.MissingRecommendedBlock( "missing recommended block" ),
 			);
 			testcase.issues.push(
-				BlockValidationResult.MissingRecommendedBlock( "missing recommended block 2", BlockPresence.Recommended ),
+				BlockValidationResult.MissingRecommendedBlock( "missing recommended block 2" ),
 			);
 
 			const result = createAnalysisMessages( testcase );

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -59,7 +59,7 @@ describe( "The createAnalysisMessages method ", () => {
 
 	it( "creates warning messages for missing required blocks, with a footer message.", () => {
 		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockPresence.Required );
-		testcase.issues.push( new BlockValidationResult( null, "missingblock", BlockValidation.MissingBlock, BlockPresence.Required ) );
+		testcase.issues.push( new BlockValidationResult( null, "missingblock", BlockValidation.MissingRequiredBlock, BlockPresence.Required ) );
 
 		const result = createAnalysisMessages( testcase );
 
@@ -76,8 +76,8 @@ describe( "The createAnalysisMessages method ", () => {
 	it( "creates a warning for missing recommended blocks, but when all the required blocks are present " +
 		"the conclusion should still be green.", () => {
 		const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockPresence.Recommended );
-		testcase.issues.push( new BlockValidationResult( null, "missing recommended block", BlockValidation.MissingBlock, BlockPresence.Recommended ) );
-		testcase.issues.push( new BlockValidationResult( null, "missing recommended block 2", BlockValidation.MissingBlock, BlockPresence.Recommended ) );
+		testcase.issues.push( new BlockValidationResult( null, "missing recommended block", BlockValidation.MissingRecommendedBlock, BlockPresence.Recommended ) );
+		testcase.issues.push( new BlockValidationResult( null, "missing recommended block 2", BlockValidation.MissingRecommendedBlock, BlockPresence.Recommended ) );
 
 		const result = createAnalysisMessages( testcase );
 
@@ -135,7 +135,7 @@ describe( "The getWarnings method ", () => {
 
 	it( "creates a warning for a required block with validation problems.", () => {
 		const testcase = new BlockValidationResult( "1", "myBlock", BlockValidation.Invalid, BlockPresence.Required );
-		testcase.issues.push( new BlockValidationResult( "2", "innerblock1", BlockValidation.MissingBlock, BlockPresence.Required ) );
+		testcase.issues.push( new BlockValidationResult( "2", "innerblock1", BlockValidation.MissingRequiredBlock, BlockPresence.Required ) );
 		validations[ "1" ] = testcase;
 
 		const result = getWarnings( "1" );

--- a/packages/schema-blocks/tests/functions/validators/innerBlocksValid.test.ts
+++ b/packages/schema-blocks/tests/functions/validators/innerBlocksValid.test.ts
@@ -58,7 +58,8 @@ function mockDefinition( clientId: string, name: string, expectedValue: BlockVal
 }
 
 const createBlockValidationResultTestArrangement = [
-	{ name: "missingblock", reason: BlockValidation.MissingBlock },
+	{ name: "missingrequiredblock", reason: BlockValidation.MissingRequiredBlock },
+	{ name: "missingrecommendedblock", reason: BlockValidation.MissingRecommendedBlock },
 	{ name: "redundantblock", reason: BlockValidation.TooMany },
 	{ name: "missingattributeblock", reason: BlockValidation.MissingAttribute },
 	{ name: "validblock", reason: BlockValidation.Valid },
@@ -78,7 +79,7 @@ describe( "The BlockValidationResult constructor", () => {
 } );
 
 describe( "The findMissingBlocks function", () => {
-	it( "creates a BlockValidationResult with reason 'MissingBlock' when a required block is missing.", () => {
+	it( "creates a BlockValidationResult with reason 'MissingRequiredBlock' when a required block is missing.", () => {
 		// Arrange.
 		const requiredBlocks: RequiredBlock[] = [
 			{
@@ -102,10 +103,10 @@ describe( "The findMissingBlocks function", () => {
 		// Assert.
 		expect( result.length ).toEqual( 1 );
 		expect( result[ 0 ].name ).toEqual( "missingblock" );
-		expect( result[ 0 ].result ).toEqual( BlockValidation.MissingBlock );
+		expect( result[ 0 ].result ).toEqual( BlockValidation.MissingRequiredBlock );
 	} );
 
-	it( "creates a BlockValidationResult with reason 'MissingBlock' when a recommended block is missing.", () => {
+	it( "creates a BlockValidationResult with reason 'MissingRecommendedBlock' when a recommended block is missing.", () => {
 		// Arrange.
 		const recommendedBlocks: RecommendedBlock[] = [
 			{
@@ -128,7 +129,7 @@ describe( "The findMissingBlocks function", () => {
 		// Assert.
 		expect( result.length ).toEqual( 1 );
 		expect( result[ 0 ].name ).toEqual( "missingblock" );
-		expect( result[ 0 ].result ).toEqual( BlockValidation.MissingBlock );
+		expect( result[ 0 ].result ).toEqual( BlockValidation.MissingRecommendedBlock );
 	} );
 
 	it( "creates no missing blocks for required blocks that are present.", () => {
@@ -391,10 +392,10 @@ describe( "the getInvalidInnerBlocks function", () => {
 		expect( result.length ).toEqual( 4 );
 
 		// Be able to find missing blocks.
-		const missingBlock = result.filter( b => b.name === "missingBlock" && b.result === BlockValidation.MissingBlock );
+		const missingBlock = result.filter( b => b.name === "missingBlock" && b.result === BlockValidation.MissingRequiredBlock );
 		expect( missingBlock.length ).toEqual( 1 );
 		expect( missingBlock[ 0 ].name ).toEqual( "missingBlock" );
-		expect( missingBlock[ 0 ].result ).toEqual( BlockValidation.MissingBlock );
+		expect( missingBlock[ 0 ].result ).toEqual( BlockValidation.MissingRequiredBlock );
 
 		// Be able to find too many instances of singleton blocks.
 		const redundantBlocks: BlockValidationResult[] = result.filter( b => b.name === "redundantBlock" && b.result === BlockValidation.TooMany );

--- a/packages/schema-blocks/tests/functions/validators/validateMany.test.ts
+++ b/packages/schema-blocks/tests/functions/validators/validateMany.test.ts
@@ -27,7 +27,7 @@ describe( "The validateMany function", () => {
 		validation.issues = [
 			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Invalid, BlockPresence.Required ),
 			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingAttribute, BlockPresence.Required ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingBlock, BlockPresence.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingRequiredBlock, BlockPresence.Required ),
 			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.TooMany, BlockPresence.Required ),
 		];
 
@@ -48,7 +48,7 @@ describe( "The validateMany function", () => {
 			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Unknown, BlockPresence.Required ),
 			new BlockValidationResult( "innerblock1", "innerblock1", BlockValidation.Invalid, BlockPresence.Required ),
 			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingAttribute, BlockPresence.Required ),
-			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingBlock, BlockPresence.Required ),
+			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.MissingRequiredBlock, BlockPresence.Required ),
 			new BlockValidationResult( "innerblock2", "innerblock2", BlockValidation.TooMany, BlockPresence.Required ),
 		];
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Fixes a bug where Schema output would still be generated if all the required blocks had been valid before, even if they were no longer valid now.
* [@yoast/schema-blocks] Fixes a bug where Schema output would be generated even when no variation had been picked for the Location block.

## Relevant technical choices:

* If the Job Posting block overall isn't valid (`validation.result > BlockValidation.Valid`), we should dispatch a `null` Schema output to the store, to overwrite the Schema output that was potentially stored there before. 
* The Job location block template has multiple instructions that are validated. Therefore, these results should be combined in an 'overall' validation result by using `validateMany`. In order to do so, we first need to collect these results and flatten them into a list using `getAllDescendantIssues`.
* I created new values from `MissingBlock` in the `BlockValidation` enum: `MissingRecommendedBlock` and `MissingRequiredBlock`. This is because a missing recommended block should not make the overall validation result invalid, whereas a missing required block should. Now we can make that distinction.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add a Job Posting block to your post. Don't fill in anything.
* Publish the post, inspect the Schema output, and see that the `JobPosting` graph piece is **absent**.
* Fill in the title and description, but don't choose a location in the location picker.
    * Move the focus to another block to make sure the validations are executed (should be fixed in https://yoast.atlassian.net/browse/P2-780).
    * Update the post, see that the `JobPosting` graph piece is still **absent**.
* Choose a location in the location picker (preferably the remote location, because that one is already filled in).
    * Move the focus to another block to make sure the validations are executed.
    * Update the post, see that the `JobPosting` graph piece is now **present**.
* Remove a recommended block. 
    * Move the focus to another block to make sure the validations are executed.
    * See an orange bullet for that recommended block appear in the analysis.
    * See that the analysis conclusion is still green.
    * Update the post, see that the `JobPosting` graph piece is still **present**.
* There is a known bug: if you delete the text in the remote location, the `JobPosting` graph piece will stay present but it should be absent. This is due to https://yoast.atlassian.net/browse/P2-807. 
* Empty the title and/or description (don't remove them).
    * Move the focus to another block to make sure the validations are executed.
    * Update the post, see that the `JobPosting` graph piece is now **absent**.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes https://yoast.atlassian.net/browse/P2-695
