### PR TITLE
Added watcher that removes a parent with variations but without innerblocks

### DIFF
--- a/packages/schema-blocks/src/functions/gutenberg/watch.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watch.ts
@@ -9,7 +9,9 @@ import storeBlockValidation from "./storeBlockValidation";
 import logger from "../logger";
 import { BlockPresence } from "../../core/validation/BlockValidationResult";
 import { getBlockType } from "../BlockHelper";
-import {ExtendedBlock} from "../../type-adapters/ExtendedBlock";
+import { ExtendedBlock } from "../../type-adapters/ExtendedBlock";
+import { mapBlocksRecursively } from "../innerBlocksHelper";
+import recurseOverBlocks from "../blocks/recurseOverBlocks";
 
 let updatingSchema = false;
 let previousRootBlocks: BlockInstance[];
@@ -139,6 +141,7 @@ export default function watch() {
 				storeBlockValidation( validations );
 
 				warningWatcher( rootBlocks, previousRootBlocks );
+				watchEmptyVariations( rootBlocks, previousRootBlocks );
 
 				generateSchemaForBlocks( rootBlocks, validations, previousRootBlocks );
 
@@ -147,39 +150,45 @@ export default function watch() {
 			updatingSchema = false;
 		}, 250, { trailing: true } ),
 	);
-
-	watchEmptyVariations();
 }
 
 /**
  * Watches the empty variation containers.
+ *
+ *
+ * @param blocks The current list of blocks.
+ * @param previousBlocks The previous list of blocks.
  */
-function watchEmptyVariations() {
-	subscribe(
-		debounce( () => {
-			const rootBlocks: BlockInstance[] = select( "core/block-editor" ).getBlocks();
-			if ( rootBlocks === previousRootBlocks ) {
-				return;
-			}
+function watchEmptyVariations( blocks: BlockInstance[], previousBlocks: BlockInstance[] ) {
+	const currentBlockIds: string[] = mapBlocksRecursively( blocks, block => block.clientId );
 
-			rootBlocks.forEach( block => {
-				if ( isUndefined( block.attributes[ "is-yoast-schema-block" ] ) ) {
-					return;
-				}
+	if ( ! previousBlocks ) {
+		return;
+	}
 
-				if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
-					block.innerBlocks.forEach( innerBlock => {
-						const blockType = getBlockType( innerBlock.name ) as ExtendedBlock;
-						if ( isUndefined( blockType.variations ) ) {
-							return;
-						}
+	recurseOverBlocks( previousBlocks, ( block: BlockInstance ) => {
+		// Is it a Yoast block?
+		if ( isUndefined( block.attributes[ "is-yoast-schema-block" ] ) ) {
+			return;
+		}
 
-						if ( innerBlock.innerBlocks.length === 0 ) {
-							dispatch( "core/block-editor" ).removeBlock( innerBlock.clientId );
-						}
-					} );
-				}
-			} );
-		}, 250, { trailing: true } ),
-	);
+		const removedInnerBlocks: BlockInstance[] = block.innerBlocks
+			.filter( innerBlock => ! currentBlockIds.includes( innerBlock.clientId ) );
+
+		// Nothing has been removed.
+		if ( removedInnerBlocks.length === 0 ) {
+			return;
+		}
+
+		// Does the block have variations.
+		const blockType = getBlockType( block.name ) as ExtendedBlock;
+		if ( isUndefined( blockType.variations )  ) {
+			return;
+		}
+
+		const currentBlock = select( "core/block-editor" ).getBlock( block.clientId );
+		if ( currentBlock.innerBlocks.length === 0 ) {
+			dispatch( "core/block-editor" ).removeBlock( currentBlock.clientId );
+		}
+	} );
 }

--- a/packages/schema-blocks/src/functions/gutenberg/watchers/emptyVariationsWatcher.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watchers/emptyVariationsWatcher.ts
@@ -8,8 +8,7 @@ import { ExtendedBlock } from "../../../type-adapters/ExtendedBlock";
 import { dispatch, select } from "@wordpress/data";
 
 /**
- * Watches the empty variation containers.
- *
+ * Watches the empty variation containers and remove them when needed.
  *
  * @param blocks The current list of blocks.
  * @param previousBlocks The previous list of blocks.

--- a/packages/schema-blocks/src/functions/gutenberg/watchers/emptyVariationsWatcher.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watchers/emptyVariationsWatcher.ts
@@ -1,0 +1,49 @@
+import { BlockInstance } from "@wordpress/blocks";
+import { isUndefined } from "lodash";
+
+import { mapBlocksRecursively } from "../../innerBlocksHelper";
+import recurseOverBlocks from "../../blocks/recurseOverBlocks";
+import { getBlockType } from "../../BlockHelper";
+import { ExtendedBlock } from "../../../type-adapters/ExtendedBlock";
+import { dispatch, select } from "@wordpress/data";
+
+/**
+ * Watches the empty variation containers.
+ *
+ *
+ * @param blocks The current list of blocks.
+ * @param previousBlocks The previous list of blocks.
+ */
+export default function emptyVariationsWatcher( blocks: BlockInstance[], previousBlocks: BlockInstance[] ) {
+	const currentBlockIds: string[] = mapBlocksRecursively( blocks, block => block.clientId );
+
+	if ( ! previousBlocks ) {
+		return;
+	}
+
+	recurseOverBlocks( previousBlocks, ( block: BlockInstance ) => {
+		// Is it a Yoast block?
+		if ( isUndefined( block.attributes[ "is-yoast-schema-block" ] ) ) {
+			return;
+		}
+
+		const removedInnerBlocks: BlockInstance[] = block.innerBlocks
+			.filter( innerBlock => ! currentBlockIds.includes( innerBlock.clientId ) );
+
+		// Nothing has been removed.
+		if ( removedInnerBlocks.length === 0 ) {
+			return;
+		}
+
+		// Does the block have variations.
+		const blockType = getBlockType( block.name ) as ExtendedBlock;
+		if ( isUndefined( blockType.variations )  ) {
+			return;
+		}
+
+		const currentBlock = select( "core/block-editor" ).getBlock( block.clientId );
+		if ( currentBlock.innerBlocks.length === 0 ) {
+			dispatch( "core/block-editor" ).removeBlock( currentBlock.clientId );
+		}
+	} );
+}

--- a/packages/schema-blocks/src/type-adapters/ExtendedBlock.ts
+++ b/packages/schema-blocks/src/type-adapters/ExtendedBlock.ts
@@ -1,0 +1,7 @@
+import { Block } from "@wordpress/blocks";
+import { BlockVariation } from "./ExtendedBlockConfiguration";
+
+
+export type ExtendedBlock = Block & {
+	variations: BlockVariation[];
+};

--- a/packages/schema-blocks/src/type-adapters/ExtendedBlock.ts
+++ b/packages/schema-blocks/src/type-adapters/ExtendedBlock.ts
@@ -1,7 +1,6 @@
 import { Block } from "@wordpress/blocks";
 import { BlockVariation } from "./ExtendedBlockConfiguration";
 
-
 export type ExtendedBlock = Block & {
 	variations: BlockVariation[];
 };


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Remove the parent when a variation itself is removed.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Add a job posting
* Choose the base salary as variation
* Fill it in and remove the base salary
* In the right menu at the top choose: code editor
* See the entire location block being removed.
* Alternative route: choose the structure menu, see:
<img width="329" alt="Edit_Post_‹_Basic_—_WordPress" src="https://user-images.githubusercontent.com/325040/113247374-36bfa100-92bb-11eb-949d-b272f9c9a420.png">
  

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
