### PR TITLE
Add header with link to the sidebar and improve the sidebar's styling

### DIFF
--- a/packages/schema-blocks/css/schema-blocks.css
+++ b/packages/schema-blocks/css/schema-blocks.css
@@ -64,6 +64,11 @@
 	color: #303030;
 }
 
+.yoast-block-sidebar-header {
+	width:100%;
+	padding: 0 0 20px 0;
+}
+
 .yoast-block-suggestions {
 	width:100%;
 	padding: 0 5px 0 15px;

--- a/packages/schema-blocks/css/schema-blocks.css
+++ b/packages/schema-blocks/css/schema-blocks.css
@@ -62,11 +62,12 @@
 .yoast-block-sidebar-title {
 	font-weight: 600;
 	color: #303030;
+	padding: 10px 0 0 0;
 }
 
 .yoast-block-sidebar-header {
 	width:100%;
-	padding: 0 0 20px 0;
+	margin-bottom: 14px;
 }
 
 .yoast-block-suggestions {
@@ -76,12 +77,12 @@
 
 .yoast-block-sidebar-warnings {
 	width:100%;
-	padding: 0 0 0 15px;
 }
 
 .yoast-block-sidebar-warning {
 	list-style: none;
 	color: #404040;
+	padding: 0 0 0 17px;
 }
 
 .yoast-block-sidebar-warning > .yoast-svg-icon {

--- a/packages/schema-blocks/css/schema-blocks.css
+++ b/packages/schema-blocks/css/schema-blocks.css
@@ -75,6 +75,10 @@
 	padding: 0 5px 0 15px;
 }
 
+.yoast-inline-icon {
+	vertical-align: middle;
+}
+
 .yoast-block-sidebar-warnings {
 	width:100%;
 }

--- a/packages/schema-blocks/src/functions/presenters/BlockSuggestionsPresenter.tsx
+++ b/packages/schema-blocks/src/functions/presenters/BlockSuggestionsPresenter.tsx
@@ -56,9 +56,13 @@ function BlockSuggestion( { blockTitle, blockName, blockClientId }: BlockSuggest
  * @returns {ReactElement} The rendered element.
  */
 function BlockSuggestionAdded( { blockTitle }: BlockSuggestionAddedDto ): ReactElement {
-	const heroIconCheck = <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="-2 3 18 16" stroke="currentColor" height="12" width="22">
-		<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={ 2.5 } d="M5 13l4 4L19 7" />
-	</svg>;
+	const heroIconCheck: JSX.Element =
+		<svg
+			xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="-2 3 18 16" stroke="currentColor"
+			height="12" width="22"
+		>
+			<path strokeLinecap="round" strokeLinejoin="round" strokeWidth={ 2.5 } d="M5 13l4 4L19 7" />
+		</svg>;
 
 	return (
 		<li className="yoast-block-suggestion yoast-block-suggestion--added" key={ "BlockSuggestionAdded" + blockTitle }>

--- a/packages/schema-blocks/src/functions/presenters/BlockSuggestionsPresenter.tsx
+++ b/packages/schema-blocks/src/functions/presenters/BlockSuggestionsPresenter.tsx
@@ -1,7 +1,6 @@
 import { ReactElement } from "react";
 import { BlockInstance, createBlock } from "@wordpress/blocks";
-import { PanelBody } from "@wordpress/components";
-import { createElement } from "@wordpress/element";
+import { createElement, Fragment } from "@wordpress/element";
 
 import { getBlockType } from "../BlockHelper";
 import { getInnerblocksByName, insertBlock } from "../innerBlocksHelper";
@@ -92,7 +91,7 @@ export default function BlockSuggestionsPresenter( { title, block, suggestions }
 	const presentBlockNames = findPresentBlocks.map( presentBlock => presentBlock.name );
 
 	return (
-		<PanelBody key={ title + block.clientId }>
+		<Fragment key={ title + block.clientId }>
 			<div className="yoast-block-sidebar-title">{ title }</div>
 			<ul className="yoast-block-suggestions">
 				{
@@ -112,6 +111,6 @@ export default function BlockSuggestionsPresenter( { title, block, suggestions }
 					} )
 				}
 			</ul>
-		</PanelBody>
+		</Fragment>
 	);
 }

--- a/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
+++ b/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
@@ -106,7 +106,7 @@ function SidebarHeader(): ReactElement {
 		<div className="yoast-block-sidebar-header">
 			<div className="yoast-block-sidebar-title">
 				{ __( "Blocks for Schema output", "yoast-schema-blocks" ) }
-				<span>{ questionMarkIcon }</span>
+				<span className="yoast-inline-icon">{ questionMarkIcon }</span>
 			</div>
 		</div>
 	);

--- a/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
+++ b/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
@@ -92,12 +92,14 @@ interface WarningListProps {
  * @returns A ReactElement containing the sidebar header.
  */
 function SidebarHeader(): ReactElement {
-	const questionMarkIcon =
+	const questionMarkIcon: JSX.Element =
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 -4.5 20 22" fill="currentColor" height="15" width="22">
-			<path
-				fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113
-			8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd"
-			/>
+			<a href="https://yoast.com/help/required-recommended-optional-fields/" rel="noopener noreferrer" target="_blank">
+				<path
+					fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113
+				8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd"
+				/>
+			</a>
 		</svg>;
 
 	return (

--- a/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
+++ b/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
@@ -67,6 +67,7 @@ export function InnerBlocksSidebar( props: InnerBlocksSidebarProps ): ReactEleme
 	}
 
 	return <Fragment>
+		<SidebarHeader />
 		<WarningList warnings={ warnings } />
 		<BlockSuggestions
 			title={ __( "Required Blocks", "yoast-schema-blocks" ) }
@@ -83,6 +84,30 @@ export function InnerBlocksSidebar( props: InnerBlocksSidebarProps ): ReactEleme
 
 interface WarningListProps {
 	warnings: SidebarWarning[];
+}
+
+/**
+ * Renders a ReactElement containing the sidebar header.
+ *
+ * @returns A ReactElement containing the sidebar header.
+ */
+function SidebarHeader(): ReactElement {
+	const questionMarkIcon =
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 -4.5 20 22" fill="currentColor" height="15" width="22">
+			<path
+				fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113
+			8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd"
+			/>
+		</svg>;
+
+	return (
+		<div className="yoast-block-sidebar-header">
+			<div className="yoast-block-sidebar-title">
+				{ __( "Blocks for Schema output", "yoast-schema-blocks" ) }
+				<span>{ questionMarkIcon }</span>
+			</div>
+		</div>
+	);
 }
 
 /**

--- a/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
+++ b/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
@@ -66,7 +66,7 @@ export function InnerBlocksSidebar( props: InnerBlocksSidebarProps ): ReactEleme
 		warnings = createAnalysisMessages( validationResults );
 	}
 
-	return <Fragment>
+	return <Fragment key={ "innerblocks-sidebar-" + block.clientId }>
 		<SidebarHeader />
 		<WarningList warnings={ warnings } />
 		<BlockSuggestions
@@ -121,12 +121,14 @@ function SidebarHeader(): ReactElement {
  */
 function WarningList( props: WarningListProps ): ReactElement {
 	return (
-		<div className="yoast-block-sidebar-warnings">
-			<div className="yoast-block-sidebar-title">{ __( "Analysis", "yoast-schema-blocks" ) }</div>
-			<ul className="yoast-block-sidebar-warnings">
-				{ ...props.warnings.map( warning => <Warning warning={ warning } key={ warning.text } /> ) }
-			</ul>
-		</div>
+		<Fragment>
+			<div className="yoast-block-sidebar-warnings">
+				<div className="yoast-block-sidebar-title">{ __( "Analysis", "yoast-schema-blocks" ) }</div>
+				<ul className="yoast-block-sidebar-warnings">
+					{ ...props.warnings.map( warning => <Warning warning={ warning } key={ warning.text } /> ) }
+				</ul>
+			</div>
+		</Fragment>
 	);
 }
 

--- a/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
+++ b/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
@@ -93,7 +93,7 @@ interface WarningListProps {
  */
 function SidebarHeader(): ReactElement {
 	const questionMarkIcon: JSX.Element =
-		<svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 -4.5 20 22" fill="currentColor" height="15" width="22">
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 0 20 18" fill="currentColor" height="15" width="22">
 			<a href="https://yoast.com/help/required-recommended-optional-fields/" rel="noopener noreferrer" target="_blank">
 				<path
 					fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113

--- a/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
+++ b/packages/schema-blocks/src/functions/presenters/InnerBlocksSidebar.tsx
@@ -94,7 +94,7 @@ interface WarningListProps {
 function SidebarHeader(): ReactElement {
 	const questionMarkIcon: JSX.Element =
 		<svg xmlns="http://www.w3.org/2000/svg" viewBox="-2 0 20 18" fill="currentColor" height="15" width="22">
-			<a href="https://yoast.com/help/required-recommended-optional-fields/" rel="noopener noreferrer" target="_blank">
+			<a href="https://yoa.st/4dk" rel="noopener noreferrer" target="_blank">
 				<path
 					fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-8-3a1 1 0 00-.867.5 1 1 0 11-1.731-1A3 3 0 0113
 				8a3.001 3.001 0 01-2 2.83V11a1 1 0 11-2 0v-1a1 1 0 011-1 1 1 0 100-2zm0 8a1 1 0 100-2 1 1 0 000 2z" clipRule="evenodd"

--- a/packages/schema-blocks/tests/functions/presenters/__snapshots__/BlockSuggestions.test.ts.snap
+++ b/packages/schema-blocks/tests/functions/presenters/__snapshots__/BlockSuggestions.test.ts.snap
@@ -1,14 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`The required blocks in the sidebar renders the required block as a non-added one 1`] = `
-<div
-  className="components-panel__body is-opened"
->
+Array [
   <div
     className="yoast-block-sidebar-title"
   >
     Required blocks
-  </div>
+  </div>,
   <ul
     className="yoast-block-suggestions"
   >
@@ -23,19 +21,17 @@ exports[`The required blocks in the sidebar renders the required block as a non-
          Add 
       </button>
     </li>
-  </ul>
-</div>
+  </ul>,
+]
 `;
 
 exports[`The required blocks in the sidebar renders the required block as an added one 1`] = `
-<div
-  className="components-panel__body is-opened"
->
+Array [
   <div
     className="yoast-block-sidebar-title"
   >
     Required blocks
-  </div>
+  </div>,
   <ul
     className="yoast-block-suggestions"
   >
@@ -63,6 +59,6 @@ exports[`The required blocks in the sidebar renders the required block as an add
         </svg>
       </span>
     </li>
-  </ul>
-</div>
+  </ul>,
+]
 `;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Adds a header to the sidebar with a link to a blog post about Yoast Structured Data blocks.
* [@yoast/schema-blocks] Improves the styling of the sidebar by removing the separators.

## Relevant technical choices:

* I added a type to the `heroIconCheck` variable (unrelated to the rest of this PR).
* I got rid of the sidebar separators by replacing the `PanelBody` component by `Fragment`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post and add the Job Posting block.
* In the sidebar, see that there is a string "Blocks for Schema output" followed by a question mark icon.
* The question mark icon should be clickable and lead to **this URL** (still to be provided by @JessieHenkes).
* Also note that the styling of the sidebar has become more similar to the styling in the design: the separators between `Analysis`, `Required blocks` and `Recommended blocks` have disappeared:

<img width="238" alt="Screenshot 2021-04-16 at 08 44 15" src="https://user-images.githubusercontent.com/20280513/114982589-f140cd80-9e8f-11eb-9775-63ad971f854d.png">


## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * The styling of the sidebar.

## UI changes
* [x] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
