### PR TITLE
Show the variation picker again when its inner-blocks are removed

### DIFF
--- a/packages/schema-blocks/src/functions/presenters/VariationPickerPresenter.tsx
+++ b/packages/schema-blocks/src/functions/presenters/VariationPickerPresenter.tsx
@@ -1,0 +1,102 @@
+import { useDispatch, useSelect } from "@wordpress/data";
+// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+// @ts-ignore -- __experimentalBlockVariationPicker is defined in the package, though no type info is available.
+import { __experimentalBlockVariationPicker as ExperimentalBlockVariationPicker, useBlockProps } from "@wordpress/block-editor";
+import { BlockInstance, createBlock } from "@wordpress/blocks";
+import { get, map } from "lodash";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { createElement } from "@wordpress/element";
+import { VariationInterface } from "../../instructions/blocks/Variation";
+import { RenderEditProps } from "../..";
+
+/**
+* Creates the blocks from the inner block templates.
+*
+* @param innerBlocksTemplate The inner blocks template.
+*
+* @returns The created blocks.
+*/
+function createBlocksFromInnerBlocksTemplate( innerBlocksTemplate: BlockInstance[] ): BlockInstance[] {
+   return map(
+       innerBlocksTemplate,
+       ( { name, attributes = {}, innerBlocks = [] } ) =>
+           createBlock(
+               name,
+               attributes,
+               createBlocksFromInnerBlocksTemplate( innerBlocks ),
+           ),
+   );
+};
+
+/**
+ * Renders the variation picker.
+ * 
+ * @param props The props. 
+ * 
+ * @returns {ReactElement} The component.
+ */
+export default function VariationPickerPresenter( {
+    clientId,
+    name,
+    setAttributes,
+    key,
+}: RenderEditProps & { key: string } ) {
+    const { blockType, defaultVariation, variations } = useSelect(
+        select => {
+            const {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+                // @ts-ignore -- getBlockVariations is defined in the package, though no type info is available.
+                getBlockVariations,
+                getBlockType,
+                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+                // @ts-ignore -- getDefaultBlockVariation is defined in the package, though no type info is available.
+                getDefaultBlockVariation,
+            } = select( "core/blocks" );
+
+            return {
+                blockType: getBlockType( name ),
+                defaultVariation: getDefaultBlockVariation( name, "block" ),
+                variations: getBlockVariations( name, "block" ),
+            };
+        },
+        [ name ],
+    );
+
+    const { replaceInnerBlocks } = useDispatch( "core/block-editor" );
+    const blockProps = useBlockProps();
+
+    /**
+     * Creates the block that is selected in the variation picker.
+     *
+     * @param nextVariation The variation that is selected by the user.
+     */
+    const onSelect = ( nextVariation = defaultVariation ) => {
+        if ( nextVariation.attributes ) {
+            setAttributes( nextVariation.attributes );
+        }
+
+        if ( nextVariation.innerBlocks ) {
+            replaceInnerBlocks(
+                clientId,
+                createBlocksFromInnerBlocksTemplate(
+                    nextVariation.innerBlocks,
+                ),
+                true,
+            );
+        }
+    };
+
+    return (
+        <div key={ key } { ...blockProps }>
+            <ExperimentalBlockVariationPicker
+                icon={ false }
+                label={ get( blockType, [ "title" ] ) }
+                variations={ variations.map( ( variation: VariationInterface ) => {
+                    return { ...variation, icon: <span dangerouslySetInnerHTML={ { __html: variation.icon } } /> };
+                } ) }
+                onSelect={ onSelect }
+                allowSkip={ false }
+            />
+        </div>
+    );
+}

--- a/packages/schema-blocks/src/functions/presenters/VariationPickerPresenter.tsx
+++ b/packages/schema-blocks/src/functions/presenters/VariationPickerPresenter.tsx
@@ -10,93 +10,88 @@ import { VariationInterface } from "../../instructions/blocks/Variation";
 import { RenderEditProps } from "../..";
 
 /**
-* Creates the blocks from the inner block templates.
-*
-* @param innerBlocksTemplate The inner blocks template.
-*
-* @returns The created blocks.
-*/
+ * Creates the blocks from the inner block templates.
+ *
+ * @param innerBlocksTemplate The inner blocks template.
+ *
+ * @returns The created blocks.
+ */
 function createBlocksFromInnerBlocksTemplate( innerBlocksTemplate: BlockInstance[] ): BlockInstance[] {
-   return map(
-       innerBlocksTemplate,
-       ( { name, attributes = {}, innerBlocks = [] } ) =>
-           createBlock(
-               name,
-               attributes,
-               createBlocksFromInnerBlocksTemplate( innerBlocks ),
-           ),
-   );
-};
+	return map(
+		innerBlocksTemplate,
+		( { name, attributes = {}, innerBlocks = [] } ) =>
+			createBlock(
+				name,
+				attributes,
+				createBlocksFromInnerBlocksTemplate( innerBlocks ),
+			),
+	);
+}
 
 /**
  * Renders the variation picker.
- * 
- * @param props The props. 
- * 
+ *
+ * @param props The props.
+ *
  * @returns {ReactElement} The component.
  */
