### PR TITLE
Re-introduces error message when not all required blocks have been filled in.

### DIFF
--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -38,14 +38,15 @@ function getValidationResult( clientId: string ): BlockValidationResult | null {
 }
 
 /**
- * If some required blocks are missing.
+ * If some required blocks are missing and/or not filled in.
  *
  * @param issues The block validation issues to check.
  *
- * @return `true` if some required blocks are missing, `false` if not.
+ * @return `true` if some required blocks are missing or not completed, `false` if not.
  */
-function someMissingRequiredBlocks( issues: BlockValidationResult[] ) {
-	return issues.some( issue => issue.result === BlockValidation.MissingBlock && issue.blockPresence === BlockPresence.Required );
+function someRequiredBlocksNotCompleted( issues: BlockValidationResult[] ) {
+	return issues.some( issue => issue.result === BlockValidation.MissingBlock && issue.blockPresence === BlockPresence.Required ||
+		issue.result === BlockValidation.MissingAttribute );
 }
 
 /**
@@ -60,7 +61,7 @@ function getAnalysisConclusion( validation: BlockValidationResult, issues: Block
 	let conclusionText = "";
 
 	// Show a red bullet when not all required blocks have been completed.
-	if ( someMissingRequiredBlocks( issues ) ) {
+	if ( someRequiredBlocksNotCompleted( issues ) ) {
 		conclusionText = sprintf(
 			/* translators: %s expands to the schema block name. */
 			__( "Not all required blocks have been completed! No %s schema will be generated for your page.", "yoast-schema-blocks" ),

--- a/packages/schema-blocks/src/instructions/blocks/Title.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/Title.tsx
@@ -6,6 +6,7 @@ import { VariableTagRichText } from "./VariableTagRichText";
 import { BlockValidation, BlockValidationResult } from "../../core/validation";
 import BlockInstruction from "../../core/blocks/BlockInstruction";
 import { BlockPresence } from "../../core/validation/BlockValidationResult";
+import { attributeExists, attributeNotEmpty } from "../../functions/validators";
 
 /**
  * Interface for a WordPress post object.
@@ -33,6 +34,19 @@ class Title extends VariableTagRichText {
 	};
 
 	/**
+	 * Whether the block is completed.
+	 *
+	 * E.g. whether the block's attribute in which the schema value is stored is filled in.
+	 *
+	 * @param blockInstance The block instance to check.
+	 *
+	 * @returns Whether the block is completed.
+	 */
+	private isCompleted( blockInstance: BlockInstance ): boolean {
+		return attributeNotEmpty( blockInstance, this.options.name ) && attributeExists( blockInstance, this.options.name );
+	}
+
+	/**
 	 * Checks if the instruction block is valid.
 	 *
 	 * @param blockInstance The attributes from the block.
@@ -45,8 +59,8 @@ class Title extends VariableTagRichText {
 		const blockTitle: string = blockInstance.attributes[ this.options.name ];
 		const postTitle: string = post.title;
 
-		if ( ! ( blockTitle && postTitle ) ) {
-			return BlockValidationResult.Valid( blockInstance );
+		if ( ! this.isCompleted( blockInstance ) ) {
+			return BlockValidationResult.MissingAttribute( blockInstance, this.options.name );
 		}
 
 		if ( blockTitle.toLocaleLowerCase() === postTitle.toLocaleLowerCase() ) {

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -46,6 +46,23 @@ describe( "The SidebarWarningPresenter ", () => {
 			} ] );
 		} );
 
+		it( "creates a footer message when some required blocks have missing attributes.", () => {
+			const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockPresence.Unknown );
+			testcase.issues.push(
+				new BlockValidationResult( null, "missingblockattribute", BlockValidation.MissingAttribute, BlockPresence.Unknown )
+			);
+
+			const result = createAnalysisMessages( testcase );
+
+			expect( result.length ).toEqual( 1 );
+			expect( result[ 0 ] ).toEqual(
+				{
+					text: "Not all required blocks have been completed! No mijnblock schema will be generated for your page.",
+					color: "red",
+				},
+			);
+		} );
+
 		it( "creates warning messages for missing required blocks, with a footer message.", () => {
 			const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockPresence.Required );
 			testcase.issues.push( BlockValidationResult.MissingBlock( "missingblock", BlockPresence.Required ) );
@@ -115,7 +132,7 @@ describe( "The SidebarWarningPresenter ", () => {
 
 			expect( result ).toEqual( [ {
 				text: "Good job! All required blocks have been completed.",
-				color: "green"
+				color: "green",
 			} ] );
 		} );
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [schema-blocks] Fixes a bug where the schema analysis would be green even if some required blocks were not filled in.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new post.
* Add a Job posting block to that post.
* Select an inner block in the newly added Job posting.
* Check the analysis section in the block's sidebar. 
	* It should contain a red bullet with the following message: `Not all required blocks have been completed! No job posting schema will be generated for your page.`
* Add a title, description to the job posting block, choose a location type (either 'office location' or 'remote') and fill the location information in.
* Check the analysis section in the block's sidebar. 
	* It should contain a **green** bullet with the following message: `Good job! All required blocks have been completed.`
* Remove the title, description and location blocks.
* Check the analysis section in the block's sidebar. 
	* It should contain a **red** bullet with the following message: `Not all required blocks have been completed! No job posting schema will be generated for your page.`
	* It should contain a **red** bullet for each removed block with the following message: `The '{Block name}' block is required but missing.`.
		* **Note**: `{Block name}` should say either 'Job title', 'Job description' or 'Job location', depending on the removed block.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
