### PR TITLE
Injects the sidebar into core blocks

### DIFF
--- a/packages/schema-blocks/src/functions/blocks/getParentSidebar.tsx
+++ b/packages/schema-blocks/src/functions/blocks/getParentSidebar.tsx
@@ -1,0 +1,37 @@
+import { BlockEditProps } from "@wordpress/blocks";
+import { createElement, Fragment } from "@wordpress/element";
+import { ReactElement } from "react";
+import { getBlockDefinition } from "../../core/blocks/BlockDefinitionRepository";
+import { getBlockByClientId } from "../BlockHelper";
+import { createBlockEditProps, getParentIdOfType } from "../gutenberg/block";
+import logger from "../logger";
+
+/**
+ * Gets the sidebar from the parent of a blocks.
+ *
+ * @param props The block props.
+ * @param parents The parents to get the sidebar from.
+ *
+ * @returns The sidebar.
+ */
+export default function getParentSidebar( props: BlockEditProps<unknown>, parents: string[] ): ReactElement {
+	let parentIds: string[] = [];
+	if ( parents ) {
+		parentIds = getParentIdOfType( props.clientId, parents );
+	}
+
+	const elements: ReactElement[] = [];
+	if ( parentIds.length > 0 ) {
+		parentIds.forEach( parentId => {
+			const parentBlock = getBlockByClientId( parentId );
+			const parentBlockDefinition = getBlockDefinition( parentBlock.name );
+			if ( parentBlockDefinition ) {
+				logger.debug( props.clientId + " inherited sidebar from " + parentBlock.name + " definition" );
+				const parentProps = createBlockEditProps( parentBlock );
+				elements.push( ...parentBlockDefinition.sidebarElements( parentProps ) );
+			}
+		} );
+	}
+
+	return <Fragment>{ ...elements }</Fragment>;
+}

--- a/packages/schema-blocks/src/functions/gutenberg/inject-sidebar.tsx
+++ b/packages/schema-blocks/src/functions/gutenberg/inject-sidebar.tsx
@@ -1,0 +1,34 @@
+import { InspectorControls } from "@wordpress/block-editor";
+import { BlockEditProps } from "@wordpress/blocks";
+import { createElement, Fragment } from "@wordpress/element";
+import { addFilter } from "@wordpress/hooks";
+import { MutableBlockConfiguration } from "../../core/blocks/BlockDefinition";
+import getParentSidebar from "../blocks/getParentSidebar";
+
+/**
+ * Injects the sidebar from our blocks into other blocks.
+ *
+ * @param blockNames The block names to inject the sidebar into.
+ * @param parents    The parent names to inject the sidebar from.
+ */
+export default function injectSidebar( blockNames: string[], parents: string[] ) {
+	addFilter(
+		"blocks.registerBlockType",
+		"yoast/wordpress-seo/injectSidebar",
+		( settings: MutableBlockConfiguration, name: string ) => {
+			if ( ! blockNames.includes( name ) ) {
+				return settings;
+			}
+
+			const OriginalEdit = settings.edit;
+			settings.edit = function enhancedEdit( props: BlockEditProps<unknown> ) {
+				return <Fragment>
+					<OriginalEdit { ...props } />
+					<InspectorControls>
+						{ getParentSidebar( props, parents ) }
+					</InspectorControls>
+				</Fragment>;
+			};
+		},
+	);
+}

--- a/packages/schema-blocks/src/functions/gutenberg/inject-sidebar.tsx
+++ b/packages/schema-blocks/src/functions/gutenberg/inject-sidebar.tsx
@@ -29,6 +29,8 @@ export default function injectSidebar( blockNames: string[], parents: string[] )
 					</InspectorControls>
 				</Fragment>;
 			};
+
+			return settings;
 		},
 	);
 }

--- a/packages/schema-blocks/src/functions/initialize.ts
+++ b/packages/schema-blocks/src/functions/initialize.ts
@@ -6,6 +6,7 @@ import { processBlock, processSchema } from "./process";
 import filter from "./gutenberg/filter";
 import watch from "./gutenberg/watch";
 import logger, { LogLevel } from "./logger";
