### PR TITLE
Update Google preview ShoppingData layout

### DIFF
--- a/packages/search-metadata-previews/src/snippet-preview/ProductDataDesktop.js
+++ b/packages/search-metadata-previews/src/snippet-preview/ProductDataDesktop.js
@@ -7,6 +7,7 @@ import { StarRating } from "@yoast/components";
 
 const ProductData = styled.span`
 	color: #70757a;
+	line-height: 1.7;
 `;
 
 /**

--- a/packages/search-metadata-previews/src/snippet-preview/ProductDataMobile.js
+++ b/packages/search-metadata-previews/src/snippet-preview/ProductDataMobile.js
@@ -8,6 +8,8 @@ import { StarRating } from "@yoast/components";
 
 const ProductData = styled.div`
 	display: flex;
+	margin-top: -16px;
+	line-height: 1.6;
 `;
 
 const ProductDataCell50 = styled.div`

--- a/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
+++ b/packages/search-metadata-previews/src/snippet-preview/SnippetPreview.js
@@ -828,14 +828,13 @@ export default class SnippetPreview extends PureComponent {
 						</SnippetTitle>
 						{ amp }
 					</PartContainer>
-					{ isDesktopMode && this.renderProductData( PartContainer ) }
 					<PartContainer>
 						<ScreenReaderText>
 							{ __( "Meta description preview:", "yoast-components" ) }
 						</ScreenReaderText>
 						{ this.renderDescription() }
 					</PartContainer>
-					{ ! isDesktopMode && this.renderProductData( PartContainer ) }
+					{ this.renderProductData( PartContainer ) }
 				</Container>
 			</section>
 		);


### PR DESCRIPTION
## Summary
Google now shows the ShoppingData information at the bottom, while we were still showing this info right under the title. This needed to be changed, so that our Google preview reflects the shopping information correctly.

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/search-metadata-previews] fixes an unreleased bug where shopping data within the Google desktop preview was still displayed in Google's old location.

## Relevant technical choices:

* Still using the `renderProductData` function to make sure no PartContainer is inserted when no ShoppingData is present.
* Also decided to tweak line-height and margin a bit to achieve looks closer to Google's.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Checkout this branch together with WP SEO 16.3RC or trunk and WP SEO for Woocommerce 14.0-beta or trunk.
* Add a product and fill price and availability and / or add one or more reviews.
* Save the product and refresh the page.
* Check that the Google preview looks the same as on the screenshots in [this](https://github.com/Yoast/wpseo-woocommerce/pull/670) PR.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  *

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [X] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes P1-487
