### PR TITLE
P2-907 - Close date picker again when the user clicks outside of it.

### DIFF
--- a/packages/schema-blocks/src/instructions/blocks/Date.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/Date.tsx
@@ -4,11 +4,11 @@ import { DateTimePicker, Dropdown } from "@wordpress/components";
 import { createElement, useState } from "@wordpress/element";
 import { __experimentalGetSettings, dateI18n, format } from "@wordpress/date";
 import { __ } from "@wordpress/i18n";
+import { useCallback, useRef } from "react";
 
 // Internal imports.
 import BlockInstruction from "../../core/blocks/BlockInstruction";
 import { RenderEditProps, RenderSaveProps } from "../../core/blocks/BlockDefinition";
-import { useCallback } from "react";
 
 /**
  * Adds a date picker to the schema block.
@@ -39,6 +39,8 @@ export default class Date extends BlockInstruction {
 			currentValue = format( "Y-m-d", attributes[ this.options.name ] as string );
 		}
 
+		const ref = useRef<HTMLElement>();
+
 		/**
 		 * Sets the selected date.
 		 *
@@ -51,6 +53,11 @@ export default class Date extends BlockInstruction {
 				[ this.options.name ]: date,
 			} );
 			setSelectedDate( dateI18n( dateFormat, date, false ) );
+
+			// Hide the date picker again.
+			if ( ref.current ) {
+				ref.current.blur();
+			}
 		}, [ props, dateFormat, setSelectedDate ] );
 
 		/**


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Fixes a bug where the date picker would not close when the user clicked outside of the opened date picker.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post.
* Add a job posting block.
* Click on the date next to _Closes on_ to open the date picker.
* Click outside of the opened date picker.
* The date picker should be hidden again.

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * N/A: should only affect the behavior of the date picker.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
