### PR TITLE
Added typings entry in schema-blocks package.json

### DIFF
--- a/packages/schema-blocks/package.json
+++ b/packages/schema-blocks/package.json
@@ -2,6 +2,7 @@
   "name": "@yoast/schema-blocks",
   "version": "1.6.0",
   "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "license": "MIT",
   "private": false,
   "dependencies": {
@@ -60,7 +61,7 @@
     "lint": "eslint \"src/**\"",
     "lint-fix": "eslint \"src/**\" --fix",
     "test": "jest",
-    "prepublishOnly": "rm -rf dist && yarn build && mkdir dist/css && cp -r css/*.css dist/css && cp package.json dist/package.json && json -I -f dist/package.json -e \"this.main='index.js'\""
+    "prepublishOnly": "rm -rf dist && yarn build && mkdir dist/css && cp -r css/*.css dist/css && cp package.json dist/package.json && json -I -f dist/package.json -e \"this.main='index.js'\" -e \"this.typings='index.d.ts'\""
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [schema-blocks] Added typings entry to `package.json` to make sure that other packages can consume the typings even with a linked schema-blocks package.

## Relevant technical choices:

* The location of the typings file of the schema-blocks package (`index.d.ts`) changes based on whether it is unlinked/installed or linked.
	* **Linked**: located within `dist/index.d.ts`
	* **Unlinked**: located within the package root: `index.d.ts`.
* This means that with a linked monorepo, WordPress SEO Premium cannot find the typings file.
	* It assumes that it is located in `index.d.ts`, but with a linked monorepo it is located within `dist/index.d.ts`.
* This PR solves this by explicitly setting the path to the typings in the `package.json` file.
* I also adapted the `prepublishOnly` hook such that the typings property is updated when the package is published.
	* Like happens for `main: dist/index.js` -> `main: index.js` right now.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
