### PR TITLE
Create three categories in the BlockValidation enum

### DIFF
--- a/packages/schema-blocks/src/core/validation/BlockValidation.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidation.ts
@@ -1,18 +1,28 @@
 export enum BlockValidation {
-	/** This schema block is defined to recommend a particular inner block, but that block doesn't exist. */
-	MissingRecommendedBlock = -3,
-	/** This block was skipped during validation, on purpose. If you ever see this value, that's a bug.  */
-	Skipped = -2,
-	/** This block doesn't have any code that validates it, so we simply don't know if it's valid or not.  */
-	Unknown = -1,
+	/** VALID RESULTS (100+): Schema can be output. */
+
 	/** This block (AND all of its innerblocks) are fine. */
-	Valid = 0,
+	Valid = 100,
+	/** This block doesn't have any code that validates it, so we simply don't know if it's valid or not.  */
+	Unknown = 101,
+	/** This block was skipped during validation, on purpose. If you ever see this value, that's a bug.  */
+	Skipped = 102,
+
+	/** OK RESULTS (200+): Will give an orange bullet, but will not prevent Schema output.
+
+	 /** This block is not completely valid, but should not prevent the Schema to be output either. */
+	OK = 200,
+	/** This block is defined to recommend a particular inner block, but that block doesn't exist. */
+	MissingRecommendedBlock = 201,
+
+	/** INVALID RESULTS (300+): Will prevent Schema output.
+
 	/** This block (OR some of its innerblocks) have a problem. The particular problem must be specified in BlockValidationResult.issues */
-	Invalid = 1,
+	Invalid = 300,
 	/** This block has required attributes, but these attributes are missing or empty. */
-	MissingAttribute = 2,
-	/** This schema block is defined to require a particular inner block, but that block doesn't exist. */
-	MissingRequiredBlock = 3,
+	MissingAttribute = 301,
+	/** This block is defined to require a particular inner block, but that block doesn't exist. */
+	MissingRequiredBlock = 302,
 	/** There may be only one of this type of block, but we found more than one. */
-	TooMany = 4,
+	TooMany = 303,
 }

--- a/packages/schema-blocks/src/functions/gutenberg/watch.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watch.ts
@@ -8,6 +8,7 @@ import { BlockValidation, BlockValidationResult } from "../../core/validation";
 import storeBlockValidation from "./storeBlockValidation";
 import logger from "../logger";
 import { BlockPresence } from "../../core/validation/BlockValidationResult";
+import { isValidResult } from "../validators";
 
 let updatingSchema = false;
 let previousRootBlocks: BlockInstance[];
@@ -71,7 +72,7 @@ function generateSchemaForBlocks(
 		}
 
 		const validation = validations.find( v => v.clientId === block.clientId );
-		if ( validation && validation.result > BlockValidation.Valid ) {
+		if ( validation && ! isValidResult( validation.result ) ) {
 			dispatch( "core/block-editor" ).updateBlockAttributes( block.clientId, { "yoast-schema": null } );
 			continue;
 		}

--- a/packages/schema-blocks/src/functions/validators/isValidResult.ts
+++ b/packages/schema-blocks/src/functions/validators/isValidResult.ts
@@ -2,11 +2,12 @@ import { BlockValidation } from "../../core/validation";
 
 /**
  * Determines if a specific validation result is essentially invalid or not.
+ * 'Valid' means that Schema can be output, 'invalid' means that it should not be output.
  *
  * @param result The source value.
  *
- * @returns {boolean} Whether the result is Valid or Invalid.
+ * @returns Whether the result is Valid or Invalid.
 */
 export default function isValidResult( result: BlockValidation ): boolean {
-	return result === BlockValidation.Valid || result === BlockValidation.Unknown || result === BlockValidation.MissingRecommendedBlock;
+	return result < 300;
 }

--- a/packages/schema-blocks/src/instructions/blocks/Title.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/Title.tsx
@@ -67,8 +67,7 @@ class Title extends VariableTagRichText {
 			return new BlockValidationResult(
 				blockInstance.clientId,
 				blockInstance.name,
-				// 'Only' a warning, so the instruction is still valid.
-				BlockValidation.Valid,
+				BlockValidation.OK,
 				BlockPresence.Recommended,
 				sprintf(
 					/* Translators: %s expands to the block's name. */


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Refactors the `BlockValidation` enum to group valid, okay and invalid results into three categories.

## Relevant technical choices:

* This is a change proposed by @herregroen. The motivation is that it will be easier to write logic based on the three categories of 'validness'.
* I created a new enum value `OK`, for those validation results that should result in an orange bullet (for reasons other than being a missing recommended block, which has its own value in the enum).
* I simplified the `isValidResult` function to just check whether the result is `< 300` (because all invalid results are 300+). A change from the previous version of the code is that the `Skipped` result now is considered valid too, whereas previously it was invalid (because it was absent in `isValidResult`). I think this is not a problem, because we should not see this result anyway.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test https://github.com/Yoast/javascript/pull/1124 again, following the test instructions there.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
