### PR TITLE
Placeholder attribute is not output on frontend anymore.

### DIFF
--- a/packages/schema-blocks/src/instructions/blocks/Heading.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/Heading.tsx
@@ -21,7 +21,7 @@ export class Heading extends RichTextBase {
 		class: string;
 		default: string;
 		placeholder: string;
-		keepPlaceholderOnFocus: boolean;
+		keepPlaceholderOnFocus?: boolean;
 		multiline: boolean;
 		label: string;
 		value: string;

--- a/packages/schema-blocks/src/instructions/blocks/Heading.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/Heading.tsx
@@ -21,7 +21,7 @@ export class Heading extends RichTextBase {
 		class: string;
 		default: string;
 		placeholder: string;
-		keepPlaceholderOnFocus?: boolean;
+		keepPlaceholderOnFocus: boolean;
 		multiline: boolean;
 		label: string;
 		value: string;
@@ -117,8 +117,6 @@ export class Heading extends RichTextBase {
 			tagName: `h${ this.getHeadingLevel( props ) }` as keyof HTMLElementTagNameMap,
 			value: props.attributes[ this.options.name ] as string || this.options.value,
 			className: this.options.class,
-			placeholder: this.options.placeholder,
-			keepPlaceholderOnFocus: this.options.keepPlaceholderOnFocus,
 			"data-id": this.options.name,
 			key: i,
 		};

--- a/packages/schema-blocks/src/instructions/blocks/RichText.ts
+++ b/packages/schema-blocks/src/instructions/blocks/RichText.ts
@@ -13,7 +13,7 @@ export default class RichText extends RichTextBase {
 		default: string;
 		placeholder: string;
 		multiline: boolean | "li" | "p";
-		keepPlaceholderOnFocus: boolean;
+		keepPlaceholderOnFocus?: boolean;
 	};
 
 	/**

--- a/packages/schema-blocks/src/instructions/blocks/RichText.ts
+++ b/packages/schema-blocks/src/instructions/blocks/RichText.ts
@@ -29,8 +29,6 @@ export default class RichText extends RichTextBase {
 			tagName: this.options.tag,
 			value: props.attributes[ this.options.name ] as string,
 			className: this.options.class,
-			placeholder: this.options.placeholder,
-			keepPlaceholderOnFocus: this.options.keepPlaceholderOnFocus,
 			"data-id": this.options.name,
 			key: i,
 		};

--- a/packages/schema-blocks/src/instructions/blocks/abstract/RichTextBase.ts
+++ b/packages/schema-blocks/src/instructions/blocks/abstract/RichTextBase.ts
@@ -22,6 +22,7 @@ export default abstract class RichTextBase extends BlockInstruction {
 		name: string;
 		default: string;
 		placeholder: string;
+		keepPlaceholderOnFocus: boolean;
 		required?: boolean;
 	};
 
@@ -52,6 +53,7 @@ export default abstract class RichTextBase extends BlockInstruction {
 		attributes.onChange = ( value ) => props.setAttributes( { [ this.options.name ]: value } );
 		if ( this.options.placeholder ) {
 			attributes.placeholder = this.options.placeholder;
+			attributes.keepPlaceholderOnFocus = this.options.keepPlaceholderOnFocus;
 		}
 
 		return createElement( WordPressRichText, attributes );

--- a/packages/schema-blocks/src/instructions/blocks/abstract/RichTextBase.ts
+++ b/packages/schema-blocks/src/instructions/blocks/abstract/RichTextBase.ts
@@ -22,7 +22,7 @@ export default abstract class RichTextBase extends BlockInstruction {
 		name: string;
 		default: string;
 		placeholder: string;
-		keepPlaceholderOnFocus: boolean;
+		keepPlaceholderOnFocus?: boolean;
 		required?: boolean;
 	};
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Fixes a bug where a `placeholder` attribute was output on the frontend for instance of the `RichText` block instruction.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Test this in WordPress SEO Premium.
* Create a post.
* Add a job posting block.
* In the location block, choose the 'office location' variation.
* Fill in the values of the office location.
* Save the post.
* View the post on the frontend.
* Check the source code of the post on the frontend.
* The source code for the location block should **not** have any `placeholder` attributes.
  ```html
  <div class="yoast-inner-container">
    <h3 data-id="Location">Location</h3>
    
    <h4 data-id="address-title">Address</h4>
    <p data-id="address">bla</p> <!-- <- These should not have any `placeholder` attributes. -->
    
    <h4 data-id="postal-code-title">Postal code</h4>
    <p data-id="postal-code">wjaoghagha</p>
    
    <h4 data-id="city-title">City</h4>
    <p data-id="city">aohawoghaoghaogh</p>
    
    <h4 data-id="region-title">Region</h4>
    <p data-id="region">agahowghaoghaogh</p>
    
    <h4 data-id="country-title">Country</h4>
    <p data-id="country">ohawogahwgoahgao</p>
  </div>
  ``` 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
