### PR TITLE
P2-921 - Treat attribute values only containing whitespace as invalid, and number values as valid.

### DIFF
--- a/packages/schema-blocks/src/functions/validators/attributeNotEmpty.ts
+++ b/packages/schema-blocks/src/functions/validators/attributeNotEmpty.ts
@@ -10,7 +10,24 @@ import { isEmpty } from "lodash";
  * @returns If the attribute is considered empty.
  */
 function attributeNotEmpty( blockInstance: BlockInstance, name: string ): boolean {
-	return ! isEmpty( blockInstance.attributes[ name ] as object );
+	let value: unknown = blockInstance.attributes[ name ];
+
+	if ( typeof value === "number" ) {
+		return true;
+	}
+
+	if ( typeof value === "string" ) {
+		/*
+		 * Google trims the whitespace from any strings
+		 * (source: Google's Rich Results test tool).
+		 *
+		 * Without trimming it here as well,
+		 * values only containing whitespace would be incorrectly considered
+		 * as valid.
+		 */
+		value = value.trim();
+	}
+	return ! isEmpty( value );
 }
 
 export default attributeNotEmpty;

--- a/packages/schema-blocks/tests/functions/validators/attributeNotEmpty.test.ts
+++ b/packages/schema-blocks/tests/functions/validators/attributeNotEmpty.test.ts
@@ -2,7 +2,7 @@ import { BlockInstance } from "@wordpress/blocks";
 import attributeNotEmpty from "../../../src/functions/validators/attributeNotEmpty";
 
 describe( "The attributeNotEmpty function", () => {
-	it( "validates that an attribute exists.", () => {
+	it( "considers an attribute that contains a non-empty string to not be empty.", () => {
 		const blockInstance: BlockInstance = {
 			clientId: "clientid",
 			name: "name",
@@ -16,7 +16,21 @@ describe( "The attributeNotEmpty function", () => {
 		expect( attributeNotEmpty( blockInstance, "title" ) ).toEqual( true );
 	} );
 
-	it( "validates that an attribute does not exist.", () => {
+	it( "considers an attribute that has a number value to not be empty.", () => {
+		const blockInstance: BlockInstance = {
+			clientId: "clientid",
+			name: "name",
+			innerBlocks: [],
+			isValid: true,
+			attributes: {
+				title: 565789,
+			},
+		};
+
+		expect( attributeNotEmpty( blockInstance, "title" ) ).toEqual( true );
+	} );
+
+	it( "considers an attribute that contains an empty string to be empty.", () => {
 		const blockInstance: BlockInstance = {
 			clientId: "clientid",
 			name: "name",
@@ -24,6 +38,48 @@ describe( "The attributeNotEmpty function", () => {
 			isValid: true,
 			attributes: {
 				title: "",
+			},
+		};
+
+		expect( attributeNotEmpty( blockInstance, "title" ) ).toEqual( false );
+	} );
+
+	it( "considers an attribute that contains a string with only whitespace to be empty.", () => {
+		const blockInstance: BlockInstance = {
+			clientId: "clientid",
+			name: "name",
+			innerBlocks: [],
+			isValid: true,
+			attributes: {
+				title: "       ",
+			},
+		};
+
+		expect( attributeNotEmpty( blockInstance, "title" ) ).toEqual( false );
+	} );
+
+	it( "considers an attribute that contains an empty array to be empty.", () => {
+		const blockInstance: BlockInstance = {
+			clientId: "clientid",
+			name: "name",
+			innerBlocks: [],
+			isValid: true,
+			attributes: {
+				title: [],
+			},
+		};
+
+		expect( attributeNotEmpty( blockInstance, "title" ) ).toEqual( false );
+	} );
+
+	it( "considers an attribute that has a `null` value to be empty.", () => {
+		const blockInstance: BlockInstance = {
+			clientId: "clientid",
+			name: "name",
+			innerBlocks: [],
+			isValid: true,
+			attributes: {
+				title: null,
 			},
 		};
 


### PR DESCRIPTION
## Summary

<!--
Attach one of the following labels to the PR: `changelog: bugfix`, `changelog: enhancement`, `changelog: other`, `changelog: non-user-facing`.
Specify between square brackets in which package changelog the item should be included, for example: * [@yoast/components] Fixes a bug where ....
If the same changelog item is applicable to multiple packages, add a separate changelog item for all of them.
If the changelog item should appear in the changelog of the plugin, also add a separate changelog item and put [Yoast SEO Free] or [Yoast SEO Premium] instead of the package name.
If the changelog item is a bugfix, please use the following sentence structure: Fixes a bug where ... would ... (when ...).
-->
This PR can be summarized in the following changelog entry:

* [@yoast/schema-blocks] Fixes a bug where an attribute that only contains whitespace was considered valid.
* [@yoast/schema-blocks] Fixes a bug where an attribute containing a number value was considered invalid.

## Relevant technical choices:

* Added a bunch of unit tests to test some unhappy paths.
	* Discovered a bug where number values were always considered 'empty'.
		* Decided to always say that they are valid, since a filled in number is a filled in number.  

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->
This PR can be tested by following these steps:

* Create a post.
* Add a job posting.
* Add whitespace (tabs, spaces, etc,), and only whitespace, to the description.
* The Schema analysis in the sidebar should give the following red result:
  > Not all required blocks have been completed! No job posting schema will be generated for your page. 
* Save the post.
* Check the Schema output of the post on the frontend.
	* It should **not** contain any `JobPosting` Schema piece. 

## Impact check
<!--
Sometimes PRs have a bigger impact than is suggested in the user-facing changes. In such cases,
additional (regression) testing might be necessary. To make it clear what parts might need additional testing,
please outline which parts of the plugin have been impacted by this PR.
-->
* This PR affects the following parts of the plugin, which may require extra testing:
  * 

## UI changes
* [ ] This PR changes the UI in the plugin. I have added the 'UI change' label to this PR.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #
