### PR TITLE
Added default-tag attribute to variable rich text instruction

### DIFF
--- a/packages/schema-blocks/src/instructions/blocks/Title.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/Title.tsx
@@ -22,6 +22,7 @@ interface Post {
 class Title extends VariableTagRichText {
 	public options: {
 		tags: ( keyof HTMLElementTagNameMap )[] | Record<string, keyof HTMLElementTagNameMap>;
+		defaultTag: string;
 		name: string;
 		blockName: string;
 		class: string;

--- a/packages/schema-blocks/src/instructions/blocks/VariableTagRichText.ts
+++ b/packages/schema-blocks/src/instructions/blocks/VariableTagRichText.ts
@@ -12,6 +12,7 @@ import { arrayOrObjectToOptions } from "../../functions/select";
 export class VariableTagRichText extends RichTextBase {
 	public options: {
 		tags: ( keyof HTMLElementTagNameMap )[] | Record<string, keyof HTMLElementTagNameMap>;
+		defaultTag: string;
 		name: string;
 		class: string;
 		default: string;
@@ -54,7 +55,7 @@ export class VariableTagRichText extends RichTextBase {
 	sidebar( props: BlockEditProps<Record<string, unknown>>, i: number ): JSX.Element {
 		return createElement( SelectControl, {
 			label: this.options.label,
-			value: props.attributes[ this.options.name + "_tag" ] as string,
+			value: props.attributes[ this.options.name + "_tag" ] as string || this.options.defaultTag,
 			options: arrayOrObjectToOptions( this.options.tags ),
 			onChange: value => props.setAttributes( { [ this.options.name + "_tag" ]: value } ),
 			key: i,
@@ -73,6 +74,7 @@ export class VariableTagRichText extends RichTextBase {
 		const attributes: RichTextSaveProps | RichTextEditProps = {
 			tagName:
 				props.attributes[ this.options.name + "_tag" ] as keyof HTMLElementTagNameMap ||
+				this.options.defaultTag as keyof HTMLElementTagNameMap ||
 				arrayOrObjectToOptions( this.options.tags )[ 0 ].value,
 			value: props.attributes[ this.options.name ] as string || this.options.value,
 			className: this.options.class,


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [schema-blocks] Adds a default tag attribute to the variable rich text instruction, allowing you to set a default tag.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check out this branch, run `yarn build` in the `packages/schema-blocks` directory,  link the monorepo to wordpress-seo and build the wordpress-seo javascript.
* In your plugin directory, edit `src/schema-templates/recipe-name.block.php`.
* Add `default-tag="h3"` to the variable-tag-richt-text instruction and save the file.
* Create a new post and add a new recipe-block (make sure the `YOAST_SEO_SCHEMA_BLOCKS` feature flag is enabled.
* Select the recipe name block. The selected heading should be h3, and h2 should still be selectable.
* Enter a name for the recipe and save the post.
* On the front-end inspect to post to check if the heading is indeed `h3`.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
