### PR TITLE
P2-861 - Made sure that no innerblocks instruction sidebar is rendered when no required or recommended blocks are set.

### DIFF
--- a/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/InnerBlocks.tsx
@@ -129,6 +129,10 @@ export default class InnerBlocks extends BlockInstruction {
 			recommendedBlockNames = this.options.recommendedBlocks.map( block => block.name );
 		}
 
+		if ( ! ( requiredBlockNames.length > 0 && recommendedBlockNames.length > 0 ) ) {
+			return null;
+		}
+
 		return (
 			<Fragment key="innerblocks-sidebar">
 				<InnerBlocksSidebar


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Fixes a bug where a variation picker would show a second, empty schema block analysis sidebar.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test this in WordPress SEO Premium.
* Create a post.
* Add a job posting block.
* Select either the job location block, or the job salary block.
* Check the contents of the sidebar. You should see only one 'Blocks for Schema output' heading and only one 'Analysis' heading.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
