### PR TITLE
Use `yarn tsc` instead of `tsc`

### DIFF
--- a/packages/schema-blocks/package.json
+++ b/packages/schema-blocks/package.json
@@ -56,8 +56,8 @@
     "react-dom": "^16.12.0"
   },
   "scripts": {
-    "build": "tsc",
-    "watch": "tsc --watch",
+    "build": "yarn tsc",
+    "watch": "yarn tsc --watch",
     "lint": "eslint \"src/**\"",
     "lint-fix": "eslint \"src/**\" --fix",
     "test": "jest",


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Replaces the `tsc` command with `yarn tsc` so building the schema-blocks package uses the locally installed TypeScript compiler instead of a globally installed one.

## Relevant technical choices:

* By running `yarn tsc` instead of `tsc` directly, the locally installed TypeScript compiler is run (as installed in the `node_modules` directory) instead of the globally installed TypeScript compiler.
	* This solves the issue of `tsc` needed to be globally installed. 
		* Now the TypeScript can be compiled after a single `yarn install` in the monorepo.
	* It fixes the version of the TypeScript compiler in the monorepo. 
		* This reduces the possibility of multiple persons having different global TypeScript compiler versions.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Run `yarn build` in the `schema-blocks` package.
	* The command should work and build the `schema-blocks` package like it normally would.
	* See that the command uses the local `tsc` from the monorepo's `node_modules` directory, instead of the globally installed `tsc`:
	  ```
	  $ yarn tsc
	  $ /Users/hans-christiaanbraun/Dev/javascript/node_modules/.bin/tsc
	  ```
* Do the same with `yarn watch` and `yarn prepublishOnly`.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
