### PR TITLE
Always wrap the inherited sidebar in a PanelBody component.

### DIFF
--- a/packages/schema-blocks/src/functions/blocks/getParentSidebar.tsx
+++ b/packages/schema-blocks/src/functions/blocks/getParentSidebar.tsx
@@ -1,10 +1,11 @@
 import { BlockEditProps } from "@wordpress/blocks";
-import { createElement, Fragment } from "@wordpress/element";
+import { createElement } from "@wordpress/element";
 import { ReactElement } from "react";
 import { getBlockDefinition } from "../../core/blocks/BlockDefinitionRepository";
 import { getBlockByClientId } from "../BlockHelper";
 import { createBlockEditProps, getParentIdOfType } from "../gutenberg/block";
 import logger from "../logger";
+import { PanelBody } from "@wordpress/components";
 
 /**
  * Gets the sidebar from the parent of a blocks.
@@ -33,5 +34,5 @@ export default function getParentSidebar( props: BlockEditProps<unknown>, parent
 		} );
 	}
 
-	return <Fragment>{ ...elements }</Fragment>;
+	return <PanelBody>{ ...elements }</PanelBody>;
 }

--- a/packages/schema-blocks/tests/functions/blocks/__snapshots__/getParentSidebar.test.ts.snap
+++ b/packages/schema-blocks/tests/functions/blocks/__snapshots__/getParentSidebar.test.ts.snap
@@ -1,9 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`The getParentSidebar function doesn't find parentIds for given parents 1`] = `null`;
+exports[`The getParentSidebar function doesn't find parentIds for given parents 1`] = `
+<div
+  className="components-panel__body is-opened"
+/>
+`;
 
-exports[`The getParentSidebar function receives finds a parent and retrieves its sidebar 1`] = `"1337"`;
+exports[`The getParentSidebar function receives finds a parent and retrieves its sidebar 1`] = `
+<div
+  className="components-panel__body is-opened"
+>
+  1337
+</div>
+`;
 
-exports[`The getParentSidebar function receives finds a parent without any block definition 1`] = `null`;
+exports[`The getParentSidebar function receives finds a parent without any block definition 1`] = `
+<div
+  className="components-panel__body is-opened"
+/>
+`;
 
-exports[`The getParentSidebar function receives the parents argument as null 1`] = `null`;
+exports[`The getParentSidebar function receives the parents argument as null 1`] = `
+<div
+  className="components-panel__body is-opened"
+/>
+`;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Fixes a bug where the styling of the sidebar of any warning blocks located inside of a schema block did not have appropriate padding.

## Relevant technical choices:

* 

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post.
* Add a job posting block.
* Do a little dance (not strictly necessary, but may brighten your day).
* Remove a required or recommended block to add a warning block.
	* For example, remove the _Requirements_ block.
* This should add a warning block in the place of the removed block.
* Select this warning block.
* The warning block's schema blocks sidebar (from 'Blocks for Schema output' to 'Advanced') should have appropriate padding.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
