### PR TITLE
Add 'new' badge component

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -16,6 +16,7 @@ export * from "./select";
 export * from "./star-rating";
 export * from "./help-icon";
 export * from "./tables";
+export * from "./new-badge";
 
 // Referenced index.js explicitly due to case-sensitive path conflicts.
 export * from "./toggle/index.js";

--- a/packages/components/src/new-badge/NewBadge.js
+++ b/packages/components/src/new-badge/NewBadge.js
@@ -1,0 +1,26 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { __ } from "@wordpress/i18n";
+
+/**
+ * Function for the NewBadge component.
+ *
+ * @param {bool} inLabel Whether the NewBadge is within a Label.
+ *
+ * @returns {React.Component} The NewBadge.
+ */
+const NewBadge = ( { inLabel } ) => (
+	<span className={ inLabel ? "yoast-badge yoast-badge__in-label yoast-new-badge" : "yoast-badge yoast-new-badge" }>
+		{ __( "New", "wordpress-seo" ) }
+	</span>
+);
+
+NewBadge.propTypes = {
+	inLabel: PropTypes.bool,
+};
+
+NewBadge.defaultProps = {
+	inLabel: false,
+};
+
+export default NewBadge;

--- a/packages/components/src/new-badge/index.js
+++ b/packages/components/src/new-badge/index.js
@@ -1,0 +1,2 @@
+import "./new-badge.css";
+export { default as NewBadge } from "./NewBadge";

--- a/packages/components/src/new-badge/new-badge.css
+++ b/packages/components/src/new-badge/new-badge.css
@@ -1,0 +1,19 @@
+.yoast-badge {
+	display: inline-block;
+	min-height: 16px;
+	padding: 0 8px;
+	border-radius: 8px;
+	font-weight: 600;
+	font-size: 10px;
+	line-height: 1.6;
+}
+
+.yoast-new-badge {
+	background-color: #cce5ff;
+	color: #004973;
+}
+
+.yoast-badge__in-label {
+	margin-left: 8px;
+	vertical-align: text-top;
+}


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/components] Adds a 'New' badge component.

## Relevant technical choices:

* The `inLabel` prop is added to the `NewBadge` to account for adding it in the label of the `replacevareditor` for the Global Social Templates.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch.
* Add the NewBadge somewhere in the metabox, for example: in `packages/yoast-components/composites/Plugin/Shared/components/KeywordInput.js`, add `{ <NewBadge /> }` on line 163 in `renderLabel()`, like such:
```
return (
	<KeywordFieldLabelContainer>
		<KeywordFieldLabel htmlFor={ id }>
			{ label }
		</KeywordFieldLabel>
		{ helpLink }
		{ <NewBadge /> }
	</KeywordFieldLabelContainer>
);
```
* On `wordpress-seo` build with `composer install && yarn link-monorepo && grunt build:dev`.
* Edit a post or create a new one. 
* Check that behind the `Focus Keyphrase` label in the Yoast metabox now is a `NewBadge` (see screenshot below), and make sure it matches [the design](https://www.sketch.com/s/6b4efaeb-fcab-4e48-8314-0d532488e164/a/g00MDDd/play).
  <img width="500" alt="Screenshot 2021-04-14 at 11 34 34" src="https://user-images.githubusercontent.com/43582255/114689005-908d8580-9d15-11eb-8501-00ca59d2cec5.png">
* Now add the new label somewhere on the admin pages, for example: in `packages/replacement-variable-editor/src/ReplacementVariableEditor.js`, add `{ <NewBadge inLabel={ true } /> }` on line 105 in `render()`, like such:
```
<SimulatedLabel
	id={ this.uniqueId }
	onClick={ onFocus }
>
	{ label }
	{ <NewBadge inLabel={ true } /> }
</SimulatedLabel>
```
* Go to SEO > Search Appearance > General and see the replacevareditors now contain a `NewBadge` (see screenshot below), and make sure it matches [the design](https://www.sketch.com/s/6b4efaeb-fcab-4e48-8314-0d532488e164/a/g00MDDd/play). 
  <img width="500" alt="Screenshot 2021-04-14 at 11 43 56" src="https://user-images.githubusercontent.com/43582255/114690164-bcf5d180-9d16-11eb-9c3b-45ef034f6c1f.png">


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes [P3-526]