-export default function VariationPickerPresenter( {
-    clientId,
-    name,
-    setAttributes,
-    key,
-}: RenderEditProps & { key: string } ) {
-    const { blockType, defaultVariation, variations } = useSelect(
-        select => {
-            const {
-                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-                // @ts-ignore -- getBlockVariations is defined in the package, though no type info is available.
-                getBlockVariations,
-                getBlockType,
-                // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-                // @ts-ignore -- getDefaultBlockVariation is defined in the package, though no type info is available.
-                getDefaultBlockVariation,
-            } = select( "core/blocks" );
+export default function VariationPickerPresenter( { clientId, name, setAttributes, key }: RenderEditProps & { key: string } ) {
+	const { blockType, defaultVariation, variations } = useSelect(
+		select => {
+			const {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+				// @ts-ignore -- getBlockVariations is defined in the package, though no type info is available.
+				getBlockVariations,
+				getBlockType,
+				// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+				// @ts-ignore -- getDefaultBlockVariation is defined in the package, though no type info is available.
+				getDefaultBlockVariation,
+			} = select( "core/blocks" );
 
-            return {
-                blockType: getBlockType( name ),
-                defaultVariation: getDefaultBlockVariation( name, "block" ),
-                variations: getBlockVariations( name, "block" ),
-            };
-        },
-        [ name ],
-    );
+			return {
+				blockType: getBlockType( name ),
+				defaultVariation: getDefaultBlockVariation( name, "block" ),
+				variations: getBlockVariations( name, "block" ),
+			};
+		},
+		[ name ],
+	);
 
-    const { replaceInnerBlocks } = useDispatch( "core/block-editor" );
-    const blockProps = useBlockProps();
+	const { replaceInnerBlocks } = useDispatch( "core/block-editor" );
+	const blockProps = useBlockProps();
 
-    /**
-     * Creates the block that is selected in the variation picker.
-     *
-     * @param nextVariation The variation that is selected by the user.
-     */
-    const onSelect = ( nextVariation = defaultVariation ) => {
-        if ( nextVariation.attributes ) {
-            setAttributes( nextVariation.attributes );
-        }
+	/**
+	 * Creates the block that is selected in the variation picker.
+	 *
+	 * @param nextVariation The variation that is selected by the user.
+	 */
+	const onSelect = ( nextVariation = defaultVariation ) => {
+		if ( nextVariation.attributes ) {
+			setAttributes( nextVariation.attributes );
+		}
 
-        if ( nextVariation.innerBlocks ) {
-            replaceInnerBlocks(
-                clientId,
-                createBlocksFromInnerBlocksTemplate(
-                    nextVariation.innerBlocks,
-                ),
-                true,
-            );
-        }
-    };
+		if ( nextVariation.innerBlocks ) {
+			replaceInnerBlocks(
+				clientId,
+				createBlocksFromInnerBlocksTemplate(
+					nextVariation.innerBlocks,
+				),
+				true,
+			);
+		}
+	};
 
-    return (
-        <div key={ key } { ...blockProps }>
-            <ExperimentalBlockVariationPicker
-                icon={ false }
-                label={ get( blockType, [ "title" ] ) }
-                variations={ variations.map( ( variation: VariationInterface ) => {
-                    return { ...variation, icon: <span dangerouslySetInnerHTML={ { __html: variation.icon } } /> };
-                } ) }
-                onSelect={ onSelect }
-                allowSkip={ false }
-            />
-        </div>
-    );
+	return (
+		<div key={ key } { ...blockProps }>
+			<ExperimentalBlockVariationPicker
+				icon={ false }
+				label={ get( blockType, [ "title" ] ) }
+				variations={ variations.map( ( variation: VariationInterface ) => {
+					return { ...variation, icon: <span dangerouslySetInnerHTML={ { __html: variation.icon } } /> };
+				} ) }
+				onSelect={ onSelect }
+				allowSkip={ false }
+			/>
+		</div>
+	);
 }

--- a/packages/schema-blocks/src/instructions/blocks/VariationPicker.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/VariationPicker.tsx
@@ -1,16 +1,12 @@
 import BlockInstruction from "../../core/blocks/BlockInstruction";
-import { select, useDispatch, useSelect } from "@wordpress/data";
+import { useSelect } from "@wordpress/data";
 import { RenderEditProps } from "../../core/blocks/BlockDefinition";
 import BlockLeaf from "../../core/blocks/BlockLeaf";
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore -- __experimentalBlockVariationPicker is defined in the package, though no type info is available.
-import { __experimentalBlockVariationPicker as ExperimentalBlockVariationPicker, useBlockProps } from "@wordpress/block-editor";
-import { get, map } from "lodash";
-import { BlockInstance, createBlock } from "@wordpress/blocks";
+import { BlockInstance } from "@wordpress/blocks";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { createElement } from "@wordpress/element";
-import { VariationInterface } from "./Variation";
 import { BlockValidationResult } from "../../core/validation";
+import VariationPickerPresenter from "../../functions/presenters/VariationPickerPresenter";
 
 /**
  * Helper function to check whether the block instance includes a picked variation.
@@ -38,102 +34,17 @@ class VariationPicker extends BlockInstruction {
 	 * @returns The variation picker or null.
 	 */
 	edit( props: RenderEditProps, leaf: BlockLeaf, index: number ) {
-		const { clientId } = props;
-		const hasInnerBlocks = select( "core/block-editor" ).getBlock( clientId ).innerBlocks.length > 0;
+		const { innerBlocks } = useSelect(
+			select => select( "core/block-editor" ).getBlock( props.clientId ),
+			[ props.clientId ],
+		);
+		const hasInnerBlocks = innerBlocks.length > 0;
 
 		if ( hasInnerBlocks ) {
 			return null;
 		}
 
-		return this.renderVariationPicker( props, "variation-picker-" + index );
-	}
-
-	/**
-	 * Creates the blocks from the inner block templates.
-	 *
-	 * @param innerBlocksTemplate The inner blocks template.
-	 *
-	 * @returns The created blocks.
-	 */
-	createBlocksFromInnerBlocksTemplate = ( innerBlocksTemplate: BlockInstance[] ): BlockInstance[] => {
-		return map(
-			innerBlocksTemplate,
-			( { name, attributes = {}, innerBlocks = [] } ) =>
-				createBlock(
-					name,
-					attributes,
-					this.createBlocksFromInnerBlocksTemplate( innerBlocks ),
-				),
-		);
-	};
-
-	/**
-	 * Renders the variation picker.
-	 *
-	 * @param props The render edit props.
-	 * @param key   The variation picker's key.
-	 *
-	 * @returns The variation picker.
-	 */
-	renderVariationPicker( props: RenderEditProps, key: string ) {
-		const { blockType, defaultVariation, variations } = useSelect(
-			( selectStore ) => {
-				const {
-					// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-					// @ts-ignore -- getBlockVariations is defined in the package, though no type info is available.
-					getBlockVariations,
-					getBlockType,
-					// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-					// @ts-ignore -- getDefaultBlockVariation is defined in the package, though no type info is available.
-					getDefaultBlockVariation,
-				} = selectStore( "core/blocks" );
-
-				return {
-					blockType: getBlockType( props.name ),
-					defaultVariation: getDefaultBlockVariation( props.name, "block" ),
-					variations: getBlockVariations( props.name, "block" ),
-				};
-			},
-			[ props.name ],
-		);
-
-		const { replaceInnerBlocks } = useDispatch( "core/block-editor" );
-		const blockProps = useBlockProps();
-
-		/**
-		 * Creates the block that is selected in the variation picker.
-		 *
-		 * @param nextVariation The variation that is selected by the user.
-		 */
-		const onSelect = ( nextVariation = defaultVariation ) => {
-			if ( nextVariation.attributes ) {
-				props.setAttributes( nextVariation.attributes );
-			}
-
-			if ( nextVariation.innerBlocks ) {
-				replaceInnerBlocks(
-					props.clientId,
-					this.createBlocksFromInnerBlocksTemplate(
-						nextVariation.innerBlocks,
-					),
-					true,
-				);
-			}
-		};
-
-		return (
-			<div key={ key } { ...blockProps }>
-				<ExperimentalBlockVariationPicker
-					icon={ false }
-					label={ get( blockType, [ "title" ] ) }
-					variations={ variations.map( ( variation: VariationInterface ) => {
-						return { ...variation, icon: <span dangerouslySetInnerHTML={ { __html: variation.icon } } /> };
-					} ) }
-					onSelect={ onSelect }
-					allowSkip={ true }
-				/>
-			</div>
-		);
+		return <VariationPickerPresenter { ...props } key={ "variation-picker-" + index } />;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [schema-blocks] Shows the variation picker again when a variation is removed.

## Relevant technical choices:

* Introduces the `VariationPickerPresenter` that envelops the Variation Picker component.
	* This is needed for the `useSelect` to work (it only works across React component boundaries, so a new component needed to be introduced).
	* This makes the code cleaner as well.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* **Note**: test this in the WordPress SEO Premium plugin.
* Create a new post.
* Add a job posting block.
* Choose one of the two salary variations inside of the base salary block (within the job posting).
	* E.g. 'base salary' or 'salary range'. 
* Remove the selected salary variation again.
* The variation picker (in which you can choose to re-add a salary variation) should be restored.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
