### PR TITLE
Watch the post title for validation

### DIFF
--- a/packages/schema-blocks/src/functions/gutenberg/watch.ts
+++ b/packages/schema-blocks/src/functions/gutenberg/watch.ts
@@ -12,6 +12,7 @@ import { isResultValidForSchema } from "../validators/validateResults";
 
 let updatingSchema = false;
 let previousRootBlocks: BlockInstance[];
+let previousPostTitle: string;
 
 /**
  * Returns whether or not a schema definition should be rendered.
@@ -129,7 +130,9 @@ export default function watch() {
 			}
 
 			const rootBlocks: BlockInstance[] = select( "core/block-editor" ).getBlocks();
-			if ( rootBlocks === previousRootBlocks ) {
+			const postTitle: string = select( "core/editor" ).getEditedPostAttribute( "title" );
+
+			if ( rootBlocks === previousRootBlocks && previousPostTitle === postTitle ) {
 				return;
 			}
 
@@ -143,6 +146,7 @@ export default function watch() {
 				generateSchemaForBlocks( rootBlocks, validations, previousRootBlocks );
 
 				previousRootBlocks = rootBlocks;
+				previousPostTitle = postTitle;
 			}
 			updatingSchema = false;
 		}, 250, { trailing: true } ),

--- a/packages/schema-blocks/src/instructions/blocks/Title.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/Title.tsx
@@ -55,10 +55,8 @@ class Title extends VariableTagRichText {
 	 * @returns The validation result.
 	 */
 	validate( blockInstance: BlockInstance ): BlockValidationResult {
-		const post: Post = select( "core/editor" ).getCurrentPost();
-
 		const blockTitle: string = blockInstance.attributes[ this.options.name ];
-		const postTitle: string = post.title;
+		const postTitle: string = select( "core/editor" ).getEditedPostAttribute( "title" );
 
 		if ( ! this.isCompleted( blockInstance ) ) {
 			return BlockValidationResult.MissingAttribute( blockInstance, this.options.name );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Watches the post title to continuously check whether it is not equal to the Job Posting title.

## Relevant technical choices:

* We're getting the most recent edited post title from the store with `select( "core/editor" ).getEditedPostAttribute( "title" )`. Previously, we only got the saved post title.
* In `watch.ts`, we're continuously watching the post title. If it has changed, we kick off the validation.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new post and add the Job Posting block.
* Add a Job Posting title.
* Add the same title as the Post title.
* Select the Job Posting block, and see that there is an orange bullet which warns you about the titles being the same.
* Change the Post title to something else.
* Select the Job Posting block, and see that the orange warning has disappeared.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
