### PR TITLE
Remove whitespace from not-present ShoppingData from Google Preview

### DIFF
--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -729,7 +729,7 @@ export default class SnippetPreview extends PureComponent {
 	 *
 	 * @returns {ReactElement} The rendered description.
 	 */
-	renderProductData() {
+	renderProductData( PartContainer ) {
 		const {	mode, shoppingData } = this.props;
 
 		if ( Object.values( shoppingData ).length === 0 ) {
@@ -738,17 +738,27 @@ export default class SnippetPreview extends PureComponent {
 
 		if ( mode === MODE_DESKTOP ) {
 			return (
-				<ProductDataDesktop
-					shoppingData={ shoppingData }
-				/>
+				<PartContainer className="yoast-shopping-data-preview--desktop">
+					<ScreenReaderText>
+						{ __( "Shopping data preview:", "yoast-components" ) }
+					</ScreenReaderText>
+					<ProductDataDesktop
+						shoppingData={ shoppingData }
+					/>
+				</PartContainer>
 			);
 		}
 
 		if ( mode === MODE_MOBILE ) {
 			return (
-				<ProductDataMobile
-					shoppingData={ shoppingData }
-				/>
+				<PartContainer className="yoast-shopping-data-preview--mobile">
+					<ScreenReaderText>
+						{ __( "Shopping data preview:", "yoast-components" ) }
+					</ScreenReaderText>
+					<ProductDataMobile
+						shoppingData={ shoppingData }
+					/>
+				</PartContainer>
 			);
 		}
 
@@ -816,24 +826,14 @@ export default class SnippetPreview extends PureComponent {
 						</SnippetTitle>
 						{ amp }
 					</PartContainer>
-					<PartContainer className="yoast-shopping-data-preview--desktop">
-						<ScreenReaderText>
-							{ __( "Shopping data preview:", "yoast-components" ) }
-						</ScreenReaderText>
-						{ isDesktopMode && this.renderProductData() }
-					</PartContainer>
+					{ isDesktopMode && this.renderProductData( PartContainer ) }
 					<PartContainer>
 						<ScreenReaderText>
 							{ __( "Meta description preview:", "yoast-components" ) }
 						</ScreenReaderText>
 						{ this.renderDescription() }
 					</PartContainer>
-					<PartContainer className="yoast-shopping-data-preview--mobile">
-						<ScreenReaderText>
-							{ __( "Shopping data preview:", "yoast-components" ) }
-						</ScreenReaderText>
-						{ ! isDesktopMode && this.renderProductData() }
-					</PartContainer>
+					{ ! isDesktopMode && this.renderProductData( PartContainer ) }
 				</Container>
 			</section>
 		);

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -727,6 +727,8 @@ export default class SnippetPreview extends PureComponent {
 	/**
 	 * Renders the product / shopping data, in mobile or desktop view, based on the mode.
 	 *
+	 * @param {object} PartContainer the PartContainer component that needs to be rendered within the snippet preview container.
+	 *
 	 * @returns {ReactElement} The rendered description.
 	 */
 	renderProductData( PartContainer ) {


### PR DESCRIPTION
## Summary
The PartContainer's for ShoppingData were always rendered, resulting in whitespace within the Google Preview when no ShoppingData was presented. This needed fixing.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/search-metadata-previews] Fixes an unreleased bug where incorrect whitespace was shown within the Google preview
## Relevant technical choices:

* Placed the PartContainer components for the ShoppingData within the render function that has a safety check.
* Since ParctContainer needs to be available, it's passed to the render function as an argument.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Check posts and pages in the 3 editors
* The whitespace from above screenshot shouldn't be visible in all cases
* When using this branch in conjunction with P1-345 of Free and WooCommerce SEO, or latest trunk of both, ShoppingData should be displayed like in the test instructions for P1-345

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-485
