### PR TITLE
P2-860 Fixes a console warning due to an invalid key property in the VariationPickerPresenter.

### DIFF
--- a/packages/schema-blocks/src/functions/presenters/VariationPickerPresenter.tsx
+++ b/packages/schema-blocks/src/functions/presenters/VariationPickerPresenter.tsx
@@ -35,7 +35,7 @@ function createBlocksFromInnerBlocksTemplate( innerBlocksTemplate: BlockInstance
  *
  * @returns {ReactElement} The component.
  */
-export default function VariationPickerPresenter( { clientId, name, setAttributes, key }: RenderEditProps & { key: string } ) {
+export default function VariationPickerPresenter( { clientId, name, setAttributes }: RenderEditProps ) {
 	const { blockType, defaultVariation, variations } = useSelect(
 		select => {
 			const {
@@ -82,7 +82,7 @@ export default function VariationPickerPresenter( { clientId, name, setAttribute
 	};
 
 	return (
-		<div key={ key } { ...blockProps }>
+		<div { ...blockProps }>
 			<ExperimentalBlockVariationPicker
 				icon={ false }
 				label={ get( blockType, [ "title" ] ) }


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Fixes the `VariationPickerPresenter: 'key' is not a prop` error that was shown in the browser console when a job posting block had been added.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post.
* Add a job posting block.
* Check the browser console, you should **not** see this error:
  ```
  VariationPickerPresenter: 'key' is not a prop.
  ```

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * N/A.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
