### PR TITLE
Sets the textdomain to the right one

### DIFF
--- a/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidationResult.ts
@@ -92,7 +92,7 @@ export class BlockValidationResult {
 			BlockPresence.Required,
 			sprintf(
 				/* Translators: %1$s expands to the block name. */
-				__( "The '%1$s' block is required but missing.", "yoast-schema-blocks" ),
+				__( "The `%1$s` block is required but missing.", "yoast-schema-blocks" ),
 				name,
 			),
 		);
@@ -113,7 +113,7 @@ export class BlockValidationResult {
 			BlockPresence.Recommended,
 			sprintf(
 				/* Translators: %1$s expands to the block name. */
-				__( "The '%1$s' block is recommended but missing.", "yoast-schema-blocks" ),
+				__( "The `%1$s` block is recommended but missing.", "yoast-schema-blocks" ),
 				name,
 			),
 		);

--- a/packages/schema-blocks/src/instructions/blocks/SidebarDuration.ts
+++ b/packages/schema-blocks/src/instructions/blocks/SidebarDuration.ts
@@ -54,7 +54,7 @@ class SidebarDuration extends SidebarBase {
 		const minutes = duration.minutes();
 
 		const hourAttributes: TextControl.Props = {
-			label: labelPrefix + __( "hours", "wordpress-seo" ),
+			label: labelPrefix + __( "hours", "yoast-schema-blocks" ),
 			value: isNaN( hours ) || hours === 0 ? "" : hours,
 			onChange: value => {
 				const newDuration = moment.duration( { hours: parseInt( value, 10 ), minutes: minutes || 0 } );
@@ -64,7 +64,7 @@ class SidebarDuration extends SidebarBase {
 			key: "hours",
 		};
 		const minuteAttributes: TextControl.Props = {
-			label: labelPrefix + __( "minutes", "wordpress-seo" ),
+			label: labelPrefix + __( "minutes", "yoast-schema-blocks" ),
 			value: isNaN( minutes ) || minutes === 0 ? "" : minutes,
 			onChange: value => {
 				const newDuration = moment.duration( { hours: hours || 0, minutes: parseInt( value, 10 ) } );

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -71,7 +71,7 @@ describe( "The SidebarWarningPresenter ", () => {
 
 			expect( result.length ).toEqual( 2 );
 			expect( result[ 0 ] ).toEqual( {
-				text: "The 'missingblock' block is required but missing.",
+				text: "The `missingblock` block is required but missing.",
 				color: "red",
 			} );
 			expect( result[ 1 ] ).toEqual(
@@ -95,11 +95,11 @@ describe( "The SidebarWarningPresenter ", () => {
 
 			expect( result.length ).toEqual( 3 );
 			expect( result[ 0 ] ).toEqual( {
-				text: "The 'missing recommended block' block is recommended but missing.",
+				text: "The `missing recommended block` block is recommended but missing.",
 				color: "orange",
 			} );
 			expect( result[ 1 ] ).toEqual( {
-				text: "The 'missing recommended block 2' block is recommended but missing.",
+				text: "The `missing recommended block 2` block is recommended but missing.",
 				color: "orange",
 			} );
 			expect( result[ 2 ] ).toEqual( {
@@ -117,7 +117,7 @@ describe( "The SidebarWarningPresenter ", () => {
 
 			expect( result ).toEqual( [ {
 				text: "Good job! All required blocks have been completed.",
-				color: "green"
+				color: "green",
 			} ] );
 		} );
 
@@ -145,7 +145,7 @@ describe( "The SidebarWarningPresenter ", () => {
 
 			expect( result.length ).toEqual( 2 );
 			expect( result[ 0 ] ).toEqual( {
-				text: "The 'innerblock1' block is required but missing.",
+				text: "The `innerblock1` block is required but missing.",
 				color: "red",
 			} );
 			expect( result[ 1 ] ).toEqual( {


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Changes the text domain for two strings to `yoast-schema-blocks`.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch and do `yarn build`
* In wordpress-seo-free link the monorepo
* Do a `grunt build:i18n:potFiles`
* In the languages directory you should have a file name `yoast-schema-blocks.pot`
* Verify that the two string changed in this pull are present in this file. These are: `hours` and `minutes`

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
