### PR TITLE
P2-918 - Remove unwanted space in select instruction.

### DIFF
--- a/packages/schema-blocks/src/instructions/blocks/Select.tsx
+++ b/packages/schema-blocks/src/instructions/blocks/Select.tsx
@@ -55,7 +55,7 @@ export default class Select extends BlockInstruction {
 
 		return <span data-id={ name } data-value={ value }>
 			{ ! hideLabelFromVision && <strong>{ label }:</strong> }
-			{ this.label( value ) + " " }
+			{ this.label( value ) }
 		</span>;
 	}
 

--- a/packages/schema-blocks/tests/instructions/blocks/__snapshots__/Select.test.ts.snap
+++ b/packages/schema-blocks/tests/instructions/blocks/__snapshots__/Select.test.ts.snap
@@ -9,6 +9,6 @@ exports[`The Select instruction the save method renders the correct React tree. 
     Cuisine
     :
   </strong>
-  Korean 
+  Korean
 </span>
 `;


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Removes an unwanted trailing space in the output of the `Select` block instruction.

## Relevant technical choices:

*

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post.
* Add a job posting block.
* Select an employment type and check one or both check boxes in the employment type's sidebar (_This is an internship_ and/or _This is a volunteer role_).
* Save the post.
* Check the post on the frontend. It should **not** have whitespace after the employment type (e.g. _Full time_) and the other elements (e.g. _this is an internship_).

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * Please also check if the spacing is still correct for the base salary and salary range variations of the salary block, since both also use a select element.

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [ ] I have tested this code to the best of my abilities
* [ ] I have added unittests to verify the code works as intended

Fixes #
