### PR TITLE
Fixed analysis conclusion, based on recent changes in the block validation.

### DIFF
--- a/packages/schema-blocks/src/core/validation/BlockValidation.ts
+++ b/packages/schema-blocks/src/core/validation/BlockValidation.ts
@@ -8,7 +8,7 @@ export enum BlockValidation {
 	/** This block was skipped during validation, on purpose. If you ever see this value, that's a bug.  */
 	Skipped = 102,
 
-	/** OK RESULTS (200+): Will give an orange bullet, but will not prevent Schema output.
+	/** OK RESULTS (200+): Will give an orange bullet, but will not prevent Schema output. */
 
 	/** This block is not completely valid, but should not prevent the Schema to be output either. */
 	OK = 200,
@@ -19,7 +19,7 @@ export enum BlockValidation {
 	/** This block contains a Variationpicker to choose between subblocks, but no choice has been made yet for this recommended block. */
 	MissingRecommendedVariation = 203,
 
-	/** INVALID RESULTS (300+): Will prevent Schema output.
+	/** INVALID RESULTS (300+): Will prevent Schema output. */
 
 	/** This block (OR some of its innerblocks) have a problem. The particular problem must be specified in BlockValidationResult.issues */
 	Invalid = 300,

--- a/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
+++ b/packages/schema-blocks/src/functions/presenters/SidebarWarningPresenter.ts
@@ -40,30 +40,17 @@ function getValidationResult( clientId: string ): BlockValidationResult | null {
 }
 
 /**
- * If some required blocks are missing and/or not filled in.
- *
- * @param issues The block validation issues to check.
- *
- * @return `true` if some required blocks are missing or not completed, `false` if not.
- */
-function someRequiredBlocksNotCompleted( issues: BlockValidationResult[] ) {
-	return issues.some( issue => issue.result === BlockValidation.MissingRequiredBlock ||
-		issue.result === BlockValidation.MissingRequiredAttribute );
-}
-
-/**
  * Adds analysis conclusions to the footer.
  *
  * @param validation The validation result for the current block.
- * @param issues     The detected issues.
  *
  * @returns Any analysis conclusions that should be in the footer.
  */
-function getAnalysisConclusion( validation: BlockValidationResult, issues: BlockValidationResult[] ): SidebarWarning {
+function getAnalysisConclusion( validation: BlockValidationResult ): SidebarWarning {
 	let conclusionText = "";
 
-	// Show a red bullet when not all required blocks have been completed.
-	if ( someRequiredBlocksNotCompleted( issues ) ) {
+	// Show a red bullet when the block is invalid.
+	if ( validation.result >= BlockValidation.Invalid ) {
 		conclusionText = sprintf(
 			/* translators: %s expands to the schema block name. */
 			__( "Not all required blocks have been completed! No %s schema will be generated for your page.", "yoast-schema-blocks" ),
@@ -125,7 +112,7 @@ export function createAnalysisMessages( validation: BlockValidationResult ): Sid
 	messages.push( ...getErrorMessages( issues ) );
 	messages.push( ...getWarningMessages( issues ) );
 
-	messages.push( getAnalysisConclusion( validation, issues ) );
+	messages.push( getAnalysisConclusion( validation ) );
 
 	return messages;
 }

--- a/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
+++ b/packages/schema-blocks/tests/functions/presenters/SidebarWarningPresenter.test.ts
@@ -85,7 +85,7 @@ describe( "The SidebarWarningPresenter ", () => {
 
 		it( "creates a warning for missing recommended blocks, but when no required blocks are missing, " +
 			"the conclusion should still be green.", () => {
-			const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockPresence.Recommended );
+			const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.MissingRecommendedBlock, BlockPresence.Recommended );
 			testcase.issues.push(
 				BlockValidationResult.MissingBlock( "missing recommended block", BlockPresence.Recommended ),
 			);
@@ -112,7 +112,7 @@ describe( "The SidebarWarningPresenter ", () => {
 
 		it( "creates a warning for missing recommended blocks, but when all required blocks are valid, " +
 			"the conclusion should still be green.", () => {
-			const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.Invalid, BlockPresence.Recommended );
+			const testcase = new BlockValidationResult( "1", "mijnblock", BlockValidation.MissingRecommendedBlock, BlockPresence.Recommended );
 			testcase.issues.push(
 				BlockValidationResult.MissingBlock( "missing recommended block", BlockPresence.Recommended ),
 			);
@@ -147,7 +147,8 @@ describe( "The SidebarWarningPresenter ", () => {
 		} );
 
 		it( "creates a compliment if we do not have copy for any of the validations of the required blocks.", () => {
-			const testcase = new BlockValidationResult( "1", "myBlock", BlockValidation.Invalid, BlockPresence.Required );
+			// `Skipped`, since this is the maximum result.
+			const testcase = new BlockValidationResult( "1", "myBlock", BlockValidation.Skipped, BlockPresence.Required );
 			testcase.issues.push( new BlockValidationResult( "2", "innerblock1", BlockValidation.Skipped, BlockPresence.Required ) );
 			testcase.issues.push( new BlockValidationResult( "3", "anotherinnerblock", BlockValidation.TooMany, BlockPresence.Required ) );
 			testcase.issues.push( new BlockValidationResult( "4", "anotherinnerblock", BlockValidation.Unknown, BlockPresence.Required ) );


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Fixed the analysis conclusion message after recent changes in the block validation.

## Relevant technical choices:

* Improved the comments in the `BlockValidation` a bit. They were malformed, since they were not properly closed.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post.
* Add a job posting block.
* The schema analysis in the sidebar of the job posting block should contain a red bullet with a message indicating that no schema will be generated since not all required blocks have been completed.
* Complete the job title and job description by filling them in.
* You should still see a red bullet with the above message.
* Pick a job location variation and make sure it is not empty.
* The schema analysis in the sidebar should have green bullet with the text: `Good job! All required blocks have been completed.
`

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