+import injectSidebar from "./gutenberg/inject-sidebar";
 
 /**
  * Removes all whitespace including line breaks from a string.
@@ -29,6 +30,15 @@ export function initialize( logLevel: LogLevel = LogLevel.ERROR ) {
 	initializeSchemaBlocksStore();
 
 	registerInternalBlocks();
+
+	injectSidebar( [
+		"core/paragraph",
+		"core/image",
+		"core/heading",
+		"core/separator",
+	], [
+		"yoast/job-posting",
+	] );
 
 	jQuery( 'script[type="text/schema-template"]' ).each( function() {
 		try {

--- a/packages/schema-blocks/tests/functions/blocks/__snapshots__/getParentSidebar.test.ts.snap
+++ b/packages/schema-blocks/tests/functions/blocks/__snapshots__/getParentSidebar.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`The getParentSidebar function doesn't find parentIds for given parents 1`] = `null`;
+
+exports[`The getParentSidebar function receives finds a parent and retrieves its sidebar 1`] = `"1337"`;
+
+exports[`The getParentSidebar function receives finds a parent without any block definition 1`] = `null`;
+
+exports[`The getParentSidebar function receives the parents argument as null 1`] = `null`;

--- a/packages/schema-blocks/tests/functions/blocks/getParentSidebar.test.ts
+++ b/packages/schema-blocks/tests/functions/blocks/getParentSidebar.test.ts
@@ -1,0 +1,119 @@
+import { BlockEditProps, BlockInstance } from "@wordpress/blocks";
+import * as renderer from "react-test-renderer";
+import getParentSidebar from "../../../src/functions/blocks/getParentSidebar";
+
+jest.mock( "../../../src/functions/gutenberg/block", () => {
+	return {
+		getParentIdOfType: jest.fn( ( clientId )  => {
+			if ( clientId === "404" ) {
+				return [];
+			}
+
+			return [ clientId ];
+		} ),
+		createBlockEditProps: jest.fn( ( block, selected = false )  => {
+			return {
+				clientId: block.clientId,
+				isSelected: selected,
+			} as BlockEditProps<unknown>;
+		} ),
+	};
+} );
+
+jest.mock( "../../../src/functions/BlockHelper", () => {
+	return {
+		getBlockByClientId: jest.fn( ( clientId )  => {
+			if ( clientId === "1337" ) {
+				return {
+					clientId: clientId,
+					name: "yoast/block",
+				} as BlockInstance;
+			}
+
+			return {
+				clientId: clientId,
+				name: "yoast/unknown-block",
+			} as BlockInstance;
+		} ),
+	};
+} );
+
+jest.mock( "../../../src/core/blocks/BlockDefinitionRepository", () => {
+	return {
+		getBlockDefinition: jest.fn( ( blockName )  => {
+			if ( blockName === "yoast/block" ) {
+				return {
+					clientId: "1337",
+					sidebarElements: jest.fn( ( props: BlockEditProps<unknown> ) => {
+						return [ props.clientId ];
+					} ),
+				};
+			}
+
+			return null;
+		} ),
+	};
+} );
+
+describe( "The getParentSidebar function", () => {
+	it( "receives the parents argument as null", () => {
+		const props: BlockEditProps<unknown> = {
+			className: "",
+			clientId: "1337",
+			isSelected: false,
+			setAttributes: null,
+			attributes: null,
+		};
+
+		const tree = renderer
+			.create( getParentSidebar( props, null ) )
+			.toJSON();
+
+		expect( tree ).toMatchSnapshot();
+	} );
+	it(  "doesn't find parentIds for given parents", () => {
+		const props: BlockEditProps<unknown> = {
+			className: "",
+			clientId: "404",
+			isSelected: false,
+			setAttributes: null,
+			attributes: null,
+		};
+
+		const tree = renderer
+			.create( getParentSidebar( props, [ "yoast/block" ] ) )
+			.toJSON();
+
+		expect( tree ).toMatchSnapshot();
+	} );
+	it(  "receives finds a parent without any block definition", () => {
+		const props: BlockEditProps<unknown> = {
+			className: "",
+			clientId: "107",
+			isSelected: false,
+			setAttributes: null,
+			attributes: null,
+		};
+
+		const tree = renderer
+			.create( getParentSidebar( props, [ "yoast/block" ] ) )
+			.toJSON();
+
+		expect( tree ).toMatchSnapshot();
+	} );
+	it(  "receives finds a parent and retrieves its sidebar", () => {
+		const props: BlockEditProps<unknown> = {
+			className: "",
+			clientId: "1337",
+			isSelected: false,
+			setAttributes: null,
+			attributes: null,
+		};
+
+		const tree = renderer
+			.create( getParentSidebar( props, [ "yoast/block" ] ) )
+			.toJSON();
+
+		expect( tree ).toMatchSnapshot();
+	} );
+} );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Injects the sidebar of the block into core blocks which are part of the block

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test this against the free & premium plugin and make sure to do all build steps: `yarn build` for this branch and `grunt build:js build:css` in the plugins
* In the `job-posting.block.php` in premium you can add to the template (`$yoast_seo_block_template`):
```php
	[ 'core/heading', [ 'level' => 2 ] ],
	[ 'core/paragraph', [ 'content' => 'Hi this is a paragraph' ] ],
```
* Add the job posting to a post
* Navigate through all blocks in the job posting
* See that the added core blocks have the sidebar just like our other blocks have:
![Bericht_bewerken_‹_Basic_—_WordPress](https://user-images.githubusercontent.com/325040/114675011-160a3900-9d08-11eb-8d97-16b146502a67.png)


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
