### PR TITLE
Check if block is active before activating the sidebar

### DIFF
--- a/packages/schema-blocks/src/core/blocks/BlockDefinition.tsx
+++ b/packages/schema-blocks/src/core/blocks/BlockDefinition.tsx
@@ -6,6 +6,7 @@ import {
 	BlockSaveProps,
 } from "@wordpress/blocks";
 import { InspectorControls, BlockIcon } from "@wordpress/block-editor";
+import { select } from "@wordpress/data";
 import BlockInstruction from "./BlockInstruction";
 import Definition from "../Definition";
 import BlockRootLeaf from "../../leaves/blocks/BlockRootLeaf";
@@ -47,7 +48,9 @@ export default class BlockDefinition extends Definition {
 	 */
 	edit( props: RenderEditProps ): ReactElement {
 		// Force the sidebar open.
-		openGeneralSidebar( "edit-post/block", true );
+		if ( select( "core/block-editor" ).isBlockSelected( props.clientId ) ) {
+			openGeneralSidebar( "edit-post/block", true );
+		}
 
 		const sidebarElements = this.sidebarElements( props );
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Fixes a bug where the block inserter in the left sidebar crashes when hovering the yoast jobs block icon.

## Relevant technical choices:

* I found out that hovering makes the editor crashes because it wants to activate and unexisting sidebar. I suspect that the preview is rendering the edit function from the blocktype. That function tries to activate the sidebar. Because there is no block active, it will crash. 
* Now I check if the block is selected before showing the sidebare

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a new post.
* Click on the + icon in the top-right of the post editor to open the block insertion sidebar to the left of the editor.
* Hover over the Yoast Job Block inside this sidebar and see the editor isn't crashing
* Now insert the block and verify that the right sidebar still opens when selecting the jobs block. 
* Also navigate through the innerblocks in the jobs block to see that this also still works
* 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
